### PR TITLE
feat(framework): add air-gapped deployment mode

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,20 @@
 
 ## Features
 
+### Air-gapped deployment mode
+
+Operators can disable Shopware-operated outbound HTTP with one `shopware.yaml` flag:
+
+```yaml
+shopware:
+    deployment:
+        air_gapped: true
+```
+
+When enabled, Shopware does not call the Store, in-app updates, remote translations, usage-data gateway, Services registry, or product-analytics gateway. Existing fine-grained flags stay independently usable. Local plugin lifecycle (activate, deactivate, zip install) is unchanged.
+
+Clear the container cache after changing the value. Provision translation files locally if extra locales are required (`translation:install --offline` or `shopware.translation.use_local_filesystem`). Merchant integrations such as payments, apps, SMTP, and object storage are not affected.
+
 ### Document generation v2 (experimental)
 
 Shopware ships a new, opt-in implementation of order document generation. It replaces the legacy pipeline, which is deprecated and will be removed with Shopware 6.9. Enable it with the `DOCUMENT_GENERATION_REWORK` feature flag. Without the flag, Shopware runs purely on the legacy implementation.

--- a/adr/2026-09-03-air-gapped-deployment-mode.md
+++ b/adr/2026-09-03-air-gapped-deployment-mode.md
@@ -1,0 +1,179 @@
+---
+title: Air-gapped deployment mode
+date: 2026-09-03
+area: framework
+tags: [deployment, config, store, usage-data, translations, services]
+---
+
+## Context
+
+Some Shopware installations run without outbound internet: government, defense, regulated industry, and other isolated networks. Core still performs Shopware-operated HTTP calls on a regular schedule and from the Administration. When those hosts are unreachable the result is not a clean offline shop. It is timeouts, failed scheduled tasks, license-check errors, First Run Wizard steps that cannot complete, and store/update toasts.
+
+Those calls are already gated by several independent knobs:
+
+- `shopware.auto_update.enabled` and `SHOPWARE_DISABLE_UPDATE_CHECK` for the recovery/update client (`releases.shopware.com`, GitHub installer download).
+- `shopware.store.frw` for the First Run Wizard store steps.
+- `shopware.deployment.runtime_extension_management` for installing or updating extensions at runtime. The Administration already reads this as `settings.disableExtensionManagement`.
+- `shopware.translation.use_local_filesystem` and `shopware.translation.scheduled_task.enabled` for Crowdin/GitHub translation fetches.
+- `shopware.usage_data.collection_enabled` and `shopware.usage_data.gateway.dispatch_enabled` for `data.shopware.io`.
+- `core.services.disabled` (system config, not `shopware.yaml`) for the service registry at `registry.services.shopware.io`.
+- Product analytics is gated only by consent plus `PRODUCT_ANALYTICS_GATEWAY_URL` / `shopware.analytics.gateway_url`.
+- Store and in-app-purchase traffic (`api.shopware.com`) has no operator kill switch. `StoreClient`, `FirstRunWizardClient`, `TrackingEventClient`, `KeyFetcher`, and `InAppPurchaseUpdater` always talk to the configured `core.store.apiUri`.
+
+An operator who wants a silent air-gapped shop today must find and set all of those, and still cannot stop Store HTTP. That is the gap.
+
+This mode is an environment property, not a Store-only flag. It belongs next to the other deployment knobs (`blue_green`, `cluster_setup`, `runtime_extension_management`).
+
+## Decision
+
+Add one operator-facing toggle:
+
+```yaml
+# config/packages/shopware.yaml
+shopware:
+    deployment:
+        air_gapped: false
+```
+
+Default is `false`. When `true`, Shopware must not initiate HTTP to Shopware-operated SaaS or content hosts. Local commerce, local plugin lifecycle, and merchant-configured integrations stay available.
+
+### Scope: Shopware-operated egress only
+
+Air-gapped mode disables Shopware's own cloud and content endpoints. It is not a process-wide HTTP firewall.
+
+**In scope (must not leave the host):**
+
+| Client | Host / config | Typical trigger |
+| --- | --- | --- |
+| `StoreClient`, `StoreClientFactory` | `core.store.apiUri` (`https://api.shopware.com`) | Store login, extension listing, updates, license checks, downloads, ratings |
+| `FirstRunWizardClient` | Store API | FRW account / domain / plugin steps |
+| `TrackingEventClient` | `/swplatform/tracking/events` | FRW and store tracking |
+| `KeyFetcher`, `InAppPurchaseUpdater` | `/inappfeatures/jwks`, purchases | Daily `in-app-purchase.update` task and IAP validation |
+| `Update\Services\ApiClient` | `releases.shopware.com`, GitHub web-installer | Update check, recovery-tool download |
+| Translation loader / `UpdateTranslationsTask` | `raw.githubusercontent.com/shopware/translations`, `translate.shopware.com` | Daily `translation.update`, language install |
+| Usage-data `GatewayClient` | `https://data.shopware.io` | Daily `usage_data.entity_data.collect`, consent reporter |
+| Service registry `Client` | `https://registry.services.shopware.io` | Daily `services.install`, Services settings |
+| Admin product analytics | `product-analytics-gateway.services.shopware.io` | Browser telemetry after consent |
+| Installer GTC fetch | `api.shopware.com/gtc` | Web installer legal texts |
+
+**Out of scope (operator-owned, stay as configured):**
+
+- App webhooks and app backends
+- Payment, shipping, and tax providers
+- SMTP / mailer
+- Object storage, CDN, Fastly
+- Elasticsearch / OpenSearch
+- Google reCAPTCHA / other captchas
+- Media upload-by-URL of merchant URLs
+- Composer / Packagist (deploy-time, not runtime Shopware)
+
+A global HTTP deny-list would break payments, apps, and storage. Those remain the operator's responsibility.
+
+`runtime_extension_management` stays a separate concern. Air-gapped mode must not imply it. Isolated shops can still activate, deactivate, and zip-install locally provisioned plugins. They must not browse, buy, or download from the Store.
+
+### One source of truth
+
+Do not scatter twenty `if ($airGapped)` checks that each invent their own meaning.
+
+Introduce an internal, `@internal` service that reads `shopware.deployment.air_gapped` and answers one question: are Shopware-operated outbound calls allowed? Existing per-subsystem flags stay independently usable for partial disable (for example disable updates but keep Store). Air-gapped mode is the conjunction: if the mode is on, those Shopware-operated calls are off regardless of the finer flags.
+
+Enforcement is two-layered:
+
+1. **Policy.** Scheduled tasks that only exist to talk to Shopware SaaS return `false` from `shouldRun()`. The Administration `_info/config` payload exposes `settings.airGapped`. Store / update / services / analytics / usage-data / FRW UIs hide or short-circuit from that flag. Controllers and CLI commands that would otherwise call Store return a dedicated exception immediately.
+2. **Safety net.** The Store Guzzle stack (`shopware.store_client`, `shopware.store_download_client`, FRW client) gets middleware that rejects every request when the mode is on. Update, usage-data, translation, and service-registry clients refuse before `request()`. This prevents a missed call site from hanging on DNS or TCP timeout.
+
+Do not implement this as a compiler pass that rewrites other config values. Rewriting `auto_update.enabled` or `usage_data.gateway.dispatch_enabled` makes dumps and tests lie about what the operator wrote. The air-gapped service is consulted in addition to those flags.
+
+### Failure contract
+
+When a Shopware-operated call is attempted in air-gapped mode, fail immediately with a dedicated domain exception (for example `StoreException::airGapped()` / a framework equivalent for non-store clients). Do not wait for cURL error 7. HTTP status should be a client-visible 4xx/503 that the Administration already knows how to surface as a notification, not a 500.
+
+Scheduled tasks and tracking fire-and-forget paths must no-op, not throw into the messenger retry loop.
+
+### Administration
+
+Follow the `disableExtensionManagement` pattern in `InfoController` and `Shopware.Store.get('context').app.config.settings`.
+
+When `airGapped` is true the Administration must:
+
+- Hide Extension Store / marketplace and Store login.
+- Skip FRW Shopware-account and domain steps (same as `disableExtensionManagement`, plus any remaining Store calls).
+- Hide or disable the in-app update checker.
+- Hide usage-data and product-analytics consent prompts, or treat them as revoked / unavailable.
+- Hide Shopware Services registry actions.
+- Keep local extension listing, config, activate/deactivate, and zip upload.
+
+Empty states should say the installation is air-gapped, not that the Store is temporarily unavailable.
+
+### Config surface
+
+Wire the boolean through the existing deployment config path:
+
+- `Configuration::createDeploymentSection()` — `booleanNode('air_gapped')->defaultFalse()`
+- `src/Core/Framework/Resources/config/packages/shopware.yaml` — `deployment.air_gapped: false`
+- `config-schema.json` — `definitions.deployment.properties.air_gapped`
+- `ConfigurationTest` coverage for the new node
+
+No system-config UI toggle. This is an operator / hosting decision, same as `cluster_setup`. Changing it requires a cache clear, which is acceptable.
+
+### Translations in air-gapped mode
+
+Remote Crowdin/GitHub fetches are Shopware-operated egress, so they stop. Language install must use the existing offline path (`translation:install --offline` / `use_local_filesystem`). The daily `translation.update` task must not run. Document that locales have to be provisioned on disk.
+
+## Considered approaches
+
+### Document the existing flags only
+
+Operators would set `auto_update.enabled`, usage-data dispatch, translation filesystem, services disabled, and `SHOPWARE_DISABLE_UPDATE_CHECK`. This was rejected because Store and in-app-purchase traffic still leave the host, and the checklist is easy to get wrong.
+
+### `shopware.store.enabled: false`
+
+Too narrow. Updates, translations, usage data, services, and analytics are not the Store client. A Store-only flag would recreate today's fragmentation.
+
+### Process-wide HTTP client decorator
+
+A Guzzle / Symfony HttpClient wrapper that denies every non-loopback request would match a literal air gap. It was rejected because it would break merchant-configured payments, apps, mail, and object storage, and it would be almost impossible to test without mocking the world. Isolated networks that also block those destinations already do so at the firewall.
+
+### Compiler-pass override of existing flags
+
+Forcing `auto_update.enabled` and friends to `false` at compile time looks convenient. It was rejected because container parameter dumps would no longer match `shopware.yaml`, and tests that set one fine-grained flag would silently change meaning.
+
+## Consequences
+
+### Positive
+
+- One `shopware.yaml` line is enough for a hosting profile that must not talk to Shopware SaaS.
+- Existing fine-grained flags remain valid for shops that only want to turn off updates or usage data.
+- Local plugin and app lifecycle stays usable.
+- Missed call sites fail closed (immediate exception) instead of hanging.
+- The Administration can hide dead Store/SaaS UI instead of showing errors.
+
+### Negative / trade-offs
+
+- In-app purchases and Store-backed license checks cannot refresh. Commercial features that require a live JWKS or license host will not work in this mode. That is intentional.
+- Remote translation updates stop. Operators must ship locale files.
+- Shopware Services cannot install or update from the registry.
+- The web installer GTC fetch still needs an installer-specific follow-up if the installer runs before project `shopware.yaml` is loaded.
+- New Shopware-operated HTTP clients must consult the air-gapped service. The safety-net middleware covers the Store stack; other clients need an explicit guard. A unit test or PHPStan rule that new tagged Store/SaaS clients are wired through the guard is recommended in implementation.
+
+### Operational impact
+
+```yaml
+shopware:
+    deployment:
+        air_gapped: true
+```
+
+After changing the value, clear the container cache. Provision translation files locally if extra locales are required. Do not expect the Extension Store, in-app updates, usage-data upload, product analytics, or Shopware Services registry to function.
+
+Merchant integrations (payments, apps, SMTP, S3) are unchanged. If the network also blocks those, configure or disable them separately.
+
+### Implementation order (when this ADR is accepted)
+
+1. Config node, schema, `ConfigurationTest`, internal air-gapped service, `RELEASE_INFO` operator note.
+2. Store / FRW / tracking / IAP clients and `shouldRun()` on `InAppPurchaseUpdateTask`. Dedicated exception. Admin `_info/config` flag.
+3. Update client, usage-data collect/dispatch, translation scheduled task and remote loader, service registry / `InstallServicesTask`.
+4. Administration: hide Store, updates, services, analytics/usage-data prompts; FRW skip; Jest coverage.
+5. Installer GTC as a follow-up if the installer is in scope for the same release.
+
+Each step needs PHPUnit (and Admin Jest where UI changes). Behaviour change without tests is not done.

--- a/config-schema.json
+++ b/config-schema.json
@@ -1010,6 +1010,11 @@
                 },
                 "runtime_extension_management": {
                     "type": "boolean"
+                },
+                "air_gapped": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, Shopware does not call Shopware-operated SaaS or content hosts (Store, updates, translations, usage data, Services registry, product analytics)."
                 }
             },
             "title": "Deployment"

--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
@@ -97,6 +98,7 @@ class AdministrationController extends AbstractController
         private readonly SymfonyBearerTokenValidator $tokenValidator,
         private readonly string $analyticsGatewayUrl,
         private readonly CustomerEmailUniqueChecker $customerEmailUniqueChecker,
+        private readonly AirGappedMode $airGappedMode,
         private readonly string $refreshTokenTtl = 'P1W',
     ) {
         // param is only available if the elasticsearch bundle is enabled
@@ -139,9 +141,9 @@ class AdministrationController extends AbstractController
             'adminEsEnable' => $this->esAdministrationEnabled,
             'storefrontEsEnable' => $this->esStorefrontEnabled,
             'refreshTokenTtl' => $refreshTokenTtl * 1000,
-            'serviceRegistryUrl' => $this->serviceRegistryUrl,
+            'serviceRegistryUrl' => $this->airGappedMode->isEnabled() ? '' : $this->serviceRegistryUrl,
             'productStreamIndexingEnabled' => $this->productStreamIndexingEnabled,
-            'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
+            'analyticsGatewayUrl' => $this->airGappedMode->isEnabled() ? '' : $this->analyticsGatewayUrl,
         ]);
 
         $response->setPublic();

--- a/src/Administration/DependencyInjection/services.php
+++ b/src/Administration/DependencyInjection/services.php
@@ -43,6 +43,7 @@ use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Notification\NotificationService;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
@@ -123,6 +124,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(SymfonyBearerTokenValidator::class),
             env('PRODUCT_ANALYTICS_GATEWAY_URL'),
             service(CustomerEmailUniqueChecker::class),
+            service(AirGappedMode::class),
             param('shopware.api.refresh_token_ttl'),
         ])
         ->call('setContainer', [service('service_container')]);

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -36,6 +36,7 @@ export interface ContextState {
                 appUrlReachable: boolean;
                 appsRequireAppUrl: boolean;
                 disableExtensionManagement: boolean;
+                airGapped: boolean;
                 firstMigrationDate?: string | null;
                 minSearchTermLength: number;
             };

--- a/src/Administration/Resources/app/administration/src/core/helper/air-gapped.helper.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/helper/air-gapped.helper.spec.js
@@ -1,0 +1,39 @@
+/**
+ * @sw-package framework
+ */
+import { isAirGapped, isShopwareStoreUnavailable } from './air-gapped.helper';
+
+describe('core/helper/air-gapped.helper.ts', () => {
+    beforeEach(() => {
+        Shopware.Store.get('context').app.config.settings = {
+            disableExtensionManagement: false,
+            airGapped: false,
+        };
+    });
+
+    it('treats missing settings as connected', () => {
+        Shopware.Store.get('context').app.config.settings = undefined;
+
+        expect(isAirGapped()).toBe(false);
+        expect(isShopwareStoreUnavailable()).toBe(false);
+    });
+
+    it('detects air-gapped mode independently of extension management', () => {
+        Shopware.Store.get('context').app.config.settings.airGapped = true;
+
+        expect(isAirGapped()).toBe(true);
+        expect(isShopwareStoreUnavailable()).toBe(true);
+    });
+
+    it('treats disabled extension management as store-unavailable without being air-gapped', () => {
+        Shopware.Store.get('context').app.config.settings.disableExtensionManagement = true;
+
+        expect(isAirGapped()).toBe(false);
+        expect(isShopwareStoreUnavailable()).toBe(true);
+    });
+
+    it('keeps a connected shop store-available', () => {
+        expect(isAirGapped()).toBe(false);
+        expect(isShopwareStoreUnavailable()).toBe(false);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/helper/air-gapped.helper.ts
+++ b/src/Administration/Resources/app/administration/src/core/helper/air-gapped.helper.ts
@@ -1,0 +1,31 @@
+/**
+ * @sw-package framework
+ */
+
+type ContextSettings = {
+    disableExtensionManagement?: boolean;
+    airGapped?: boolean;
+};
+
+function getSettings(): ContextSettings | undefined {
+    return Shopware.Store.get('context').app.config.settings as ContextSettings | undefined;
+}
+
+/**
+ * Returns true when this installation must not call Shopware-operated SaaS hosts.
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export function isAirGapped(): boolean {
+    return getSettings()?.airGapped === true;
+}
+
+/**
+ * Returns true when the Shopware Store / account / marketplace is unavailable.
+ * Air-gapped mode and disabled runtime extension management both skip Store traffic.
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export function isShopwareStoreUnavailable(): boolean {
+    const settings = getSettings();
+
+    return settings?.disableExtensionManagement === true || settings?.airGapped === true;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-extension-card-base.html.twig';
 import './sw-extension-card-base.scss';
 
@@ -243,6 +244,10 @@ export default {
             return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
         },
 
+        shopwareStoreUnavailable() {
+            return isAirGapped() || this.extensionManagementDisabled;
+        },
+
         showContextMenu() {
             if (this.isInstalled && this.extension.configurable) {
                 return true;
@@ -264,12 +269,12 @@ export default {
                 return true;
             }
 
-            if (!this.extensionManagementDisabled && this.isUpdateable) {
+            if (!this.shopwareStoreUnavailable && this.isUpdateable) {
                 return true;
             }
 
             if (
-                !this.extensionManagementDisabled &&
+                !this.shopwareStoreUnavailable &&
                 this.extension.storeLicense &&
                 this.extension.storeLicense.variant === 'rent' &&
                 this.extension.storeLicense.expirationDate === null

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -59,7 +59,7 @@
                 {{ $t('sw-extension.my-extensions.listing.version') }}: {{ extension.version }}
             </span>
 
-            <span v-if="!extensionManagementDisabled && isUpdateable">
+            <span v-if="!shopwareStoreUnavailable && isUpdateable">
                 <a
                     href="#"
                     @click.prevent="updateExtension(false)"
@@ -152,7 +152,7 @@
         </sw-context-menu-item>
 
         <sw-context-menu-item
-            v-if="!extensionManagementDisabled && isUpdateable"
+            v-if="!shopwareStoreUnavailable && isUpdateable"
             @click="updateExtension(false)"
         >
             {{ $t('sw-extension-store.component.sw-extension-card-base.contextMenu.updateLabel', { version: extension.latestVersion }, 0) }}
@@ -161,7 +161,7 @@
         {% block sw_extension_card_base_context_menu_actions_additional %}{% endblock %}
 
         <sw-context-menu-item
-            v-if="!extensionManagementDisabled && extension.storeLicense && extension.storeLicense.variant === 'rent' && extension.storeLicense.expirationDate === null"
+            v-if="!shopwareStoreUnavailable && extension.storeLicense && extension.storeLicense.variant === 'rent' && extension.storeLicense.expirationDate === null"
             class="sw-extension-card-base__cancel-and-remove-link"
             variant="danger"
             @click="openRemovalModal"

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/index.js
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-extension-my-extensions-index.html.twig';
 
 /**
@@ -31,6 +32,10 @@ export default {
 
         extensionManagementDisabled() {
             return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+        },
+
+        airGapped() {
+            return isAirGapped();
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.html.twig
@@ -36,13 +36,19 @@
         {% endblock %}
 
         {% block sw_extension_my_extensions_index_smart_bar_tabs_recommendation %}
-        <sw-tabs-item :route="{ name: 'sw.extension.my-extensions.recommendation' }">
+        <sw-tabs-item
+            v-if="!airGapped"
+            :route="{ name: 'sw.extension.my-extensions.recommendation' }"
+        >
             {{ $t('sw-extension.my-extensions.tabs.recommendation') }}
         </sw-tabs-item>
         {% endblock %}
 
         {% block sw_extension_my_extensions_index_smart_bar_tabs_account %}
-        <sw-tabs-item :route="{ name: 'sw.extension.my-extensions.account' }">
+        <sw-tabs-item
+            v-if="!airGapped"
+            :route="{ name: 'sw.extension.my-extensions.account' }"
+        >
             {{ $t('sw-extension.my-extensions.tabs.shopwareAccount') }}
         </sw-tabs-item>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -59,6 +59,7 @@ describe('module/sw-extension/page/sw-extension-my-extensions-index', () => {
                     config: {
                         settings: {
                             disableExtensionManagement: false,
+                            airGapped: false,
                         },
                     },
                 },
@@ -74,6 +75,7 @@ describe('module/sw-extension/page/sw-extension-my-extensions-index', () => {
 
     afterEach(() => {
         Shopware.Store.get('context').app.config.settings.disableExtensionManagement = false;
+        Shopware.Store.get('context').app.config.settings.airGapped = false;
         global.activeAclRoles = [];
     });
 
@@ -90,6 +92,15 @@ describe('module/sw-extension/page/sw-extension-my-extensions-index', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(false);
+    });
+
+    it('keeps the upload button when the installation is air-gapped', async () => {
+        global.activeAclRoles = ['system.plugin_upload'];
+        Shopware.Store.get('context').app.config.settings.airGapped = true;
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(true);
+        expect(wrapper.findAll('sw-tabs-item-stub')).toHaveLength(2);
     });
 
     it('upload button should be not there when missing plugin_upload acl', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -100,7 +100,9 @@ describe('module/sw-extension/page/sw-extension-my-extensions-index', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(true);
-        expect(wrapper.findAll('sw-tabs-item-stub')).toHaveLength(2);
+        expect(wrapper.vm.airGapped).toBe(true);
+        expect(wrapper.html()).not.toContain('sw.extension.my-extensions.recommendation');
+        expect(wrapper.html()).not.toContain('sw.extension.my-extensions.account');
     });
 
     it('upload button should be not there when missing plugin_upload acl', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-extension-my-extensions-listing.html.twig';
 import './sw-extension-my-extensions-listing.scss';
 
@@ -177,6 +178,10 @@ export default {
 
         extensionManagementDisabled() {
             return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+        },
+
+        airGapped() {
+            return isAirGapped();
         },
 
         selectedExtensions() {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
@@ -28,6 +28,17 @@
         </mt-banner>
 
         <mt-banner
+            v-if="airGapped"
+            class="sw-extension-my-extensions-listing__air-gapped-warning"
+            variant="attention"
+            :title="$t('sw-extension-store.component.sw-extension-my-extensions-listing.alertAirGapped.title')"
+        >
+            <div>
+                {{ $t('sw-extension-store.component.sw-extension-my-extensions-listing.alertAirGapped.description') }}
+            </div>
+        </mt-banner>
+
+        <mt-banner
             v-if="extensionManagementDisabled"
             class="sw-extension-my-extensions-listing__runtime-extension-warning"
             variant="attention"
@@ -55,7 +66,10 @@
             :headline="emptyStateHeadline"
             :description="emptyStateDescription"
         >
-            <template #button>
+            <template
+                v-if="!airGapped"
+                #button
+            >
                 <mt-button
                     variant="secondary"
                     @click="isThemeRoute ? openThemesStore() : openStore()"

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/index.js
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-extension-store-landing-page.html.twig';
 import './sw-extension-store-landing-page.scss';
 
@@ -42,6 +43,10 @@ export default {
         /** @deprecated tag:v6.9.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
         assetFilter() {
             return Shopware.Filter.getByName('asset');
+        },
+
+        airGapped() {
+            return isAirGapped();
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.html.twig
@@ -46,6 +46,15 @@
             />
 
             <mt-empty-state
+                v-else-if="airGapped"
+                class="sw-extension-store-landing-page__wrapper-content"
+                :centered="true"
+                icon="regular-lock"
+                :headline="$t('sw-extension-store.landing-page.airGappedTitle')"
+                :description="$t('sw-extension-store.landing-page.airGappedDescription')"
+            />
+
+            <mt-empty-state
                 v-else
                 class="sw-extension-store-landing-page__wrapper-content"
                 :centered="true"

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
@@ -53,6 +53,7 @@ describe('src/module/sw-extension/service/shopware-extension.service', () => {
                     config: {
                         settings: {
                             disableExtensionManagement: false,
+                            airGapped: false,
                         },
                     },
                 },
@@ -166,6 +167,17 @@ describe('src/module/sw-extension/service/shopware-extension.service', () => {
             expect(mockedExtensionStoreActionService[lifecycleMethod]).toHaveBeenCalledWith(...parameters);
 
             expectUpdateExtensionDataCalled();
+        });
+
+        it('skips store refresh when the installation is air-gapped', async () => {
+            Shopware.Store.get('context').app.config.settings.airGapped = true;
+
+            await mockedShopwareExtensionService.updateExtensionData();
+
+            expect(mockedExtensionStoreActionService.refresh).not.toHaveBeenCalled();
+            expect(mockedExtensionStoreActionService.getMyExtensions).toHaveBeenCalledTimes(1);
+
+            Shopware.Store.get('context').app.config.settings.airGapped = false;
         });
 
         it('delegates cancelLicense correctly', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import type { RouteLocationNamedRaw, RouteLocation } from 'vue-router';
 import type { AppModulesService, AppModuleDefinition } from 'src/core/service/api/app-modules.service';
 import type StoreApiService from 'src/core/service/api/store.api.service';
@@ -99,7 +100,7 @@ export default class ShopwareExtensionService {
         Shopware.Store.get('shopwareExtensions').loadMyExtensions();
 
         try {
-            if (!Shopware.Store.get('context').app.config?.settings?.disableExtensionManagement && refreshExtensions) {
+            if (!isShopwareStoreUnavailable() && refreshExtensions) {
                 await this.extensionStoreActionService.refresh();
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de.json
@@ -144,7 +144,9 @@
       "activationDescriptionTitleFirst": "Erweiterungen einfach entdecken und kaufen -",
       "activationDescriptionTitleSecond": "direkt aus Ihrem eigenen Shopware-Shop heraus.",
       "activationDescriptionTitleDescription": "Aktiviere den Shopware Store und erhalte Zugriff auf viele hilfreiche Erweiterungen und moderne Themes, die Du nahtlos in Deinen Shop integrieren kannst - ganz ohne Programmierkenntnisse.",
-      "activate": "Aktivieren"
+      "activate": "Aktivieren",
+      "airGappedTitle": "Diese Installation ist air-gapped",
+      "airGappedDescription": "Der Shopware Store ist deaktiviert, weil dieser Shop Shopware-Cloud-Dienste nicht erreichen kann."
     },
     "title": "Store",
     "descriptionTextModule": "Verwalte Deine Erweiterungen",
@@ -348,6 +350,10 @@
         "alertExtensionManagement": {
           "title": "Erweiterungsverwaltung eingeschränkt",
           "description": "Die Verwaltung der Erweiterungen ist bei dieser Installation deaktiviert. Es ist nur möglich die Einstellungen der Erweiterungen zu verändern."
+        },
+        "alertAirGapped": {
+          "title": "Diese Installation ist air-gapped",
+          "description": "Der Shopware Store, In-App-Updates und Shopware-Cloud-Dienste sind deaktiviert. Lokal bereitgestellte Erweiterungen kannst Du weiterhin aktivieren, deaktivieren und per ZIP installieren."
         }
       },
       "sw-extension-removal-modal": {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
@@ -144,7 +144,9 @@
       "activationDescriptionTitleFirst": "Explore and buy extensions easily -",
       "activationDescriptionTitleSecond": "right from within your own Shopware shop.",
       "activationDescriptionTitleDescription": "Activate the Shopware Store and get access to loads of helpful extensions and modern themes that can be integrated into your shop seemlessly - without any programming skills.",
-      "activate": "Activate"
+      "activate": "Activate",
+      "airGappedTitle": "This installation is air-gapped",
+      "airGappedDescription": "The Shopware Store is disabled because this shop cannot reach Shopware-operated cloud services."
     },
     "title": "Store",
     "descriptionTextModule": "Manage your extensions",
@@ -348,6 +350,10 @@
         "alertExtensionManagement": {
           "title": "Runtime extension management disabled",
           "description": "The runtime extension management is disabled in this installation. You can only change the settings of the extensions in the administration."
+        },
+        "alertAirGapped": {
+          "title": "This installation is air-gapped",
+          "description": "The Shopware Store, in-app updates, and Shopware-operated cloud services are disabled. You can still activate, deactivate, and zip-install locally provisioned extensions."
         }
       },
       "sw-extension-removal-modal": {

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-modal.html.twig';
 import './sw-first-run-wizard-modal.scss';
 
@@ -93,7 +94,7 @@ export default {
         },
 
         extensionManagementDisabled() {
-            return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+            return isShopwareStoreUnavailable();
         },
 
         isClosable() {
@@ -101,7 +102,7 @@ export default {
         },
 
         stepper() {
-            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
+            if (isShopwareStoreUnavailable()) {
                 return {
                     welcome: {
                         name: 'sw.first.run.wizard.index.welcome',

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/sw-first-run-wizard-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/sw-first-run-wizard-modal.spec.js
@@ -134,6 +134,20 @@ describe('module/sw-first-run-wizard/component/sw-first-run-wizard-modal', () =>
         Shopware.Store.get('context').app.config.settings.disableExtensionManagement = false;
     });
 
+    it('stepper has less steps when the installation is air-gapped', async () => {
+        const wrapper = await createWrapper();
+
+        expect(Object.keys(wrapper.vm.stepper)).toHaveLength(13);
+
+        Shopware.Store.get('context').app.config.settings.airGapped = true;
+
+        await wrapper.vm.$nextTick();
+
+        expect(Object.keys(wrapper.vm.stepper)).toHaveLength(8);
+
+        Shopware.Store.get('context').app.config.settings.airGapped = false;
+    });
+
     it('the default button config should be the config of the sw-first-run-wizard-welcome component', async () => {
         const wrapper = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-defaults/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-defaults/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-defaults.html.twig';
 import './sw-first-run-wizard-defaults.scss';
 
@@ -49,7 +50,7 @@ export default {
                 },
             ];
 
-            if (!Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
+            if (!isShopwareStoreUnavailable()) {
                 buttons.unshift({
                     key: 'back',
                     label: this.$t('global.default.back'),

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-finish.html.twig';
 import './sw-first-run-wizard-finish.scss';
 
@@ -48,9 +49,7 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement =
-                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
-            const prevRoute = disabledExtensionManagement ? 'shopware.account' : 'store';
+            const prevRoute = isShopwareStoreUnavailable() ? 'shopware.account' : 'store';
 
             return [
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-local/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-local/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import './sw-first-run-wizard-mailer-local.scss';
 import template from './sw-first-run-wizard-mailer-local.html.twig';
 
@@ -46,7 +47,7 @@ export default {
         },
 
         nextAction() {
-            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
+            if (isShopwareStoreUnavailable()) {
                 return 'sw.first.run.wizard.index.shopware.account';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-mailer-selection.html.twig';
 import './sw-first-run-wizard-mailer-selection.scss';
 
@@ -30,9 +31,7 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement =
-                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
-            const nextRoute = disabledExtensionManagement ? 'shopware.account' : 'paypal.info';
+            const nextRoute = isShopwareStoreUnavailable() ? 'shopware.account' : 'paypal.info';
 
             return [
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-smtp/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-smtp/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import './sw-first-run-wizard-mailer-smtp.scss';
 import template from './sw-first-run-wizard-mailer-smtp.html.twig';
 
@@ -35,7 +36,7 @@ export default {
 
     computed: {
         nextAction() {
-            if (Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (isShopwareStoreUnavailable()) {
                 return 'sw.first.run.wizard.index.shopware.account';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-shopware-account.html.twig';
 import './sw-first-run-wizard-shopware-account.scss';
 
@@ -45,10 +46,9 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement =
-                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
-            const prevRoute = disabledExtensionManagement ? 'mailer.selection' : 'plugins';
-            const skipRoute = disabledExtensionManagement ? 'finish' : 'store';
+            const storeUnavailable = isShopwareStoreUnavailable();
+            const prevRoute = storeUnavailable ? 'mailer.selection' : 'plugins';
+            const skipRoute = storeUnavailable ? 'finish' : 'store';
 
             const buttonConfig = [
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-domain/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-domain/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-shopware-domain.html.twig';
 import './sw-first-run-wizard-shopware-domain.scss';
 
@@ -38,7 +39,7 @@ export default {
         },
 
         nextAction() {
-            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
+            if (isShopwareStoreUnavailable()) {
                 return 'sw.first.run.wizard.index.finish';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
@@ -1,3 +1,4 @@
+import { isShopwareStoreUnavailable } from 'src/core/helper/air-gapped.helper';
 import template from './sw-first-run-wizard-welcome.html.twig';
 import './sw-first-run-wizard-welcome.scss';
 
@@ -39,9 +40,7 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement =
-                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
-            const nextRoute = disabledExtensionManagement ? 'defaults' : 'data-import';
+            const nextRoute = isShopwareStoreUnavailable() ? 'defaults' : 'data-import';
 
             const buttonConfig = [
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/index.ts
@@ -1,4 +1,5 @@
 import { mapState } from 'pinia';
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import useSession from 'src/app/composables/use-session';
 import { useShopwareServicesStore } from '../../store/shopware-services.store';
 import template from './sw-settings-services-index.html.twig';
@@ -64,9 +65,18 @@ export default Shopware.Component.wrapComponentConfig({
         servicesWithAccountRequirement(): ServiceWithShopwareAccountRequirement[] {
             return getServicesWithShopwareAccountRequirement(this.services);
         },
+
+        airGapped() {
+            return isAirGapped();
+        },
     },
 
     created() {
+        if (this.airGapped) {
+            this.suspended = false;
+            return;
+        }
+
         const shopwareServicesService = Shopware.Service('shopwareServicesService');
         const serviceRegistryClient = Shopware.Service('serviceRegistryClient');
         const shopwareServicesStore = useShopwareServicesStore();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -14,6 +14,16 @@
         v-if="!suspended"
         #content
     >
+        <mt-empty-state
+            v-if="airGapped"
+            class="sw-settings-services-index__air-gapped"
+            :centered="true"
+            icon="regular-lock"
+            :headline="$t('sw-settings-services.index.air-gapped-title')"
+            :description="$t('sw-settings-services.index.air-gapped-description')"
+        />
+
+        <template v-else>
         <sw-extension-component-section
             position-identifier="sw-settings-services-header"
         />
@@ -125,5 +135,6 @@
         <sw-extension-component-section
             position-identifier="sw-settings-services-footer"
         />
+        </template>
     </template>
 </sw-page>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de.json
@@ -29,7 +29,9 @@
       "label-documentation-link": "Dokumentation",
       "label-tos-link": "AGB",
       "installing-services-title": "Shopware Services werden installiert",
-      "installing-services-description": "Dies kann eine Weile dauern. Du wirst benachrichtigt, sobald die Installationen abgeschlossen sind. In der Zwischenzeit kannst Du Deine Shopware Administration frei nutzen."
+      "installing-services-description": "Dies kann eine Weile dauern. Du wirst benachrichtigt, sobald die Installationen abgeschlossen sind. In der Zwischenzeit kannst Du Deine Shopware Administration frei nutzen.",
+      "air-gapped-title": "Diese Installation ist air-gapped",
+      "air-gapped-description": "Shopware Services können nicht aus der Registry installiert oder aktualisiert werden, weil dieser Shop Shopware-Cloud-Dienste nicht erreichen kann."
     },
     "service-card": {
       "status-active": "Aktiv",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en.json
@@ -29,7 +29,9 @@
       "label-documentation-link": "Documentation",
       "label-tos-link": "Terms & Conditions",
       "installing-services-title": "Installing Shopware Services",
-      "installing-services-description": "This might take a while. You will be notified as soon as the installations are complete. In the meantime you can freely use your Shopware administration."
+      "installing-services-description": "This might take a while. You will be notified as soon as the installations are complete. In the meantime you can freely use your Shopware administration.",
+      "air-gapped-title": "This installation is air-gapped",
+      "air-gapped-description": "Shopware Services cannot be installed or updated from the registry because this shop cannot reach Shopware-operated cloud services."
     },
     "service-card": {
       "status-active": "Active",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/index.ts
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-settings-shopware-updates-wizard.html.twig';
 import './sw-settings-shopware-updates-wizard.scss';
 import useSession from 'src/app/composables/use-session';
@@ -97,6 +98,20 @@ export default Component.wrapComponentConfig({
             return !(this.displayIncompatiblePluginsWarning || this.displayUnknownPluginsWarning);
         },
 
+        airGapped() {
+            return isAirGapped();
+        },
+
+        emptyStateHeadline() {
+            return this.airGapped
+                ? this.$t('sw-settings-shopware-updates.general.airGappedTitle')
+                : this.$t('sw-settings-shopware-updates.general.emptyState');
+        },
+
+        emptyStateDescription() {
+            return this.airGapped ? this.$t('sw-settings-shopware-updates.general.airGappedDescription') : '';
+        },
+
         optionDeactivateIncompatibleTranslation() {
             const deactivateIncompatTrans = this.$t('sw-settings-shopware-updates.plugins.actions.deactivateIncompatible');
             const isRecommended =
@@ -129,6 +144,11 @@ export default Component.wrapComponentConfig({
         },
 
         createdComponent() {
+            if (this.airGapped) {
+                this.isLoading = false;
+                return;
+            }
+
             void this.updateService.checkForUpdates().then((response) => {
                 this.updateInfo = response;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.html.twig
@@ -56,7 +56,8 @@
                 v-if="!isLoading && !updateInfo.version"
                 :centered="true"
                 :icon="$route.meta.$module.icon"
-                :headline="$t('sw-settings-shopware-updates.general.emptyState')"
+                :headline="emptyStateHeadline"
+                :description="emptyStateDescription"
             />
 
             <sw-modal

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/snippet/de.json
@@ -5,6 +5,8 @@
       "title": "Shopware-Aktualisierung ({version})",
       "emptyTitle": "Shopware-Aktualisierungen",
       "emptyState": "Du bist auf dem aktuellsten Stand.",
+      "airGappedTitle": "Diese Installation ist air-gapped",
+      "airGappedDescription": "In-App-Aktualisierungen sind deaktiviert, weil dieser Shop die Shopware-Update-Hosts nicht erreichen kann.",
       "checkForUpdates": "Nach Aktualisierungen suchen",
       "currentVersion": "Aktuelle Version:"
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/snippet/en.json
@@ -5,6 +5,8 @@
       "title": "Shopware update ({version})",
       "emptyTitle": "Shopware updates",
       "emptyState": "You are running the latest version.",
+      "airGappedTitle": "This installation is air-gapped",
+      "airGappedDescription": "In-app Shopware updates are disabled because this shop cannot reach Shopware-operated update hosts.",
       "checkForUpdates": "Check for updates",
       "currentVersion": "Current version:"
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal-data-provider/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal-data-provider/index.ts
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import useConsentStore from 'src/core/consent/consent.store';
 import template from './sw-settings-usage-data-consent-modal-data-provider.html.twig';
 
@@ -122,7 +123,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         showConsentModal() {
-            if (!this.areConsentsLoaded) {
+            if (isAirGapped() || !this.areConsentsLoaded) {
                 return false;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal-data-provider/sw-settings-usage-data-consent-modal-data-provider.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal-data-provider/sw-settings-usage-data-consent-modal-data-provider.spec.js
@@ -88,6 +88,16 @@ describe('/module/sw-settings-usage-data/component/sw-settings-usage-data-consen
             expect(wrapper.findComponent(SwSettingsUsageDataConsentModal).exists()).toBe(true);
         });
 
+        it('doesnt show modal when the installation is air-gapped', async () => {
+            Shopware.Store.get('context').app.config.settings.airGapped = true;
+
+            const wrapper = await createWrapper();
+
+            expect(wrapper.findComponent(SwSettingsUsageDataConsentModal).exists()).toBe(false);
+
+            Shopware.Store.get('context').app.config.settings.airGapped = false;
+        });
+
         it('doesnt show modal when admin user is too new', async () => {
             setConsentEligibilityContext({
                 adminUserCreatedAt: getDateStringDaysAgo(5),

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/snippet/de.json
@@ -3,7 +3,9 @@
     "general": {
       "mainMenuItemGeneral": "Datenschutzeinstellungen",
       "textHeadline": "Datenschutzeinstellungen",
-      "description": "Lege Deine Datenschutzeinstellungen fest."
+      "description": "Lege Deine Datenschutzeinstellungen fest.",
+      "airGappedTitle": "Diese Installation ist air-gapped",
+      "airGappedDescription": "Einwilligungen für Nutzungsdaten und Produktanalysen sind nicht verfügbar, weil dieser Shop Shopware-Cloud-Dienste nicht erreichen kann."
     },
     "errors": {
       "consent-update-error": "Beim Aktualisieren Deiner Einwilligung \"{consent}\" ist ein Fehler aufgetreten."

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/snippet/en.json
@@ -3,7 +3,9 @@
     "general": {
       "mainMenuItemGeneral": "Privacy",
       "textHeadline": "Privacy",
-      "description": "Set your privacy preferences."
+      "description": "Set your privacy preferences.",
+      "airGappedTitle": "This installation is air-gapped",
+      "airGappedDescription": "Usage-data and product-analytics consent are unavailable because this shop cannot reach Shopware-operated cloud services."
     },
     "errors": {
       "consent-update-error": "The consent “{consent}” could not be updated"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/index.ts
@@ -1,3 +1,4 @@
+import { isAirGapped } from 'src/core/helper/air-gapped.helper';
 import template from './sw-settings-usage-data-general.html.twig';
 import SwSettingsUsageDataStoreDataConsent from '../../component/sw-settings-usage-data-store-data-consent';
 
@@ -13,5 +14,11 @@ export default Shopware.Component.wrapComponentConfig({
 
     components: {
         SwSettingsUsageDataStoreDataConsent,
+    },
+
+    computed: {
+        airGapped() {
+            return isAirGapped();
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/sw-settings-usage-data-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/sw-settings-usage-data-general.html.twig
@@ -1,7 +1,18 @@
 {% block sw_settings_usage_data_general %}
-<sw-settings-usage-data-store-data-consent />
-
-<sw-extension-component-section
-    position-identifier="sw-settings-usage-data-general"
+<mt-empty-state
+    v-if="airGapped"
+    class="sw-settings-usage-data-general__air-gapped"
+    :centered="true"
+    icon="regular-lock"
+    :headline="$t('sw-settings-usage-data.general.airGappedTitle')"
+    :description="$t('sw-settings-usage-data.general.airGappedDescription')"
 />
+
+<template v-else>
+    <sw-settings-usage-data-store-data-consent />
+
+    <sw-extension-component-section
+        position-identifier="sw-settings-usage-data-general"
+    />
+</template>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/sw-settings-usage-data-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/view/sw-settings-usage-data-general/sw-settings-usage-data-general.spec.js
@@ -36,4 +36,19 @@ describe('src/module/sw-settings-usage-data/view/sw-settings-usage-data-general'
 
         expect(wrapper.findComponent(SwSettingsUsageDataStoreDataConsent).exists()).toBe(true);
     });
+
+    it('hides consent when the installation is air-gapped', async () => {
+        Shopware.Store.get('context').app.config.settings = {
+            ...Shopware.Store.get('context').app.config.settings,
+            airGapped: true,
+        };
+
+        wrapper = await createWrapper();
+        await flushPromises();
+
+        expect(wrapper.findComponent(SwSettingsUsageDataStoreDataConsent).exists()).toBe(false);
+        expect(wrapper.find('.sw-settings-usage-data-general__air-gapped').exists()).toBe(true);
+
+        Shopware.Store.get('context').app.config.settings.airGapped = false;
+    });
 });

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
@@ -152,6 +152,10 @@
                 "type": "boolean",
                 "description": "True if runtime extension management is disabled."
               },
+              "airGapped": {
+                "type": "boolean",
+                "description": "True if the installation is air-gapped and Shopware-operated cloud services are disabled."
+              },
               "presignedUploadSupported": {
                 "type": "boolean",
                 "description": "Whether presigned S3 upload is available. True when presigned upload is enabled and an S3 filesystem is configured."

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/config.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/config.json
@@ -110,7 +110,8 @@
                     },
                     "enableHtmlSanitizer": true,
                     "enableStagingMode": false,
-                    "disableExtensionManagement": false
+                    "disableExtensionManagement": false,
+                    "airGapped": false
                   },
                   "inAppPurchases": []
                 }

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -209,6 +209,7 @@ class InfoController extends AbstractController
                 'enableHtmlSanitizer' => $this->params->get('shopware.html_sanitizer.enabled'),
                 'enableStagingMode' => $this->params->get('shopware.staging.administration.show_banner') && $this->systemConfigService->getBool(SetupStagingEvent::CONFIG_FLAG),
                 'disableExtensionManagement' => !$this->params->get('shopware.deployment.runtime_extension_management'),
+                'airGapped' => (bool) $this->params->get('shopware.deployment.air_gapped'),
                 'minSearchTermLength' => $this->systemConfigService->getInt('core.search.minSearchTermLength') ?: 2,
             ],
             'inAppPurchases' => $this->inAppPurchase->all(),

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -333,6 +333,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('blue_green')->end()
                 ->booleanNode('cluster_setup')->end()
                 ->booleanNode('runtime_extension_management')->defaultTrue()->end()
+                ->booleanNode('air_gapped')->defaultFalse()->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/services.php
+++ b/src/Core/Framework/DependencyInjection/services.php
@@ -55,6 +55,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Telemetry\EntityGroupResolver;
 use Shopware\Core\Framework\Demodata\PersonalData\CleanPersonalDataCommand;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Feature\Command\FeatureDisableCommand;
 use Shopware\Core\Framework\Feature\Command\FeatureDumpCommand;
@@ -954,4 +955,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(EnvIntOrNullProcessor::class)
         ->tag('container.env_var_processor');
+
+    $services->set(AirGappedMode::class)
+        ->args([
+            param('shopware.deployment.air_gapped'),
+        ]);
 };

--- a/src/Core/Framework/DependencyInjection/store.php
+++ b/src/Core/Framework/DependencyInjection/store.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\App\Source\SourceResolver;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\JWT\JWTDecoder;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\PluginManagementService;
@@ -38,6 +39,7 @@ use Shopware\Core\Framework\Store\InAppPurchase\Subscriber\InAppPurchaseConfigSu
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionStoreLicensesService;
 use Shopware\Core\Framework\Store\Services\AbstractStoreAppLifecycleService;
+use Shopware\Core\Framework\Store\Services\AirGappedStoreRequestMiddleware;
 use Shopware\Core\Framework\Store\Services\ExtensionDataProvider;
 use Shopware\Core\Framework\Store\Services\ExtensionDownloader;
 use Shopware\Core\Framework\Store\Services\ExtensionLifecycleService;
@@ -335,6 +337,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RetryFailedStoreRequestMiddleware::class)
         ->public()
         ->tag('shopware.store_client.middleware');
+
+    $services->set(AirGappedStoreRequestMiddleware::class)
+        ->args([
+            service(AirGappedMode::class),
+        ])
+        ->tag('shopware.store_client.middleware')
+        ->tag('shopware.frw_client.middleware');
 
     $services->set(TrackingEventClient::class)
         ->args([

--- a/src/Core/Framework/DependencyInjection/update.php
+++ b/src/Core/Framework/DependencyInjection/update.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DependencyInjection;
 
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Notification\NotificationService;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Framework\Store\Services\ExtensionLifecycleService;
@@ -52,6 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('kernel.shopware_version'),
             param('kernel.project_dir'),
             service(ClockInterface::class),
+            service(AirGappedMode::class),
         ]);
 
     $services->set(ExtensionCompatibility::class)

--- a/src/Core/Framework/Deployment/AirGappedMode.php
+++ b/src/Core/Framework/Deployment/AirGappedMode.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Deployment;
+
+use Shopware\Core\Framework\FrameworkException;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Operator-facing deployment mode that forbids HTTP to Shopware-operated SaaS and content hosts.
+ *
+ * @internal
+ */
+#[Package('framework')]
+final class AirGappedMode
+{
+    public function __construct(
+        private readonly bool $enabled,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @throws FrameworkException
+     */
+    public function denyShopwareOperatedHttp(): void
+    {
+        if ($this->enabled) {
+            throw FrameworkException::airGapped();
+        }
+    }
+}

--- a/src/Core/Framework/FrameworkException.php
+++ b/src/Core/Framework/FrameworkException.php
@@ -30,6 +30,7 @@ class FrameworkException extends HttpException
     private const INVALID_OPTIONS = 'FRAMEWORK__INVALID_OPTIONS';
     private const ASSOCIATION_NOT_FOUND = 'FRAMEWORK__ASSOCIATION_NOT_FOUND';
     private const CREATE_FROM_ERROR = 'FRAMEWORK__CREATE_FROM_ERROR';
+    private const AIR_GAPPED = 'FRAMEWORK__AIR_GAPPED';
 
     public static function projectDirNotExists(string $dir, ?\Throwable $e = null): self
     {
@@ -164,6 +165,15 @@ class FrameworkException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::CREATE_FROM_ERROR,
             $message
+        );
+    }
+
+    public static function airGapped(): self
+    {
+        return new self(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            self::AIR_GAPPED,
+            'This installation is air-gapped. Shopware-operated cloud services are disabled.',
         );
     }
 }

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -424,6 +424,7 @@ shopware:
     deployment:
         blue_green: '%env(bool:default:defaults_bool_true:BLUE_GREEN_DEPLOYMENT)%'
         cluster_setup: false
+        air_gapped: false
 
     media:
         enable_url_upload_feature: true

--- a/src/Core/Framework/Store/InAppPurchase/InAppPurchaseUpdateTask.php
+++ b/src/Core/Framework/Store/InAppPurchase/InAppPurchaseUpdateTask.php
@@ -4,11 +4,10 @@ namespace Shopware\Core\Framework\Store\InAppPurchase;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * @internal
- *
- * @codeCoverageIgnore
  */
 #[Package('checkout')]
 final class InAppPurchaseUpdateTask extends ScheduledTask
@@ -26,5 +25,10 @@ final class InAppPurchaseUpdateTask extends ScheduledTask
     public static function shouldRescheduleOnFailure(): bool
     {
         return true;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return !($bag->has('shopware.deployment.air_gapped') && $bag->get('shopware.deployment.air_gapped'));
     }
 }

--- a/src/Core/Framework/Store/Services/AirGappedStoreRequestMiddleware.php
+++ b/src/Core/Framework/Store/Services/AirGappedStoreRequestMiddleware.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Services;
+
+use Psr\Http\Message\RequestInterface;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Safety net for every Store / FRW Guzzle request.
+ *
+ * @internal
+ */
+#[Package('checkout')]
+class AirGappedStoreRequestMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly AirGappedMode $airGappedMode,
+    ) {
+    }
+
+    public function __invoke(callable $handler): callable
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            $this->airGappedMode->denyShopwareOperatedHttp();
+
+            return $handler($request, $options);
+        };
+    }
+}

--- a/src/Core/Framework/Update/Services/ApiClient.php
+++ b/src/Core/Framework/Update/Services/ApiClient.php
@@ -4,15 +4,13 @@ namespace Shopware\Core\Framework\Update\Services;
 
 use Psr\Clock\ClockInterface;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Struct\Version;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-/**
- * @phpstan-import-type VersionFixedVulnerabilities from Version
- */
 /**
  * @phpstan-import-type VersionFixedVulnerabilities from Version
  */
@@ -27,7 +25,8 @@ class ApiClient
         private readonly bool $shopwareUpdateEnabled,
         private readonly string $shopwareVersion,
         private readonly string $projectDir,
-        private readonly ClockInterface $clock
+        private readonly ClockInterface $clock,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -44,7 +43,7 @@ class ApiClient
             ]);
         }
 
-        if (!$this->shopwareUpdateEnabled) {
+        if (!$this->shopwareUpdateEnabled || $this->airGappedMode->isEnabled()) {
             return new Version();
         }
 
@@ -72,6 +71,10 @@ class ApiClient
     public function downloadRecoveryTool(): void
     {
         if (\is_string(EnvironmentHelper::getVariable('SW_RECOVERY_NEXT_VERSION'))) {
+            return;
+        }
+
+        if ($this->airGappedMode->isEnabled()) {
             return;
         }
 

--- a/src/Core/Service/DependencyInjection/services.php
+++ b/src/Core/Service/DependencyInjection/services.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Manifest\ManifestFactory;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Notification\NotificationService;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Service\AllServiceInstaller;
@@ -99,6 +100,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('shopware.service_registry.url'),
             env('APP_URL'),
             service('service_registry.http_client'),
+            service(AirGappedMode::class),
         ])
         ->tag('kernel.reset', ['method' => 'reset']);
 
@@ -259,6 +261,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(PermissionsService::class),
             service(Client::class),
             service(RequirementsValidator::class),
+            service(AirGappedMode::class),
         ]);
 
     $services->set(ServiceLifecycleSubscriber::class)

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Service;
 
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\DTO\Service;
 use Shopware\Core\Service\Permission\PermissionsService;
@@ -42,6 +43,7 @@ class LifecycleManager
         private readonly PermissionsService $permissionsService,
         private readonly Client $client,
         private readonly RequirementsValidator $requirementsValidator,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -114,6 +116,10 @@ class LifecycleManager
 
     public function enabled(): bool
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return false;
+        }
+
         return !$this->areDisabledFromEnv();
     }
 

--- a/src/Core/Service/ScheduledTask/InstallServicesTask.php
+++ b/src/Core/Service/ScheduledTask/InstallServicesTask.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Service\ScheduledTask;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * @internal
@@ -24,5 +25,10 @@ class InstallServicesTask extends ScheduledTask
     public static function shouldRescheduleOnFailure(): bool
     {
         return true;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return !($bag->has('shopware.deployment.air_gapped') && $bag->get('shopware.deployment.air_gapped'));
     }
 }

--- a/src/Core/Service/ServiceRegistry/Client.php
+++ b/src/Core/Service/ServiceRegistry/Client.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Service\ServiceRegistry;
 
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\ServiceException;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,6 +30,7 @@ class Client implements ResetInterface
         string $registryUrl,
         private readonly string $appUrl,
         private readonly HttpClientInterface $client,
+        private readonly AirGappedMode $airGappedMode,
     ) {
         $this->registryUrl = rtrim($registryUrl, '/');
     }
@@ -51,6 +53,8 @@ class Client implements ResetInterface
      */
     public function fetchServiceZip(string $zipUrl): \Generator
     {
+        $this->airGappedMode->denyShopwareOperatedHttp();
+
         $client = $this->client->withOptions([
             'max_duration' => 10,
         ]);
@@ -77,6 +81,10 @@ class Client implements ResetInterface
      */
     public function getAll(): array
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return [];
+        }
+
         if ($this->services !== null) {
             return $this->services;
         }
@@ -115,6 +123,10 @@ class Client implements ResetInterface
 
     public function saveConsent(SaveConsentRequest $saveConsentRequest): void
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return;
+        }
+
         try {
             $response = $this->client->request('POST', \sprintf('%s/api/consent/', $this->registryUrl), [
                 'headers' => [
@@ -134,6 +146,10 @@ class Client implements ResetInterface
 
     public function revokeConsent(string $identifier): void
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return;
+        }
+
         try {
             $response = $this->client->request('DELETE', \sprintf('%s/api/consent/revoke/%s', $this->registryUrl, $identifier), [
                 'headers' => [

--- a/src/Core/System/DependencyInjection/snippet.php
+++ b/src/Core/System/DependencyInjection/snippet.php
@@ -9,6 +9,7 @@ use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetDefinition;
 use Shopware\Core\System\Snippet\Command\DownloadTranslationCommand;
@@ -155,6 +156,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('shopware.translation.client'),
             service(TranslationConfig::class),
             service('event_dispatcher'),
+            service(AirGappedMode::class),
         ]);
 
     $services->alias(AbstractTranslationLoader::class, TranslationLoader::class);
@@ -165,6 +167,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('shopware.translation.client'),
             service('shopware.filesystem.translation'),
             service('cache.object'),
+            service(AirGappedMode::class),
         ]);
 
     $services->set(TranslationUpdater::class)

--- a/src/Core/System/DependencyInjection/usage_data.php
+++ b/src/Core/System/DependencyInjection/usage_data.php
@@ -7,6 +7,7 @@
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider as FrameworkShopIdProvider;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Store\Services\InstanceService;
 use Shopware\Core\System\Consent\Service\ConsentService;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -43,6 +44,7 @@ return static function (ContainerConfigurator $container): void {
             new Reference('clock'),
             new Reference(ConsentService::class),
             '%shopware.usage_data.collection_enabled%',
+            new Reference(AirGappedMode::class),
         ])
         ->tag('kernel.event_subscriber');
 
@@ -82,6 +84,7 @@ return static function (ContainerConfigurator $container): void {
             new Reference('clock'),
             '%kernel.environment%',
             '%shopware.usage_data.gateway.dispatch_enabled%',
+            new Reference(AirGappedMode::class),
         ]);
 
     $services->set(IterateEntitiesQueryBuilder::class)
@@ -103,6 +106,7 @@ return static function (ContainerConfigurator $container): void {
             new Reference(SystemConfigService::class),
             new Reference(ConsentService::class),
             '%shopware.usage_data.collection_enabled%',
+            new Reference(AirGappedMode::class),
         ]);
 
     $services->set(ManyToManyAssociationService::class)
@@ -123,6 +127,7 @@ return static function (ContainerConfigurator $container): void {
             new Reference(SystemConfigService::class),
             new Reference(InstanceService::class),
             '%env(APP_URL)%',
+            new Reference(AirGappedMode::class),
         ])
         ->tag('kernel.event_subscriber');
 
@@ -143,6 +148,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             new Reference('shopware.usage_data.gateway.client'),
             new Reference(ShopIdProvider::class),
+            new Reference(AirGappedMode::class),
         ]);
 
     $services->set(CollectEntityDataTask::class)

--- a/src/Core/System/Snippet/ScheduledTask/UpdateTranslationsTask.php
+++ b/src/Core/System/Snippet/ScheduledTask/UpdateTranslationsTask.php
@@ -21,7 +21,8 @@ class UpdateTranslationsTask extends ScheduledTask
 
     public static function shouldRun(ParameterBagInterface $bag): bool
     {
-        return (bool) $bag->get('shopware.translation.scheduled_task.enabled');
+        return (bool) $bag->get('shopware.translation.scheduled_task.enabled')
+            && !($bag->has('shopware.deployment.air_gapped') && $bag->get('shopware.deployment.air_gapped'));
     }
 
     public static function shouldRescheduleOnFailure(): bool

--- a/src/Core/System/Snippet/Service/TranslationLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationLoader.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -63,6 +64,7 @@ class TranslationLoader extends AbstractTranslationLoader implements ResetInterf
         private readonly ClientInterface $client,
         private readonly TranslationConfig $config,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -125,6 +127,8 @@ class TranslationLoader extends AbstractTranslationLoader implements ResetInterf
 
     public function download(string $locale): void
     {
+        $this->airGappedMode->denyShopwareOperatedHttp();
+
         if (!$this->config->languages->has($locale)) {
             throw SnippetException::languageDoesNotExist($locale);
         }

--- a/src/Core/System/Snippet/Service/TranslationMetadataStore.php
+++ b/src/Core/System/Snippet/Service/TranslationMetadataStore.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\ResponseInterface;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\DataTransfer\Metadata\MetadataCollection;
 use Shopware\Core\System\Snippet\DataTransfer\Metadata\MetadataEntry;
@@ -36,6 +37,7 @@ class TranslationMetadataStore
         private readonly ClientInterface $client,
         private readonly FilesystemOperator $filesystem,
         private readonly CacheInterface $cache,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -205,6 +207,10 @@ class TranslationMetadataStore
      */
     private function fetchRemoteMetadataArray(): array
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return [];
+        }
+
         $response = $this->downloadFile();
         $content = $response->getBody()->getContents();
 

--- a/src/Core/System/UsageData/Client/GatewayClient.php
+++ b/src/Core/System/UsageData/Client/GatewayClient.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\UsageData\Client;
 
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\UsageData\Services\ShopIdProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,11 +17,16 @@ class GatewayClient
     public function __construct(
         private readonly HttpClientInterface $client,
         private readonly ShopIdProvider $shopIdProvider,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
     public function isGatewayAllowsPush(): bool
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return false;
+        }
+
         $response = $this->client->request(
             Request::METHOD_GET,
             '/killswitch',

--- a/src/Core/System/UsageData/Consent/ConsentReporter.php
+++ b/src/Core/System/UsageData/Consent/ConsentReporter.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\UsageData\Consent;
 
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\InstanceService;
 use Shopware\Core\Framework\Store\Services\StoreService;
@@ -26,6 +27,7 @@ class ConsentReporter implements EventSubscriberInterface
         private readonly SystemConfigService $systemConfigService,
         private readonly InstanceService $instanceService,
         private readonly string $appUrl,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -57,6 +59,10 @@ class ConsentReporter implements EventSubscriberInterface
 
     private function reportConsentState(string $consentState): void
     {
+        if ($this->airGappedMode->isEnabled()) {
+            return;
+        }
+
         $payload = [
             'app_url' => $this->appUrl,
             'consent_state' => $consentState,

--- a/src/Core/System/UsageData/EntitySync/EntityDispatcher.php
+++ b/src/Core/System/UsageData/EntitySync/EntityDispatcher.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\UsageData\EntitySync;
 
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\InstanceService;
 use Shopware\Core\Framework\Store\Services\StoreService;
@@ -30,6 +31,7 @@ class EntityDispatcher
         private readonly ClockInterface $clock,
         private readonly string $environment,
         private readonly bool $dispatchEnabled,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -43,7 +45,7 @@ class EntityDispatcher
         \DateTimeImmutable $runDate,
         string $shopId
     ): void {
-        if (!$this->dispatchEnabled) {
+        if (!$this->dispatchEnabled || $this->airGappedMode->isEnabled()) {
             return;
         }
 

--- a/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTask.php
+++ b/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTask.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\UsageData\ScheduledTask;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
  * @internal
@@ -24,5 +25,10 @@ class CollectEntityDataTask extends ScheduledTask
     public static function shouldRescheduleOnFailure(): bool
     {
         return true;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return !($bag->has('shopware.deployment.air_gapped') && $bag->get('shopware.deployment.air_gapped'));
     }
 }

--- a/src/Core/System/UsageData/Services/EntityDispatchService.php
+++ b/src/Core/System/UsageData/Services/EntityDispatchService.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\UsageData\Services;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Consent\Definition\BackendData;
 use Shopware\Core\System\Consent\Service\ConsentService;
@@ -35,6 +36,7 @@ class EntityDispatchService
         private readonly SystemConfigService $systemConfigService,
         private readonly ConsentService $consentService,
         private readonly bool $collectionEnabled,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -45,7 +47,7 @@ class EntityDispatchService
 
     public function dispatchCollectEntityDataMessage(): void
     {
-        if (!$this->collectionEnabled) {
+        if (!$this->collectionEnabled || $this->airGappedMode->isEnabled()) {
             return;
         }
 

--- a/src/Core/System/UsageData/Subscriber/EntityDeleteSubscriber.php
+++ b/src/Core/System/UsageData/Subscriber/EntityDeleteSubscriber.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Consent\ConsentStatus;
@@ -36,6 +37,7 @@ class EntityDeleteSubscriber implements EventSubscriberInterface
         private readonly ClockInterface $clock,
         private readonly ConsentService $consentService,
         private readonly bool $collectionEnabled,
+        private readonly AirGappedMode $airGappedMode,
     ) {
     }
 
@@ -48,7 +50,7 @@ class EntityDeleteSubscriber implements EventSubscriberInterface
 
     public function handleEntityDeleteEvent(EntityDeleteEvent $event): void
     {
-        if (!$this->collectionEnabled) {
+        if (!$this->collectionEnabled || $this->airGappedMode->isEnabled()) {
             return;
         }
 

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -136,6 +136,7 @@ class InfoControllerTest extends TestCase
                 'enableHtmlSanitizer' => true,
                 'enableStagingMode' => false,
                 'disableExtensionManagement' => false,
+                'airGapped' => false,
                 'minSearchTermLength' => 2,
             ],
             'inAppPurchases' => [],

--- a/tests/integration/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/integration/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -107,6 +108,7 @@ class InstallTranslationCommandTest extends TestCase
             client: $client,
             config: $this->config,
             eventDispatcher: static::getContainer()->get('event_dispatcher'),
+            airGappedMode: new AirGappedMode(false),
         );
     }
 

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
@@ -169,6 +170,69 @@ class AdministrationControllerTest extends TestCase
         $response = $controller->index(new Request(), $this->context);
 
         static::assertNotFalse($response->getContent());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testIndexBlanksShopwareOperatedUrlsWhenAirGapped(): void
+    {
+        $this->parameterBag->method('has')->willReturn(true);
+        $this->parameterBag->method('get')->willReturn(true);
+
+        $currencyRepository = $this->createMock(EntityRepository::class);
+
+        $controller = $this->createAdministrationController(
+            currencyRepository: $currencyRepository,
+            airGappedMode: new AirGappedMode(true),
+        );
+
+        $container = new Container();
+        $twig = $this->createMock(Environment::class);
+
+        $twig->expects($this->once())->method('render')
+            ->willReturnArgument(0)
+            ->with(
+                '',
+                [
+                    'features' => [],
+                    'systemLanguageId' => Defaults::LANGUAGE_SYSTEM,
+                    'defaultLanguageIds' => [Defaults::LANGUAGE_SYSTEM],
+                    'systemCurrencyId' => Defaults::CURRENCY,
+                    'systemCurrencyISOCode' => 'fakeIsoCode',
+                    'liveVersionId' => Defaults::LIVE_VERSION,
+                    'firstRunWizard' => false,
+                    'apiVersion' => null,
+                    'cspNonce' => null,
+                    'adminEsEnable' => true,
+                    'storefrontEsEnable' => true,
+                    'serviceRegistryUrl' => '',
+                    'refreshTokenTtl' => 7 * 86400 * 1000,
+                    'productStreamIndexingEnabled' => true,
+                    'analyticsGatewayUrl' => '',
+                ]
+            );
+
+        $container->set('twig', $twig);
+        $controller->setContainer($container);
+
+        $currencyCollection = new CurrencyCollection();
+        $currency = new CurrencyEntity();
+        $currency->setId(Uuid::randomHex());
+        $currency->setIsoCode('fakeIsoCode');
+        $currencyCollection->add($currency);
+
+        $currencyRepository->expects($this->once())->method('search')->willReturn(
+            new EntitySearchResult(
+                'currency',
+                1,
+                $currencyCollection,
+                null,
+                new Criteria(),
+                $this->context
+            )
+        );
+
+        $response = $controller->index(new Request(), $this->context);
+
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -720,6 +784,7 @@ class AdministrationControllerTest extends TestCase
         ?HtmlSanitizer $htmlSanitizer = null,
         ?DefinitionInstanceRegistry $definitionRegistry = null,
         ?PrefixFilesystem $fileSystemOperator = null,
+        ?AirGappedMode $airGappedMode = null,
     ): AdministrationController {
         $collection = $collection ?? new CustomerCollection();
 
@@ -749,6 +814,7 @@ class AdministrationControllerTest extends TestCase
             $tokenValidator ?? static::createStub(SymfonyBearerTokenValidator::class),
             $this->analyticsGatewayUrl,
             $customerEmailUniqueChecker,
+            $airGappedMode ?? new AirGappedMode(false),
             $this->refreshTokenTtl,
         );
     }

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Shopware\Administration\Administration;
 use Shopware\Administration\Snippet\SnippetException;
 use Shopware\Administration\Snippet\SnippetFinder;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
@@ -573,6 +574,7 @@ class SnippetFinderTest extends TestCase
             client: static::createStub(ClientInterface::class),
             config: $translationConfig,
             eventDispatcher: new EventDispatcher(),
+            airGappedMode: new AirGappedMode(false),
         );
     }
 }

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -128,6 +128,8 @@ class InfoControllerTest extends TestCase
         static::assertTrue($settings['enableHtmlSanitizer']);
         static::assertArrayHasKey('minSearchTermLength', $settings);
         static::assertSame(2, $settings['minSearchTermLength']);
+        static::assertArrayHasKey('airGapped', $settings);
+        static::assertFalse($settings['airGapped']);
 
         static::assertArrayHasKey('inAppPurchases', $data);
         $inAppPurchases = $data['inAppPurchases'];
@@ -306,6 +308,7 @@ class InfoControllerTest extends TestCase
             'shopware.media.enable_url_upload_feature' => true,
             'shopware.staging.administration.show_banner' => false,
             'shopware.deployment.runtime_extension_management' => true,
+            'shopware.deployment.air_gapped' => false,
         ]);
 
         return new InfoController(

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -289,7 +289,11 @@ class ConfigurationTest extends TestCase
 
     public function testDeploymentAirGappedDefaultsToFalse(): void
     {
-        $config = (new Processor())->processConfiguration(new Configuration(), []);
+        $config = (new Processor())->processConfiguration(new Configuration(), [
+            [
+                'deployment' => [],
+            ],
+        ]);
 
         static::assertFalse($config['deployment']['air_gapped']);
     }

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -271,6 +271,42 @@ class ConfigurationTest extends TestCase
         static::assertInstanceOf(ArrayNodeDefinition::class, $nodes['']);
     }
 
+    public function testDeploymentSectionContainsAirGappedNode(): void
+    {
+        $configuration = new Configuration();
+
+        $rootNode = $configuration->getConfigTreeBuilder()->getRootNode();
+
+        static::assertInstanceOf(ArrayNodeDefinition::class, $rootNode);
+        $nodes = $rootNode->getChildNodeDefinitions();
+
+        static::assertArrayHasKey('deployment', $nodes);
+        static::assertInstanceOf(ArrayNodeDefinition::class, $nodes['deployment']);
+
+        $children = $nodes['deployment']->getChildNodeDefinitions();
+        static::assertInstanceOf(BooleanNodeDefinition::class, $children['air_gapped']);
+    }
+
+    public function testDeploymentAirGappedDefaultsToFalse(): void
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(), []);
+
+        static::assertFalse($config['deployment']['air_gapped']);
+    }
+
+    public function testDeploymentAirGappedCanBeEnabled(): void
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(), [
+            [
+                'deployment' => [
+                    'air_gapped' => true,
+                ],
+            ],
+        ]);
+
+        static::assertTrue($config['deployment']['air_gapped']);
+    }
+
     public function testUsageDataSection(): void
     {
         $configuration = new Configuration();

--- a/tests/unit/Core/Framework/Deployment/AirGappedModeTest.php
+++ b/tests/unit/Core/Framework/Deployment/AirGappedModeTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Deployment;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
+use Shopware\Core\Framework\FrameworkException;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AirGappedMode::class)]
+class AirGappedModeTest extends TestCase
+{
+    public function testIsEnabled(): void
+    {
+        static::assertFalse((new AirGappedMode(false))->isEnabled());
+        static::assertTrue((new AirGappedMode(true))->isEnabled());
+    }
+
+    public function testDenyShopwareOperatedHttpAllowsWhenDisabled(): void
+    {
+        $mode = new AirGappedMode(false);
+
+        $mode->denyShopwareOperatedHttp();
+
+        static::assertFalse($mode->isEnabled());
+    }
+
+    public function testDenyShopwareOperatedHttpThrowsWhenEnabled(): void
+    {
+        $mode = new AirGappedMode(true);
+
+        $this->expectExceptionObject(FrameworkException::airGapped());
+        $mode->denyShopwareOperatedHttp();
+    }
+}

--- a/tests/unit/Core/Framework/FrameworkExceptionTest.php
+++ b/tests/unit/Core/Framework/FrameworkExceptionTest.php
@@ -57,4 +57,16 @@ class FrameworkExceptionTest extends TestCase
 
         static::assertEquals(new \InvalidArgumentException('error message'), $exception);
     }
+
+    public function testAirGapped(): void
+    {
+        $exception = FrameworkException::airGapped();
+
+        static::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__AIR_GAPPED', $exception->getErrorCode());
+        static::assertSame(
+            'This installation is air-gapped. Shopware-operated cloud services are disabled.',
+            $exception->getMessage()
+        );
+    }
 }

--- a/tests/unit/Core/Framework/Store/InAppPurchase/InAppPurchaseUpdateTaskTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchase/InAppPurchaseUpdateTaskTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\InAppPurchase;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\InAppPurchase\InAppPurchaseUpdateTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(InAppPurchaseUpdateTask::class)]
+class InAppPurchaseUpdateTaskTest extends TestCase
+{
+    public function testMeta(): void
+    {
+        static::assertSame('in-app-purchase.update', InAppPurchaseUpdateTask::getTaskName());
+        static::assertSame(86400, InAppPurchaseUpdateTask::getDefaultInterval());
+        static::assertTrue(InAppPurchaseUpdateTask::shouldRescheduleOnFailure());
+        static::assertTrue(InAppPurchaseUpdateTask::shouldRun(new ParameterBag()));
+        static::assertTrue(InAppPurchaseUpdateTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => false,
+        ])));
+    }
+
+    public function testShouldNotRunWhenAirGapped(): void
+    {
+        static::assertFalse(InAppPurchaseUpdateTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => true,
+        ])));
+    }
+}

--- a/tests/unit/Core/Framework/Store/Services/AirGappedStoreRequestMiddlewareTest.php
+++ b/tests/unit/Core/Framework/Store/Services/AirGappedStoreRequestMiddlewareTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Services;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
+use Shopware\Core\Framework\FrameworkException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Services\AirGappedStoreRequestMiddleware;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(AirGappedStoreRequestMiddleware::class)]
+class AirGappedStoreRequestMiddlewareTest extends TestCase
+{
+    public function testPassesThroughWhenAirGappedModeIsDisabled(): void
+    {
+        $response = new Response(200, [], '{"ok":true}');
+        $request = new Psr7Request('GET', 'https://api.shopware.com/swplatform/login');
+        $handlerCalled = false;
+
+        $middleware = new AirGappedStoreRequestMiddleware(new AirGappedMode(false));
+
+        $handler = function (RequestInterface $req, array $options) use ($response, &$handlerCalled): PromiseInterface {
+            $handlerCalled = true;
+
+            return new FulfilledPromise($response);
+        };
+
+        /** @var PromiseInterface $promise */
+        $promise = ($middleware($handler))($request, []);
+        $handledResponse = $promise->wait();
+
+        static::assertTrue($handlerCalled);
+        static::assertSame($response, $handledResponse);
+    }
+
+    public function testRejectsRequestWhenAirGappedModeIsEnabled(): void
+    {
+        $request = new Psr7Request('GET', 'https://api.shopware.com/swplatform/login');
+
+        $middleware = new AirGappedStoreRequestMiddleware(new AirGappedMode(true));
+
+        $handler = function (RequestInterface $req, array $options): PromiseInterface {
+            static::fail('Store handler must not run in air-gapped mode');
+        };
+
+        $this->expectExceptionObject(FrameworkException::airGapped());
+        ($middleware($handler))($request, []);
+    }
+}

--- a/tests/unit/Core/Framework/Update/Services/ApiClientTest.php
+++ b/tests/unit/Core/Framework/Update/Services/ApiClientTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Update\Services;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Services\ApiClient;
 use Symfony\Component\Clock\NativeClock;
@@ -21,7 +22,7 @@ class ApiClientTest extends TestCase
 {
     public function testCheckForUpdatesDisabled(): void
     {
-        $client = new ApiClient(new MockHttpClient([]), false, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient([]), false, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         static::assertEmpty($version->version);
@@ -31,7 +32,7 @@ class ApiClientTest extends TestCase
     {
         $_SERVER['SW_RECOVERY_NEXT_VERSION'] = '6.4.1.0';
 
-        $client = new ApiClient(new MockHttpClient([]), true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient([]), true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         unset($_SERVER['SW_RECOVERY_NEXT_VERSION']);
@@ -46,7 +47,7 @@ class ApiClientTest extends TestCase
             new MockResponse('{"title": "Shopware", "body": "bla", "date": "2021-09-01", "version": "6.4.8.1", "fixedVulnerabilities": []}', ['Content-Type' => 'application/json']),
         ];
 
-        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         static::assertSame('6.4.8.1', $version->version);
@@ -59,7 +60,7 @@ class ApiClientTest extends TestCase
             new MockResponse('{"title": "Shopware", "body": "bla", "date": "2021-09-01", "version": "6.4.8.1", "fixedVulnerabilities": []}', ['Content-Type' => 'application/json']),
         ];
 
-        $client = new ApiClient(new MockHttpClient($responses), true, '6.6.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient($responses), true, '6.6.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         static::assertSame('6.4.8.1', $version->version);
@@ -72,7 +73,7 @@ class ApiClientTest extends TestCase
             new MockResponse('{"title": "Shopware", "body": "bla", "date": "2021-09-01", "version": "6.5.0.0", "fixedVulnerabilities": []}', ['Content-Type' => 'application/json']),
         ];
 
-        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         static::assertSame('6.5.0.0', $version->version);
@@ -85,7 +86,7 @@ class ApiClientTest extends TestCase
             new MockResponse('', ['http_code' => 404]),
         ];
 
-        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
         $version = $client->checkForUpdates();
 
         static::assertSame('', $version->version);
@@ -100,10 +101,31 @@ class ApiClientTest extends TestCase
             new MockResponse('', ['http_code' => 500]),
         ];
 
-        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient(new MockHttpClient($responses), true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
 
         static::expectException(ServerException::class);
         $client->checkForUpdates();
+    }
+
+    public function testCheckForUpdatesAirGappedReturnsEmptyVersion(): void
+    {
+        $httpClient = new MockHttpClient([]);
+        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(true));
+
+        $version = $client->checkForUpdates();
+
+        static::assertSame('', $version->version);
+        static::assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testDownloadRecoveryToolAirGappedDoesNothing(): void
+    {
+        $httpClient = new MockHttpClient([]);
+        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(true));
+
+        $client->downloadRecoveryTool();
+
+        static::assertSame(0, $httpClient->getRequestsCount());
     }
 
     public function testDownloadRecoveryToolDoesNothing(): void
@@ -111,7 +133,7 @@ class ApiClientTest extends TestCase
         $_SERVER['SW_RECOVERY_NEXT_VERSION'] = '6.4.0.0';
 
         $httpClient = new MockHttpClient([]);
-        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
 
         $client->downloadRecoveryTool();
 
@@ -129,7 +151,7 @@ class ApiClientTest extends TestCase
         $fs->mkdir(__DIR__ . '/public');
 
         $httpClient = new MockHttpClient($responses);
-        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock());
+        $client = new ApiClient($httpClient, true, '6.4.0.0', __DIR__, new NativeClock(), new AirGappedMode(false));
 
         $client->downloadRecoveryTool();
 

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\AllServiceInstaller;
 use Shopware\Core\Service\LifecycleManager;
@@ -390,9 +391,29 @@ class LifecycleManagerTest extends TestCase
             static::createStub(PermissionsService::class),
             static::createStub(Client::class),
             static::createStub(RequirementsValidator::class),
+            new AirGappedMode(false),
         );
 
         static::assertSame($expectedEnabled, $manager->enabled());
+    }
+
+    public function testEnabledIsFalseWhenAirGapped(): void
+    {
+        $manager = new LifecycleManager(
+            'true',
+            'prod',
+            static::createStub(Privileges::class),
+            new StaticSystemConfigService(),
+            new ServiceStorage($this->createAppRepository()),
+            static::createStub(ServiceLifecycle::class),
+            static::createStub(AllServiceInstaller::class),
+            static::createStub(PermissionsService::class),
+            static::createStub(Client::class),
+            static::createStub(RequirementsValidator::class),
+            new AirGappedMode(true),
+        );
+
+        static::assertFalse($manager->enabled());
     }
 
     public static function enabledProvider(): \Generator
@@ -467,6 +488,7 @@ class LifecycleManagerTest extends TestCase
             $this->permissionsService,
             $this->client,
             $requirements,
+            new AirGappedMode(false),
         );
     }
 

--- a/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskTest.php
+++ b/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskTest.php
@@ -21,6 +21,16 @@ class InstallServicesTaskTest extends TestCase
         static::assertSame(86_400, InstallServicesTask::getDefaultInterval());
 
         static::assertTrue(InstallServicesTask::shouldRun(new ParameterBag()));
+        static::assertTrue(InstallServicesTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => false,
+        ])));
         static::assertTrue(InstallServicesTask::shouldRescheduleOnFailure());
+    }
+
+    public function testShouldNotRunWhenAirGapped(): void
+    {
+        static::assertFalse(InstallServicesTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => true,
+        ])));
     }
 }

--- a/tests/unit/Core/Service/ServiceRegistry/ClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistry/ClientTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Unit\Core\Service\ServiceRegistry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\ServiceException;
 use Shopware\Core\Service\ServiceRegistry\Client as ServiceRegistryClient;
@@ -65,7 +67,7 @@ class ClientTest extends TestCase
             $response = new MockResponse($response),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         static::assertSame([], $registryClient->getAll());
         static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
@@ -77,7 +79,7 @@ class ClientTest extends TestCase
             $response = new MockResponse('', ['http_code' => Response::HTTP_SERVICE_UNAVAILABLE]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         static::assertSame([], $registryClient->getAll());
         static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
@@ -96,7 +98,7 @@ class ClientTest extends TestCase
             $response = new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $entries = $registryClient->getAll();
 
@@ -113,6 +115,75 @@ class ClientTest extends TestCase
         static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
     }
 
+    public function testGetAllReturnsEmptyListWhenAirGapped(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $registryClient = new ServiceRegistryClient(
+            'https://www.shopware.com',
+            'https://example.com',
+            $httpClient,
+            new AirGappedMode(true),
+        );
+
+        static::assertSame([], $registryClient->getAll());
+        static::assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testSaveConsentIsNoOpWhenAirGapped(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $registryClient = new ServiceRegistryClient(
+            'https://example.com',
+            'https://example.com',
+            $httpClient,
+            new AirGappedMode(true),
+        );
+
+        $registryClient->saveConsent(new SaveConsentRequest(
+            'service-123',
+            'user-456',
+            'shop-789',
+            '2023-07-01T10:00:00Z',
+            'v1.0',
+        ));
+
+        static::assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testRevokeConsentIsNoOpWhenAirGapped(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $registryClient = new ServiceRegistryClient(
+            'https://example.com',
+            'https://example.com',
+            $httpClient,
+            new AirGappedMode(true),
+        );
+
+        $registryClient->revokeConsent('service-123');
+
+        static::assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testFetchServiceZipThrowsWhenAirGapped(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $registryClient = new ServiceRegistryClient(
+            'https://example.com',
+            'https://example.com',
+            $httpClient,
+            new AirGappedMode(true),
+        );
+
+        $this->expectExceptionObject(FrameworkException::airGapped());
+
+        iterator_to_array($registryClient->fetchServiceZip('https://example.com/service.zip'));
+    }
+
     public function testServicesAreFetchedAndCached(): void
     {
         $service = [
@@ -126,7 +197,7 @@ class ClientTest extends TestCase
             new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $entries1 = $registryClient->getAll();
         static::assertCount(2, $entries1);
@@ -161,7 +232,7 @@ class ClientTest extends TestCase
             new MockResponse((string) json_encode($services2, \JSON_THROW_ON_ERROR)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $entries1 = $registryClient->getAll();
         static::assertCount(2, $entries1);
@@ -189,7 +260,7 @@ class ClientTest extends TestCase
             $response2 = new MockResponse((string) json_encode($servicesPage2, \JSON_THROW_ON_ERROR)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $client, new AirGappedMode(false));
         $entries = $registryClient->getAll();
 
         static::assertCount(2, $entries);
@@ -213,7 +284,7 @@ class ClientTest extends TestCase
             },
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         static::assertSame([], $registryClient->getAll());
     }
@@ -224,7 +295,7 @@ class ClientTest extends TestCase
             $response = new MockResponse('', ['http_code' => Response::HTTP_ACCEPTED]), // Changed from 200 to 202 (HTTP_ACCEPTED)
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $saveConsentRequest = new SaveConsentRequest(
             'service-123',
@@ -247,7 +318,7 @@ class ClientTest extends TestCase
             new MockResponse('', ['http_code' => Response::HTTP_INTERNAL_SERVER_ERROR]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $saveConsentRequest = new SaveConsentRequest(
             'service-123',
@@ -267,7 +338,7 @@ class ClientTest extends TestCase
             new MockResponse('', ['http_code' => Response::HTTP_OK]), // 200 is not HTTP_ACCEPTED (202)
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $saveConsentRequest = new SaveConsentRequest(
             'service-123',
@@ -287,7 +358,7 @@ class ClientTest extends TestCase
             $response = new MockResponse('', ['http_code' => Response::HTTP_ACCEPTED]), // Changed from 200 to 202 (HTTP_ACCEPTED)
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $registryClient->revokeConsent('service-123');
 
@@ -301,7 +372,7 @@ class ClientTest extends TestCase
             new MockResponse('', ['http_code' => Response::HTTP_INTERNAL_SERVER_ERROR]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $this->expectExceptionObject(ServiceException::consentRevokeFailed('Unexpected response status code: 500'));
         $registryClient->revokeConsent('service-123');
@@ -313,7 +384,7 @@ class ClientTest extends TestCase
             new MockResponse('', ['http_code' => Response::HTTP_OK]), // 200 is not HTTP_ACCEPTED (202)
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $this->expectExceptionObject(ServiceException::consentRevokeFailed('Unexpected response status code: 200'));
         $registryClient->revokeConsent('service-123');
@@ -329,13 +400,13 @@ class ClientTest extends TestCase
         $servicePayload = (string) json_encode($service, \JSON_THROW_ON_ERROR);
         $expectedUrl = 'https://www.shopware.com/api/service/?page=1&limit=10';
         $clientWithSlash = new MockHttpClient([$responseWithSlash = new MockResponse($servicePayload)]);
-        $registryClientWithSlash = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $clientWithSlash);
+        $registryClientWithSlash = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $clientWithSlash, new AirGappedMode(false));
         $entriesWithSlash = $registryClientWithSlash->getAll();
         static::assertCount(1, $entriesWithSlash);
         static::assertSame($expectedUrl, $responseWithSlash->getRequestUrl());
 
         $clientWithoutSlash = new MockHttpClient([$responseWithoutSlash = new MockResponse($servicePayload)]);
-        $registryClientWithoutSlash = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $clientWithoutSlash);
+        $registryClientWithoutSlash = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $clientWithoutSlash, new AirGappedMode(false));
         $entriesWithoutSlash = $registryClientWithoutSlash->getAll();
         static::assertCount(1, $entriesWithoutSlash);
         static::assertSame($expectedUrl, $responseWithoutSlash->getRequestUrl());
@@ -352,7 +423,7 @@ class ClientTest extends TestCase
             ]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $collected = '';
         foreach ($registryClient->fetchServiceZip($zipUrl) as $chunk) {
@@ -372,7 +443,7 @@ class ClientTest extends TestCase
             new MockResponse('', ['http_code' => Response::HTTP_NOT_FOUND]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $this->expectException(ServiceException::class);
         // Force execution so checkResponse() runs and throws
@@ -397,7 +468,7 @@ class ClientTest extends TestCase
             ]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client, new AirGappedMode(false));
         $this->expectException(ServiceException::class);
         // Force execution so checkResponse() runs and throws
         \iterator_to_array($registryClient->fetchServiceZip($zipUrl));
@@ -413,7 +484,7 @@ class ClientTest extends TestCase
             $response = new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client, new AirGappedMode(false));
 
         $registryClient->getAll();
 

--- a/tests/unit/Core/System/Snippet/Files/SnippetFileLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Files/SnippetFileLoaderTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
@@ -789,6 +790,7 @@ class SnippetFileLoaderTest extends TestCase
             client: static::createStub(ClientInterface::class),
             config: $this->config,
             eventDispatcher: new EventDispatcher(),
+            airGappedMode: new AirGappedMode(false),
         );
     }
 }

--- a/tests/unit/Core/System/Snippet/ScheduledTask/UpdateTranslationsTaskTest.php
+++ b/tests/unit/Core/System/Snippet/ScheduledTask/UpdateTranslationsTaskTest.php
@@ -28,4 +28,20 @@ class UpdateTranslationsTaskTest extends TestCase
             'shopware.translation.scheduled_task.enabled' => false,
         ])));
     }
+
+    public function testTaskRunsWhenEnabledAndNotAirGapped(): void
+    {
+        static::assertTrue(UpdateTranslationsTask::shouldRun(new ParameterBag([
+            'shopware.translation.scheduled_task.enabled' => true,
+            'shopware.deployment.air_gapped' => false,
+        ])));
+    }
+
+    public function testTaskDoesNotRunWhenAirGapped(): void
+    {
+        static::assertFalse(UpdateTranslationsTask::shouldRun(new ParameterBag([
+            'shopware.translation.scheduled_task.enabled' => true,
+            'shopware.deployment.air_gapped' => true,
+        ])));
+    }
 }

--- a/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
@@ -17,6 +17,8 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -574,6 +576,14 @@ class TranslationLoaderTest extends TestCase
         static::assertTrue($loader->hasTranslationFiles('es-ES'));
     }
 
+    public function testDownloadThrowsWhenAirGapped(): void
+    {
+        $loader = $this->getTranslationLoader(new AirGappedMode(true));
+
+        $this->expectExceptionObject(FrameworkException::airGapped());
+        $loader->download('es-ES');
+    }
+
     public function testHasTranslationFilesReturnsFalseForMalformedLocale(): void
     {
         $loader = $this->getTranslationLoader();
@@ -583,7 +593,7 @@ class TranslationLoaderTest extends TestCase
         static::assertFalse($loader->hasTranslationFiles('_not-a-locale_'));
     }
 
-    private function getTranslationLoader(): TranslationLoader
+    private function getTranslationLoader(?AirGappedMode $airGappedMode = null): TranslationLoader
     {
         return new TranslationLoader(
             translationWriter: $this->flysystem,
@@ -593,6 +603,7 @@ class TranslationLoaderTest extends TestCase
             client: $this->client,
             config: $this->config,
             eventDispatcher: $this->eventDispatcher,
+            airGappedMode: $airGappedMode ?? new AirGappedMode(false),
         );
     }
 

--- a/tests/unit/Core/System/Snippet/Service/TranslationMetadataStoreTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationMetadataStoreTest.php
@@ -12,6 +12,7 @@ use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\DataTransfer\Language\Language;
 use Shopware\Core\System\Snippet\DataTransfer\Language\LanguageCollection;
@@ -285,6 +286,29 @@ class TranslationMetadataStoreTest extends TestCase
         static::assertFalse($byLocale['it-IT']['isPseudoLanguage']);
     }
 
+    public function testGetTranslationListDoesNotFetchRemoteWhenAirGapped(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->never())->method('request');
+
+        $store = new TranslationMetadataStore(
+            $this->config,
+            $client,
+            $this->filesystem,
+            new ArrayAdapter(),
+            new AirGappedMode(true),
+        );
+        $store->save($this->getMetadataCollection());
+
+        $byLocale = array_column($store->getTranslationList(), null, 'locale');
+
+        static::assertArrayHasKey('it-IT', $byLocale);
+        static::assertFalse($byLocale['it-IT']['updateAvailable']);
+        static::assertArrayHasKey('ro-RO', $byLocale);
+        static::assertNull($byLocale['ro-RO']['progress']);
+        static::assertFalse($byLocale['ro-RO']['updateAvailable']);
+    }
+
     public function testGetTranslationListDegradesWhenRemoteMetadataUnavailable(): void
     {
         $client = static::createStub(ClientInterface::class);
@@ -339,7 +363,7 @@ class TranslationMetadataStoreTest extends TestCase
         // The list path fetches the remote metadata once and serves the second call from the cache.
         $client->expects($this->once())->method('request')->willReturn($response);
 
-        $store = new TranslationMetadataStore($this->config, $client, $this->filesystem, new ArrayAdapter());
+        $store = new TranslationMetadataStore($this->config, $client, $this->filesystem, new ArrayAdapter(), new AirGappedMode(false));
 
         $store->getTranslationList();
         $store->getTranslationList();
@@ -347,7 +371,7 @@ class TranslationMetadataStoreTest extends TestCase
 
     private function getTranslationMetadataStore(): TranslationMetadataStore
     {
-        return new TranslationMetadataStore($this->config, $this->client, $this->filesystem, new ArrayAdapter());
+        return new TranslationMetadataStore($this->config, $this->client, $this->filesystem, new ArrayAdapter(), new AirGappedMode(false));
     }
 
     /**

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -539,6 +540,7 @@ class SnippetServiceTest extends TestCase
             client: static::createStub(ClientInterface::class),
             config: $config,
             eventDispatcher: new EventDispatcher(),
+            airGappedMode: new AirGappedMode(false),
         );
     }
 }

--- a/tests/unit/Core/System/UsageData/Client/GatewayClientTest.php
+++ b/tests/unit/Core/System/UsageData/Client/GatewayClientTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\Client;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\UsageData\Client\GatewayClient;
 use Shopware\Core\System\UsageData\Services\ShopIdProvider;
@@ -28,6 +29,7 @@ class GatewayClientTest extends TestCase
         $gatewayClient = new GatewayClient(
             $client,
             static::createStub(ShopIdProvider::class),
+            new AirGappedMode(false),
         );
 
         static::assertTrue($gatewayClient->isGatewayAllowsPush());
@@ -44,8 +46,23 @@ class GatewayClientTest extends TestCase
         $gatewayClient = new GatewayClient(
             $client,
             static::createStub(ShopIdProvider::class),
+            new AirGappedMode(false),
         );
 
         static::assertFalse($gatewayClient->isGatewayAllowsPush());
+    }
+
+    public function testGatewayDoesNotAllowPushWhenAirGapped(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $gatewayClient = new GatewayClient(
+            $httpClient,
+            static::createStub(ShopIdProvider::class),
+            new AirGappedMode(true),
+        );
+
+        static::assertFalse($gatewayClient->isGatewayAllowsPush());
+        static::assertSame(0, $httpClient->getRequestsCount());
     }
 }

--- a/tests/unit/Core/System/UsageData/Consent/ConsentReporterTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/ConsentReporterTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\Consent;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Services\InstanceService;
@@ -53,6 +54,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -78,6 +80,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -99,6 +102,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -120,6 +124,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportRevokedConsent(new ConsentRevokedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -145,6 +150,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             $instanceService,
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -168,6 +174,7 @@ class ConsentReporterTest extends TestCase
             ]),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -190,6 +197,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent(BackendData::NAME, 'system', 'system', 'actor'));
@@ -206,6 +214,7 @@ class ConsentReporterTest extends TestCase
             new StaticSystemConfigService(),
             static::createStub(InstanceService::class),
             'APP_URL',
+            new AirGappedMode(false),
         );
 
         $reporter->reportAcceptedConsent(new ConsentAcceptedEvent('other-consent', 'system', 'system', 'actor'));

--- a/tests/unit/Core/System/UsageData/EntitySync/EntityDispatcherTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/EntityDispatcherTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\InstanceService;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -52,6 +53,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -80,6 +82,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -111,6 +114,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -139,6 +143,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -183,6 +188,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -217,6 +223,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -248,6 +255,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -279,6 +287,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -312,6 +321,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatcher->dispatch(
@@ -343,6 +353,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -376,6 +387,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -409,6 +421,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -435,6 +448,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -463,6 +477,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -491,6 +506,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -517,6 +533,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'dev',
             false,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();
@@ -542,6 +559,7 @@ class EntityDispatcherTest extends TestCase
             $this->clock,
             'prod',
             true,
+            new AirGappedMode(false),
         );
 
         $runDate = new \DateTimeImmutable();

--- a/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskTest.php
+++ b/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\UsageData\ScheduledTask\CollectEntityDataTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @internal
@@ -22,5 +23,20 @@ class CollectEntityDataTaskTest extends TestCase
     public function testItIsRescheduledEvery24Hours(): void
     {
         static::assertSame(60 * 60 * 24, CollectEntityDataTask::getDefaultInterval());
+    }
+
+    public function testShouldRunWhenNotAirGapped(): void
+    {
+        static::assertTrue(CollectEntityDataTask::shouldRun(new ParameterBag()));
+        static::assertTrue(CollectEntityDataTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => false,
+        ])));
+    }
+
+    public function testShouldNotRunWhenAirGapped(): void
+    {
+        static::assertFalse(CollectEntityDataTask::shouldRun(new ParameterBag([
+            'shopware.deployment.air_gapped' => true,
+        ])));
     }
 }

--- a/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Rule\Aggregate\RuleTag\RuleTagDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Consent\ConsentScope;
 use Shopware\Core\System\Consent\ConsentStatus;
@@ -83,6 +84,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchCollectEntityDataMessage();
@@ -111,6 +113,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::UNSET, null),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchCollectEntityDataMessage();
@@ -138,6 +141,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             false,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchCollectEntityDataMessage();
@@ -167,6 +171,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
 
         static::assertNull($appConfig->get('usageData-entitySync-lastRun-product'));
@@ -229,6 +234,7 @@ class EntityDispatchServiceTest extends TestCase
             $systemConfigService,
             $consentService,
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -273,6 +279,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
 
         // first run
@@ -317,6 +324,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $consentService,
             true,
+            new AirGappedMode(false),
         );
 
         // first run
@@ -361,6 +369,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -406,6 +415,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
         $storedScLastRunDatetime = new \DateTimeImmutable($lastScRunDatetime->format(Defaults::STORAGE_DATE_TIME_FORMAT));
 
@@ -449,6 +459,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-03'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -468,6 +479,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -493,6 +505,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::UNSET, null),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -518,6 +531,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('old-shop-id'));
@@ -542,6 +556,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -577,6 +592,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -616,6 +632,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -697,6 +714,7 @@ class EntityDispatchServiceTest extends TestCase
             new StaticSystemConfigService([]),
             $this->createConsentService(ConsentStatus::ACCEPTED, '2026-03-02'),
             true,
+            new AirGappedMode(false),
         );
 
         $entityDispatchService->resetLastRunDateForAllEntities();

--- a/tests/unit/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
+++ b/tests/unit/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Deployment\AirGappedMode;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Consent\ConsentScope;
@@ -120,6 +121,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             true,
+            new AirGappedMode(false),
         );
 
         $deleteCommand = new DeleteCommand(
@@ -172,6 +174,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             true,
+            new AirGappedMode(false),
         );
 
         $deleteCommand = new DeleteCommand(
@@ -234,6 +237,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             true,
+            new AirGappedMode(false),
         );
 
         $deleteCommand = new DeleteCommand(
@@ -286,6 +290,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             true,
+            new AirGappedMode(false),
         );
 
         $event = DeletedEvent::create(
@@ -320,6 +325,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock(),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             true,
+            new AirGappedMode(false),
         );
 
         $event = DeletedEvent::create(
@@ -356,6 +362,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $consentService,
             true,
+            new AirGappedMode(false),
         );
 
         $event = DeletedEvent::create(
@@ -392,6 +399,7 @@ class EntityDeleteSubscriberTest extends TestCase
             new MockClock('2023-09-01 12:00:00'),
             $this->createConsentService(ConsentStatus::ACCEPTED),
             false,
+            new AirGappedMode(false),
         );
 
         $event = DeletedEvent::create(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 1. Why is this change necessary?

Some installations run without outbound internet. Shopware still calls Shopware-operated hosts (Store, updates, translations, usage data, Services registry, product analytics). Operators currently have to find several independent flags and still cannot stop Store HTTP. That produces timeouts, failed scheduled tasks, and Administration errors instead of a silent offline shop.

### 2. What does this change do, exactly?

Adds one operator-facing toggle:

```yaml
shopware:
    deployment:
        air_gapped: true
```

When enabled:

- Shopware does not initiate HTTP to Shopware-operated SaaS or content hosts.
- Existing fine-grained flags stay independently usable.
- Local plugin lifecycle (activate, deactivate, zip install) stays available.
- Scheduled Store/SaaS tasks return `false` from `shouldRun()`.
- Store/FRW Guzzle requests are rejected immediately by middleware.
- The Administration `_info/config` payload exposes `settings.airGapped`.
- Store, FRW account steps, in-app updates, Services registry, and usage-data/analytics consent are hidden or skipped.

Merchant integrations (payments, apps, SMTP, object storage) are unchanged.

See `adr/2026-09-03-air-gapped-deployment-mode.md`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set `shopware.deployment.air_gapped: true` in `config/packages/shopware.yaml`.
2. Clear the container cache.
3. Confirm Store, update check, remote translation fetch, usage-data dispatch, and Services registry no longer leave the host.
4. Confirm local zip install / activate / deactivate still works.
5. Confirm the Administration empty states say the installation is air-gapped.

### 4. Please link to the relevant issues (if any).

Relates to the planned air-gapped operator toggle discussed in the ADR.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a23d93df-369f-456c-93a6-00214e6093b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a23d93df-369f-456c-93a6-00214e6093b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

