### PR TITLE
ci: grant id-token to the nightly failure reporter callers

### DIFF
--- a/.github/workflows/nightly-major.yml
+++ b/.github/workflows/nightly-major.yml
@@ -64,6 +64,7 @@ jobs:
     uses: ./.github/workflows/report-phpunit-failures.yml
     permissions:
       contents: read
+      id-token: write # the called workflow mints an octo-sts token
       issues: write
     with:
       report-title: "[nightly] Nightly Major test failures"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,6 +110,7 @@ jobs:
     uses: ./.github/workflows/report-phpunit-failures.yml
     permissions:
       contents: read
+      id-token: write # the called workflow mints an octo-sts token
       issues: write
     with:
       report-title: "[nightly] Nightly test failures"


### PR DESCRIPTION
### 1. Why is this change necessary?

Every Nightly and Nightly Major run since #19994 ends in `startup_failure` after 1-2 seconds — the whole run is rejected before any job starts. That PR added `id-token: write` to `report-phpunit-failures.yml` for octo-sts, but the caller jobs still cap the called workflow at `contents: read` / `issues: write`. A reusable workflow may not request more permissions than its caller holds, so GitHub refuses the workflow file at startup.

### 2. What does this change do, exactly?

Adds `id-token: write` to the `report-phpunit-failures` caller job in `nightly.yml` and `nightly-major.yml`.

### 3. Describe each step to reproduce the issue or behaviour.

Dispatch `Nightly` on `trunk` before this change: https://github.com/shopware/shopware/actions/runs/33721115164 (`startup_failure`, 2s). Same for `Nightly Major`: https://github.com/shopware/shopware/actions/runs/33714864816.

### 4. Please link to the relevant issues (if any).

relates #19994

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
