### PR TITLE
ci: bring the dynamic-matrix workflows back into the zizmor audit

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -42,7 +42,8 @@ Three mechanisms decide how much runs:
 - **Profile** — `''` (PR), `nightly`, or `release`, passed into
   `generate-phpunit-matrix.php` / `generate-acceptance-matrix.php`. Only
   `nightly` widens the matrix. The matrix is generated at runtime and consumed as
-  `strategy: ${{ fromJson(...) }}`.
+  `matrix: ${{ fromJson(...) }}` — the expression must stay on `matrix:`, since
+  zizmor cannot audit a file whose whole `strategy:` block is an expression.
 - **Major arms** — opt in on a PR with the `major-php` or `major-acceptance`
   label, or the `major-tests` umbrella. `01-pr-issue-labeler.yml` applies
   `major-php` automatically when the diff touches major feature flags. Nightly

--- a/.github/bin/generate-acceptance-matrix.php
+++ b/.github/bin/generate-acceptance-matrix.php
@@ -2,6 +2,9 @@
 
 $php = ['8.2'];
 
+// Emits the `strategy.matrix` object only — `fail-fast` is set statically by the calling
+// workflow, because zizmor cannot audit a file whose whole `strategy:` is an expression.
+//
 // argv[1] is the run profile: '' (PR), 'nightly' or 'release' (patch release gate).
 $mode = \strtolower($_SERVER['argv'][1] ?? '');
 $nightly = $mode === 'nightly';
@@ -32,21 +35,18 @@ if ($majorFilter === 'exclude') {
 }
 
 $matrix = [
-    'fail-fast' => false,
-    'matrix' => [
-        'name' => ['Platform'],
-        'major' => $majorVariants,
-        'php-version' => $php,
-        'shard' => ['1', '2', '3'],
-        'shard-count' => [3],
-        'no-currents' => [true],
-        'include' => [],
-    ],
+    'name' => ['Platform'],
+    'major' => $majorVariants,
+    'php-version' => $php,
+    'shard' => ['1', '2', '3'],
+    'shard-count' => [3],
+    'no-currents' => [true],
+    'include' => [],
 ];
 
 // The install test is not a major test, so it only belongs to the non-major run.
 if ($majorFilter !== 'only') {
-    $matrix['matrix']['include'][] = [
+    $matrix['include'][] = [
         'name' => 'Install',
         'php-version' => ($nightly || $release) ? '8.4' : '8.2',
         'shard' => 1,
@@ -58,7 +58,7 @@ if ($majorFilter !== 'only') {
 if ($nightly) {
     for ($i = 0; $i < 3; ++$i) {
         if ($majorFilter !== 'only') {
-            $matrix['matrix']['include'][] = [
+            $matrix['include'][] = [
                 'name' => 'Platform',
                 'php-version' => '8.4',
                 'shard' => $i + 1,
@@ -67,7 +67,7 @@ if ($nightly) {
             ];
         }
         if ($majorFilter !== 'exclude') {
-            $matrix['matrix']['include'][] = [
+            $matrix['include'][] = [
                 'name' => 'Platform',
                 'major' => 'major',
                 'php-version' => '8.4',

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -1,5 +1,8 @@
 <?php
 
+// Emits the `strategy.matrix` object only — `fail-fast` is set statically by the calling
+// workflow, because zizmor cannot audit a file whose whole `strategy:` is an expression.
+//
 // argv[1] is the run profile: '' (PR), 'nightly' or 'release'. Only nightly widens the matrix.
 $nightly = ($_SERVER['argv'][1] ?? '') === 'nightly';
 $major = filter_var($_SERVER['argv'][2] ?? false, \FILTER_VALIDATE_BOOLEAN);
@@ -19,13 +22,10 @@ $integrationTests = [
 if ($major) {
     // Nightly major-flag run: each integration shard once on a single PHP/DB (migration excluded — php.yml already runs it major).
     echo \json_encode([
-        'fail-fast' => false,
-        'matrix' => [
-            'test' => $integrationTests,
-            'php' => ['8.2'],
-            'db' => ['mysql:8.0'],
-            'opensearch' => ['opensearchproject/opensearch:3'],
-        ],
+        'test' => $integrationTests,
+        'php' => ['8.2'],
+        'db' => ['mysql:8.0'],
+        'opensearch' => ['opensearchproject/opensearch:3'],
     ], \JSON_THROW_ON_ERROR);
 
     return;
@@ -78,27 +78,24 @@ if ($nightly) {
 }
 
 $matrix = [
-    'fail-fast' => false,
-    'matrix' => [
-        'test' => array_merge($integrationTests, [
-            ['testsuite' => 'migration'],
-        ]),
-        'php' => $php,
-        'db' => $db,
-        'opensearch' => ['opensearchproject/opensearch:3'],
-        'include' => $includes
-    ]
+    'test' => array_merge($integrationTests, [
+        ['testsuite' => 'migration'],
+    ]),
+    'php' => $php,
+    'db' => $db,
+    'opensearch' => ['opensearchproject/opensearch:3'],
+    'include' => $includes
 ];
 
 if ($nightly) {
-    $matrix['matrix']['include'][] = [
+    $matrix['include'][] = [
         'test' => ['path' => '{Administration,Elasticsearch}'],
         'php' => '8.4',
         'db' => 'mysql:8.0',
         'opensearch' => 'opensearchproject/opensearch:2',
     ];
     /** @deprecated tag:v6.8.0 - Support for OpenSearch 1 will be removed in v6.8.0 (update the docs as well!) */
-    $matrix['matrix']['include'][] = [
+    $matrix['include'][] = [
         'test' => ['path' => '{Administration,Elasticsearch}'],
         'php' => '8.4',
         'db' => 'mysql:8.0',

--- a/.github/bin/js/zizmor-collection-guard.ts
+++ b/.github/bin/js/zizmor-collection-guard.ts
@@ -7,25 +7,19 @@
  * exact "green without proving anything" failure mode the CI rules exist to
  * prevent, so the skips are reconciled against an explicit list instead.
  *
- * `strategy: ${{ fromJson(...) }}` (a dynamic matrix) is valid GitHub Actions but
- * is not modelled by zizmor's schema, which is why the three entries below are
- * skipped. There is no upstream escape hatch and no open issue for the `strategy`
- * case; the closest precedent is zizmorcore/zizmor#1769, which fixed the same
- * problem for a dynamic `with:`.
+ * The list is empty, and the goal is to keep it that way. zizmor's schema does not
+ * model a whole `strategy:` block that is an expression, so the dynamic-matrix
+ * workflows put the expression on `strategy.matrix` instead — the shape zizmor does
+ * parse. Moving it back onto `strategy:` silently drops those files out of the audit.
  *
  * The check runs in both directions on purpose: a file that starts being skipped
  * is a new coverage hole, and a listed file that is no longer skipped means the
- * entry is stale and should be deleted — that is how this list retires itself
- * once zizmor learns the construct.
+ * entry is stale and should be deleted.
  */
 
 import { readFileSync } from 'node:fs';
 
-export const KNOWN_UNCOLLECTABLE = [
-    '.github/workflows/acceptance.yml',
-    '.github/workflows/integration-major.yml',
-    '.github/workflows/integration.yml',
-];
+export const KNOWN_UNCOLLECTABLE: string[] = [];
 
 const SCHEMA_FAILURE = /failed to validate file:\/\/(\S+?) as \w+: input does not match expected validation schema/g;
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -70,8 +70,6 @@ jobs:
     timeout-minutes: 40
     needs: generate-acceptance-matrix
     strategy:
-      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
-      # `strategy:` is one, and an unaudited file loses its action-pinning check.
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-acceptance-matrix.outputs.matrix) }}
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -69,7 +69,11 @@ jobs:
     # Shards finish in under 20 minutes; without a cap a single hung step holds the job for GitHub's 6-hour default.
     timeout-minutes: 40
     needs: generate-acceptance-matrix
-    strategy: ${{ fromJson(needs.generate-acceptance-matrix.outputs.matrix) }}
+    strategy:
+      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
+      # `strategy:` is one, and an unaudited file loses its action-pinning check.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-acceptance-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/integration-major.yml
+++ b/.github/workflows/integration-major.yml
@@ -39,8 +39,6 @@ jobs:
       - phpunit-major-matrix
     runs-on: ubuntu-24.04
     strategy:
-      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
-      # `strategy:` is one, and an unaudited file loses its action-pinning check.
       fail-fast: false
       matrix: ${{ fromJson(needs.phpunit-major-matrix.outputs.matrix) }}
     env:

--- a/.github/workflows/integration-major.yml
+++ b/.github/workflows/integration-major.yml
@@ -38,7 +38,11 @@ jobs:
     needs:
       - phpunit-major-matrix
     runs-on: ubuntu-24.04
-    strategy: ${{ fromJson(needs.phpunit-major-matrix.outputs.matrix) }}
+    strategy:
+      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
+      # `strategy:` is one, and an unaudited file loses its action-pinning check.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.phpunit-major-matrix.outputs.matrix) }}
     env:
       APP_ENV: test
       FEATURE_ALL: major

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,11 @@ jobs:
     needs:
       - phpunit-matrix
     runs-on: ubuntu-24.04
-    strategy: ${{ fromJson(needs.phpunit-matrix.outputs.matrix) }}
+    strategy:
+      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
+      # `strategy:` is one, and an unaudited file loses its action-pinning check.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.phpunit-matrix.outputs.matrix) }}
     env:
       APP_ENV: test
       DATABASE_URL: mysql://root@127.0.0.1:3306/root

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,8 +55,6 @@ jobs:
       - phpunit-matrix
     runs-on: ubuntu-24.04
     strategy:
-      # Only `matrix:` carries the expression: zizmor cannot audit a file whose whole
-      # `strategy:` is one, and an unaudited file loses its action-pinning check.
       fail-fast: false
       matrix: ${{ fromJson(needs.phpunit-matrix.outputs.matrix) }}
     env:


### PR DESCRIPTION
### 1. Why is this change necessary?

`acceptance.yml`, `integration.yml` and `integration-major.yml` passed their whole `strategy:` block as an expression. zizmor's schema does not model that, so it warned and skipped the three files — and a skipped file is an unaudited file, in which an unpinned action would have gone unnoticed. They were the only entries in `KNOWN_UNCOLLECTABLE`.

### 2. What does this change do, exactly?

zizmor does parse an expression on `strategy.matrix`, which is also the shape GitHub documents. So the two generators emit the matrix object alone, `fail-fast: false` moves into the three workflows, and `KNOWN_UNCOLLECTABLE` is emptied — the guard's staleness check keeps it that way.

The generated matrices are unchanged: all ten profile combinations of the two generators produce output identical to the previous scripts' `matrix` key, and every code path set `fail-fast` to `false` already.

### 3. Describe each step to reproduce the issue or behaviour.

`composer lint:actions` on trunk warns `failed to validate ... as workflow` for the three files; after this change it reports no skips. The `phpunit` and `acceptance` jobs of this PR are the run proving the dynamic matrix still expands; `major-php` is set so `integration-major.yml` runs too.

### 4. Please link to the relevant issues (if any).

Builds on #20066 (base branch). Relates #18740.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
