### PR TITLE
fix: cms product listing filter inheritance

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
@@ -103,12 +103,17 @@ export default Shopware.Component.wrapComponentConfig({
         supportsInheritance() {
             return !!this.contentEntity;
         },
+        isSystemDefaultLanguage() {
+            return Shopware.Store.get('context').isSystemDefaultLanguage;
+        },
         /**
          * Fields are inherited if the layout is used on a content page (product, category, landing page)
          * and the field is not overridden in the <entity>.slot_config
          */
         isInherited() {
-            return this.supportsInheritance && isUndefined(get(this.childConfig, this.field));
+            return (
+                this.supportsInheritance && !this.isSystemDefaultLanguage && isUndefined(get(this.childConfig, this.field))
+            );
         },
         fullPath() {
             return this.field.concat('.', this.fieldPath);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.html.twig
@@ -6,6 +6,7 @@
         <sw-inheritance-switch
             v-if="supportsInheritance"
             :is-inherited="isInherited"
+            :disabled="isSystemDefaultLanguage"
             @inheritance-restore="showModal = true;"
             @inheritance-remove="onInheritanceRemove"
         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -67,7 +67,7 @@ async function createWrapper(props = {}, options = {}, route = categoryDetailCms
                                 {{ isInherited ? 'Remove' : 'Restore' }}
                             </button>
                         `,
-                        props: ['isInherited'],
+                        props: ['isInherited', 'disabled'],
                     },
                     'mt-icon': {
                         template: '<i class="mt-icon" :name="name"></i>',
@@ -102,16 +102,23 @@ async function createWrapper(props = {}, options = {}, route = categoryDetailCms
 describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
     let initialLanguageId;
     let initialLanguage;
+    let initialSystemLanguageId;
 
     beforeEach(() => {
         initialLanguageId = Shopware.Store.get('context').api.languageId;
         initialLanguage = Shopware.Store.get('context').api.language;
+        initialSystemLanguageId = Shopware.Store.get('context').api.systemLanguageId;
         Shopware.Store.get('swCategoryDetail').$reset();
+
+        // Inheritance only applies to non-default languages, so default the suite to a child language.
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
     });
 
     afterEach(() => {
         Shopware.Store.get('context').api.languageId = initialLanguageId;
         Shopware.Store.get('context').api.language = initialLanguage;
+        Shopware.Store.get('context').api.systemLanguageId = initialSystemLanguageId;
     });
 
     describe('computed properties', () => {
@@ -225,6 +232,27 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             const wrapper = await createWrapper();
 
             expect(wrapper.vm.isInherited).toBe(false);
+        });
+
+        it('should never inherit and disable the switch in the system default language', async () => {
+            Shopware.Store.get('swCategoryDetail').category = {
+                'test-slot-id': {
+                    testField: { value: 'child-value' },
+                },
+            };
+            // System default language: languageId equals systemLanguageId => root of the inheritance chain.
+            Shopware.Store.get('context').api.systemLanguageId = 'system-language-id';
+            Shopware.Store.get('context').api.languageId = 'system-language-id';
+            Shopware.Store.get('context').api.language = { parentId: null };
+
+            const wrapper = await createWrapper();
+
+            expect(wrapper.vm.isSystemDefaultLanguage).toBe(true);
+            expect(wrapper.vm.isInherited).toBe(false);
+
+            const inheritanceSwitch = wrapper.findComponent('.sw-inheritance-switch');
+            expect(inheritanceSwitch.props('disabled')).toBe(true);
+            expect(inheritanceSwitch.props('isInherited')).toBe(false);
         });
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -67,7 +67,10 @@ async function createWrapper(props = {}, options = {}, route = categoryDetailCms
                                 {{ isInherited ? 'Remove' : 'Restore' }}
                             </button>
                         `,
-                        props: ['isInherited', 'disabled'],
+                        props: [
+                            'isInherited',
+                            'disabled',
+                        ],
                     },
                     'mt-icon': {
                         template: '<i class="mt-icon" :name="name"></i>',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
@@ -3,6 +3,8 @@ import './sw-cms-el-config-product-listing.scss';
 
 const { Mixin } = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
+const { get, set, unset, has, cloneDeep } = Shopware.Utils.object;
+const { isEmpty } = Shopware.Utils.types;
 
 /**
  * @private
@@ -268,6 +270,9 @@ export default {
                 this.element.config.defaultSorting.value = this.defaultSorting.id;
             }
         },
+        'element.config.filters.value'() {
+            this.unpackFilters();
+        },
     },
 
     created() {
@@ -482,6 +487,7 @@ export default {
             const filters = this.element.config.filters.value;
 
             if (filters === null || filters === '') {
+                this.filters = [];
                 return;
             }
 
@@ -526,6 +532,45 @@ export default {
                     current,
                 ];
             }, []);
+        },
+
+        onFilterInheritanceRemove() {
+            const childConfig = this.contentEntity?.slotConfig?.[this.element.id];
+
+            if (!childConfig || has(childConfig, 'propertyWhitelist')) {
+                return;
+            }
+
+            const inherited = get(this.inheritedSlotConfig?.[this.element.id], 'propertyWhitelist') ?? {
+                source: 'static',
+                value: [],
+            };
+            set(childConfig, 'propertyWhitelist', cloneDeep(inherited));
+        },
+
+        onFilterInheritanceRestore() {
+            const contentEntity = this.contentEntity;
+            const slotConfig = contentEntity?.slotConfig;
+
+            if (slotConfig?.[this.element.id]) {
+                unset(slotConfig[this.element.id], 'propertyWhitelist');
+
+                if (isEmpty(slotConfig[this.element.id])) {
+                    unset(slotConfig, this.element.id);
+                }
+
+                if (isEmpty(slotConfig)) {
+                    set(contentEntity, 'slotConfig', null);
+                }
+            }
+
+            const inherited = get(this.inheritedSlotConfig?.[this.element.id], 'propertyWhitelist') ?? {
+                source: 'static',
+                value: [],
+            };
+            set(this.element.config, 'propertyWhitelist', cloneDeep(inherited));
+            this.unpackFilters();
+            this.sortProperties(this.properties);
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
@@ -196,6 +196,8 @@
                 :element="element"
                 :label="$t('sw-cms.elements.productListing.config.tab.filter')"
                 class="sw-cms-el-config-product-listing__config-filter"
+                @inheritance:remove="onFilterInheritanceRemove"
+                @inheritance:restore="onFilterInheritanceRestore"
             >
                 <template #default="{ isInherited }">
                     {% block sw_cms_element_product_listing_config_mt_filter_info %}
@@ -304,7 +306,7 @@
                                     {% block sw_cms_element_product_listing_config_mt_filter_property_grid_column_status %}
                                     <mt-switch
                                         class="sw-cms-el-config-product-listing__property-grid-switch"
-                                        :disabled="column.disabled"
+                                        :disabled="column.disabled || isInherited"
                                         :model-value="item.active"
                                         @update:model-value="propertyStatusChanged($event, item.id)"
                                     />
@@ -557,6 +559,8 @@
                         :element="element"
                         :label="$t('sw-cms.elements.productListing.config.tab.filter')"
                         class="sw-cms-el-config-product-listing__config-filter"
+                        @inheritance:remove="onFilterInheritanceRemove"
+                        @inheritance:restore="onFilterInheritanceRestore"
                     >
                         <template #default="{ isInherited }">
                         {% block sw_cms_element_product_listing_config_filter_info %}
@@ -665,7 +669,7 @@
                                                     {% block sw_cms_element_product_listing_config_filter_property_grid_column_status %}
                                             <mt-switch
                                                 class="sw-cms-el-config-product-listing__property-grid-switch"
-                                                :disabled="column.disabled"
+                                                :disabled="column.disabled || isInherited"
                                                 :model-value="item.active"
                                                 @update:model-value="propertyStatusChanged($event, item.id)"
                                             />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -216,7 +216,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
         });
     });
 
-    it('should not apply system language slotConfig without explicit parent language', async () => {
+    it('should apply system default language slotConfig without an explicit parent language', async () => {
         Shopware.Store.get('swProductDetail').product = {
             translations: [
                 {
@@ -237,7 +237,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
 
         const wrapper = await createWrapper(defaultElement, 'sw.product.detail');
 
-        expect(wrapper.vm.element.config.content.value).not.toBe('system override');
+        expect(wrapper.vm.element.config.content.value).toBe('system override');
     });
 
     it('should not mutate the base CMS config when the element has no own translation', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
@@ -113,7 +113,7 @@ describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
         expect(wrapper.vm.inheritedSlotConfig).toStrictEqual(inheritedSlotConfig);
     });
 
-    it('should not fall back to system language slotConfig without explicit parent language', async () => {
+    it('should fall back to the system default language slotConfig without an explicit parent language', async () => {
         const wrapper = await createWrapper('sw.category.detail.cms');
 
         Shopware.Store.get('swCategoryDetail').category = {
@@ -133,7 +133,13 @@ describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
         Shopware.Store.get('context').api.languageId = 'child-language-id';
         Shopware.Store.get('context').api.language = { parentId: null };
 
-        expect(wrapper.vm.inheritedSlotConfig).toBeNull();
+        expect(wrapper.vm.inheritedSlotConfig).toStrictEqual({
+            'slot-id': {
+                content: {
+                    value: 'system',
+                },
+            },
+        });
     });
 
     it('should retain parent-language fields when the child slot has a partial override', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -103,7 +103,9 @@ export default Shopware.Mixin.register(
 
             inheritedSlotConfig() {
                 const currentLanguageId = Shopware.Store.get('context').api.languageId;
-                const parentLanguageId = Shopware.Store.get('context').api.language?.parentId;
+                const parentLanguageId =
+                    Shopware.Store.get('context').api.language?.parentId ??
+                    Shopware.Store.get('context').api.systemLanguageId;
 
                 const currentSlotConfig = this.getSlotConfigForLanguage(currentLanguageId);
                 const parentSlotConfig = parentLanguageId ? this.getSlotConfigForLanguage(parentLanguageId) : null;


### PR DESCRIPTION
### 1. Why is this change necessary?

Product listing filter settings could not be configured per language: in a non-default language the filter properties were not saved, and enabling inheritance did not reset the language-specific settings. The inheritance toggle was also shown in the system default language, where there is nothing to inherit from.

### 2. What does this change do, exactly?

  - Treats the filter panel (`filters` + property whitelist) as one inheritance unit in the product listing element config: the whitelist override is seeded when inheritance is removed and cleared when it is restored, and the filter switches + property grid re-sync with the inherited values.
  - Disables the individual property switches while the panel is inherited, like the other filter switches.
  - Disables and switches off the inheritance toggle in `sw-cms-inherit-wrapper` in the system default language.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Open a category layout and switch to a non-default backend language.
  2. Remove inheritance on the Product Listing → Filter panel, enable a filterable property, and save.
  3. Reload: the property is now persisted.
  4. Restore inheritance: all filter settings, including the property whitelist, fall back to the default language.
  5. In the default language the inheritance toggle is off and disabled.

### 4. Please link to the relevant issues (if any).

  - closes #19709

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them