### PR TITLE
fix(administration): align manufacturer and promotion empty-state wording

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/index.js
@@ -17,7 +17,7 @@ Module.register('sw-manufacturer', {
     type: 'core',
     name: 'manufacturer',
     title: 'sw-manufacturer.general.mainMenuItemGeneral',
-    description: 'Manages the manufacturer of the application',
+    description: 'sw-manufacturer.general.descriptionTextModule',
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#57D9A3',

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.html.twig
@@ -66,7 +66,7 @@
                 v-if="!isLoading && !total"
                 :centered="true"
                 :icon="$route.meta.$module.icon"
-                :headline="isValidTerm(term) ? $t('sw-empty-state.messageNoResultTitle') : $t('sw-empty-state.messageNoResultTitle')"
+                :headline="isValidTerm(term) ? $t('sw-empty-state.messageNoResultTitle') : $t('sw-manufacturer.list.messageEmpty')"
                 :description="isValidTerm(term) ? $t('sw-empty-state.messageNoResultSubline') : $t($route.meta.$module.description)"
                 :link-text="isValidTerm(term) ? $t('sw-empty-state.messageNoResultLink') : ''"
                 :link-href="isValidTerm(term) ? $router.resolve({ name: 'sw.profile.index.searchPreferences' }).href : ''"

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
@@ -47,6 +47,7 @@ async function createWrapper(privileges = []) {
                     meta: {
                         $module: {
                             icon: 'regular-content',
+                            description: 'sw-manufacturer.general.descriptionTextModule',
                         },
                     },
                 },
@@ -194,5 +195,15 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
         expect(wrapper.vm.entitySearchable).toBe(false);
 
         wrapper.vm.searchRankingService.getSearchFieldsByEntity.mockRestore();
+    });
+
+    it('should show empty state with module snippets when there are no manufacturers', async () => {
+        const wrapper = await createWrapper();
+        await wrapper.vm.getList();
+
+        expect(wrapper.find('.mt-empty-state').exists()).toBeTruthy();
+        expect(wrapper.find('.mt-empty-state__headline').text()).toBe('sw-manufacturer.list.messageEmpty');
+        expect(wrapper.find('.mt-empty-state__description').text()).toBe('sw-manufacturer.general.descriptionTextModule');
+        expect(wrapper.find('sw-entity-listing-stub').exists()).toBeFalsy();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/snippet/de.json
@@ -2,12 +2,14 @@
   "sw-manufacturer": {
     "general": {
       "mainMenuItemList": "Hersteller",
+      "descriptionTextModule": "Verwaltung von Herstellern.",
       "mainMenuItemGeneral": "Hersteller",
       "placeholderSearchBar": "Durchsuche alle Hersteller ..."
     },
     "list": {
       "textManufacturerOverview": "Hersteller",
       "textTotalManufacturer": "Keine Hersteller | Ein Hersteller | {count} Hersteller",
+      "messageEmpty": "Noch keine Hersteller",
       "buttonAddManufacturer": "Hersteller anlegen",
       "columnName": "Hersteller",
       "columnLink": "Webseite"

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/snippet/en.json
@@ -2,12 +2,14 @@
   "sw-manufacturer": {
     "general": {
       "mainMenuItemList": "Manufacturers",
+      "descriptionTextModule": "Manage manufacturers here.",
       "mainMenuItemGeneral": "Manufacturers",
       "placeholderSearchBar": "Search manufacturers..."
     },
     "list": {
       "textManufacturerOverview": "Manufacturers",
       "textTotalManufacturer": "No manufacturers | One manufacturer | {count} manufacturers",
+      "messageEmpty": "No manufacturers yet",
       "buttonAddManufacturer": "Add manufacturer",
       "columnName": "Manufacturer",
       "columnLink": "Website"

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de.json
@@ -12,7 +12,7 @@
             "columnName": "Name",
             "columnValidFrom": "Gültig von",
             "columnValidUntil": "Gültig bis",
-            "titleEmpty": "Noch keine Rabattaktionen.",
+            "titleEmpty": "Noch keine Rabattaktionen",
             "descriptionEmpty": "Steigere Deinen Umsatz durch Rabatte auf Deine Produkte und Leistungen.",
             "placeholderSearchBar": "Durchsuche alle Rabattaktionen ...",
             "textDeleteConfirm": "Möchtest Du die Rabattaktion \"{name}\" wirklich löschen?",

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en.json
@@ -12,7 +12,7 @@
             "columnName": "Name",
             "columnValidFrom": "Valid from",
             "columnValidUntil": "Valid until",
-            "titleEmpty": "No promotions yet.",
+            "titleEmpty": "No promotions yet",
             "descriptionEmpty": "Boost your sales by discounting your products and services.",
             "placeholderSearchBar": "Search promotions...",
             "textDeleteConfirm": "Are you sure you want to delete the promotion \"{name}\"?",


### PR DESCRIPTION
### 1. Why is this change necessary?

The manufacturer empty state shows "Nothing found" and an untranslated module description. Other lists show "No <entities> yet". The promotion headline "No promotions yet." has a trailing period.

### 2. What does this change do, exactly?

- Manufacturer list: new `messageEmpty` snippet ("No manufacturers yet") as headline, module description moved to a snippet.
- Promotion list: drop the trailing period from `titleEmpty`.
- Add a Jest test for the manufacturer empty state.

### 3. Describe each step to reproduce the issue or behaviour.

Open Manufacturers or Promotions with no entries and check the empty state.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them