### PR TITLE
feat: reject colliding document filename infixes

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -16,7 +16,7 @@ A document type (invoice, cancellation invoice, delivery note, credit note) can 
 
 ZUGFeRD is no longer a document type of its own. It is a file format of the invoice, cancellation invoice, and credit note types. Mail attachments and the archive download include all generated formats by default, Flow Builder mail actions can select specific formats.
 
-Each generation snapshots the order into a dedicated order version. A document always renders the order state at generation time. Generated files receive unique, readable filenames with configurable per-format infixes.
+Each generation snapshots the order into a dedicated order version. A document always renders the order state at generation time. Generated files receive unique, readable filenames with configurable per-format infixes. Infixes that would give two formats with the same file extension the same filename are rejected on write with the violation code `DOCUMENT_BASE_CONFIG_DUPLICATE_FILENAME_INFIX`. An empty sales-channel infix inherits the global one, as the prefix and suffix do.
 
 #### Opting in
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -21,6 +21,7 @@ export const DOCUMENT_TYPE_TECHNICAL_NAMES = {
 export const COMPANY_SETTINGS_MOVED_BANNER_STORAGE_KEY = 'companySettingsMovedBannerHidden';
 
 const INVALID_PAYMENT_DUE_DATE = 'DOCUMENT_BASE_CONFIG_INVALID_PAYMENT_DUE_DATE';
+const DUPLICATE_FILENAME_INFIX = 'DOCUMENT_BASE_CONFIG_DUPLICATE_FILENAME_INFIX';
 
 /**
  * @private
@@ -745,11 +746,13 @@ export default {
                     this.paymentDueDateIsValid = true;
                 })
                 .catch((error) => {
+                    this.documentConfig.filenameInfixes ??= {};
+
                     if (error.response?.data?.errors?.length) {
                         error.response.data.errors.forEach((errorEntry) => {
                             if (errorEntry.code === INVALID_PAYMENT_DUE_DATE) {
                                 this.paymentDueDateIsValid = false;
-                            } else {
+                            } else if (errorEntry.code !== DUPLICATE_FILENAME_INFIX) {
                                 this.createNotificationError({
                                     message: this.$t(
                                         'global.notification.notificationSaveErrorMessageRequiredFieldsInvalid',
@@ -766,6 +769,51 @@ export default {
                 .finally(() => {
                     this.isLoading = false;
                 });
+        },
+
+        filenameInfixError(format) {
+            if (!this.documentConfig?.id) {
+                return null;
+            }
+
+            const error = Shopware.Store.get('error').getApiErrorFromPath('document_base_config', this.documentConfig.id, [
+                'filenameInfixes',
+                format,
+            ]);
+
+            if (!error) {
+                return null;
+            }
+
+            const formats = (error.parameters?.['{{ formats }}'] ?? '')
+                .split(',')
+                .map((otherFormat) => otherFormat.trim())
+                .filter((otherFormat) => otherFormat !== '')
+                .map((otherFormat) => this.formatLabels[otherFormat] ?? otherFormat)
+                .join(', ');
+            const configs = error.parameters?.['{{ configs }}'];
+
+            if (configs) {
+                return {
+                    detail: this.$t('sw-settings-document.errors.duplicateFilenameInfixInSalesChannelConfig', {
+                        formats,
+                        configs,
+                    }),
+                };
+            }
+
+            const infix = error.parameters?.['{{ infix }}'];
+            const isInherited = infix && !this.documentConfig.filenameInfixes?.[format];
+
+            if (isInherited) {
+                return {
+                    detail: this.$t('sw-settings-document.errors.duplicateFilenameInfixInherited', { formats, infix }),
+                };
+            }
+
+            return {
+                detail: this.$t('sw-settings-document.errors.duplicateFilenameInfix', { formats }),
+            };
         },
 
         async onCancel() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.html.twig
@@ -281,6 +281,7 @@
                             :disabled="!acl.can('document.editor') || undefined"
                             :label="formatLabels[format]"
                             :placeholder="$t('sw-settings-document.detail.placeholderFileNameInfix')"
+                            :error="filenameInfixError(format)"
                         />
                     </sw-container>
                 </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import { config, mount } from '@vue/test-utils';
+import ShopwareError from 'src/core/data/ShopwareError';
 import { COMPANY_SETTINGS_MOVED_BANNER_STORAGE_KEY } from './index';
 
 /**
@@ -202,6 +203,7 @@ describe('src/module/sw-settings-document/page/sw-settings-document-detail', () 
         documentBaseConfigRepositoryMock.save.mockResolvedValue();
         documentV2ServiceMock.getAvailableDocumentTypes.mockClear();
         localStorage.removeItem(COMPANY_SETTINGS_MOVED_BANNER_STORAGE_KEY);
+        Shopware.Store.get('error').resetApiErrors();
     });
 
     it('should create an array with sales channel ids from the document config sales channels association', async () => {
@@ -750,13 +752,20 @@ describe('src/module/sw-settings-document/page/sw-settings-document-detail', () 
     });
 
     it('should set filenameInfixes on save to null when no infixes were configured', async () => {
+        let savedConfig;
+        documentBaseConfigRepositoryMock.save.mockImplementationOnce((config) => {
+            savedConfig = JSON.parse(JSON.stringify(config));
+
+            return Promise.resolve();
+        });
+
         const wrapper = await createWrapper({}, ['document.editor'], true);
         await flushPromises();
 
         await wrapper.find('.sw-settings-document-detail__save-action').trigger('click');
         await flushPromises();
 
-        expect(documentBaseConfigRepositoryMock.save).toHaveBeenCalledWith({
+        expect(savedConfig).toEqual({
             config: {
                 displayAdditionalNoteDelivery: false,
                 displayCompanyAddress: false,
@@ -831,4 +840,78 @@ describe('src/module/sw-settings-document/page/sw-settings-document-detail', () 
             salesChannels: [],
         });
     });
+
+    it.each([
+        {
+            variant: 'the other format',
+            field: 'pdf',
+            parameters: { '{{ formats }}': 'zugferd_embedded_pdf, html' },
+            snippet: 'sw-settings-document.errors.duplicateFilenameInfix',
+            snippetParams: {
+                formats:
+                    'sw-order.components.createDocumentModal.fileFormats.zugferd_embedded_pdf, ' +
+                    'sw-order.components.createDocumentModal.fileFormats.html',
+            },
+        },
+        {
+            variant: 'the affected sales channel configurations',
+            field: 'zugferd_embedded_pdf',
+            parameters: { '{{ formats }}': 'pdf', '{{ configs }}': 'Storefront invoice, B2B invoice' },
+            snippet: 'sw-settings-document.errors.duplicateFilenameInfixInSalesChannelConfig',
+            snippetParams: {
+                formats: 'sw-order.components.createDocumentModal.fileFormats.pdf',
+                configs: 'Storefront invoice, B2B invoice',
+            },
+        },
+        {
+            variant: 'the inherited infix on an empty field',
+            field: 'zugferd_embedded_pdf',
+            parameters: { '{{ formats }}': 'pdf', '{{ infix }}': '_zugferd' },
+            snippet: 'sw-settings-document.errors.duplicateFilenameInfixInherited',
+            snippetParams: {
+                formats: 'sw-order.components.createDocumentModal.fileFormats.pdf',
+                infix: '_zugferd',
+            },
+        },
+    ])(
+        'should show the duplicate filename infix error naming $variant',
+        async ({ field, parameters, snippet, snippetParams }) => {
+            documentBaseConfigRepositoryMock.save.mockImplementationOnce(() => {
+                Shopware.Store.get('error').addApiError({
+                    expression: `document_base_config.documentConfigWithFormats.filenameInfixes.${field}`,
+                    error: new ShopwareError({
+                        code: 'DOCUMENT_BASE_CONFIG_DUPLICATE_FILENAME_INFIX',
+                        meta: { parameters },
+                    }),
+                });
+
+                return Promise.reject({
+                    response: { data: { errors: [{ code: 'DOCUMENT_BASE_CONFIG_DUPLICATE_FILENAME_INFIX' }] } },
+                });
+            });
+            const translate = jest.spyOn(config.global.mocks, '$t');
+
+            const wrapper = await createWrapper(
+                {
+                    props: { documentConfigId: 'documentConfigWithFormats' },
+                },
+                ['document.editor'],
+                true,
+            );
+            await flushPromises();
+            wrapper.vm.createNotificationError = jest.fn();
+
+            await wrapper.get('.sw-settings-document-detail__save-action').trigger('click');
+            await flushPromises();
+
+            const fieldsWithError = wrapper
+                .findAll('.sw-settings-document-detail__field_file_name_infix')
+                .filter((infixField) => infixField.find('.mt-field__error').exists());
+            expect(fieldsWithError).toHaveLength(1);
+            expect(fieldsWithError[0].find(`#sw-field--documentConfig-filenameInfixes-${field}`).exists()).toBe(true);
+            expect(wrapper.vm.createNotificationError).not.toHaveBeenCalled();
+            expect(translate).toHaveBeenCalledWith(snippet, snippetParams);
+            translate.mockRestore();
+        },
+    );
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/de.json
@@ -115,7 +115,10 @@
       "placeholderPaymentDueDate": "Fälligkeit eingeben ..."
     },
     "errors": {
-      "invalidDueDateFormat": "Datums-Modifier ist nicht gültig."
+      "invalidDueDateFormat": "Datums-Modifier ist nicht gültig.",
+      "duplicateFilenameInfix": "Erzeugt denselben Dateinamen wie {formats}.",
+      "duplicateFilenameInfixInSalesChannelConfig": "Erzeugt in der Verkaufskanal-Konfiguration {configs} denselben Dateinamen wie {formats}.",
+      "duplicateFilenameInfixInherited": "Das geerbte Infix \"{infix}\" erzeugt denselben Dateinamen wie {formats}."
     }
   },
   "sw-privileges": {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/en.json
@@ -115,7 +115,10 @@
       "placeholderPaymentDueDate": "Enter payment due date..."
     },
     "errors": {
-      "invalidDueDateFormat": "The date modifier is invalid."
+      "invalidDueDateFormat": "The date modifier is invalid.",
+      "duplicateFilenameInfix": "Produces the same filename as {formats}.",
+      "duplicateFilenameInfixInSalesChannelConfig": "Produces the same filename as {formats} in the sales channel configuration {configs}.",
+      "duplicateFilenameInfixInherited": "The inherited infix \"{infix}\" produces the same filename as {formats}."
     }
   },
   "sw-privileges": {

--- a/src/Core/Checkout/DependencyInjection/document.php
+++ b/src/Core/Checkout/DependencyInjection/document.php
@@ -39,8 +39,10 @@ use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
 use Shopware\Core\Checkout\Document\Subscriber\DocumentDeleteSubscriber;
 use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdBuilder;
+use Shopware\Core\Checkout\DocumentV2\Renderer\DocumentRendererRegistry as DocumentV2RendererRegistry;
 use Shopware\Core\Checkout\DocumentV2\Service\DocumentFileResolver;
 use Shopware\Core\Checkout\DocumentV2\Service\DocumentReader;
+use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
@@ -53,6 +55,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service_closure;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -320,6 +323,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DocumentBaseConfigValidator::class)
         ->args([
             service(ClockInterface::class),
+            service(Connection::class),
+            service(DocumentTypeRegistry::class),
+            service_closure(DocumentV2RendererRegistry::class),
         ])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
@@ -2,7 +2,13 @@
 
 namespace Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig;
 
+use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentConfigLoader;
+use Shopware\Core\Checkout\DocumentV2\Renderer\DocumentRendererRegistry;
+use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
@@ -18,8 +24,18 @@ class DocumentBaseConfigValidator implements EventSubscriberInterface
 {
     final public const INVALID_PAYMENT_DUE_DATE = 'DOCUMENT_BASE_CONFIG_INVALID_PAYMENT_DUE_DATE';
 
+    final public const DUPLICATE_FILENAME_INFIX = 'DOCUMENT_BASE_CONFIG_DUPLICATE_FILENAME_INFIX';
+
+    private const SCOPE_FIELDS = ['type_name', 'document_type_id', 'global'];
+
+    /**
+     * @param \Closure(): DocumentRendererRegistry $documentRendererRegistry
+     */
     public function __construct(
         private readonly ClockInterface $clock,
+        private readonly Connection $connection,
+        private readonly DocumentTypeRegistry $documentTypeRegistry,
+        private readonly \Closure $documentRendererRegistry,
     ) {
     }
 
@@ -35,39 +51,8 @@ class DocumentBaseConfigValidator implements EventSubscriberInterface
         $violations = new ConstraintViolationList();
 
         foreach ($event->getCommandsForEntity(DocumentBaseConfigDefinition::ENTITY_NAME) as $command) {
-            if (!$command->hasField('config')) {
-                continue;
-            }
-
-            $encodedConfig = $command->getPayload()['config'];
-            if (!\is_string($encodedConfig)) {
-                continue;
-            }
-
-            $config = json_decode($encodedConfig, true, 512, \JSON_THROW_ON_ERROR);
-            $paymentDueDate = $config['paymentDueDate'] ?? null;
-
-            // Empty value is still allowed.
-            if ($paymentDueDate === null || $paymentDueDate === '') {
-                continue;
-            }
-
-            if (\is_string($paymentDueDate) && $this->isValid($paymentDueDate)) {
-                continue;
-            }
-
-            $messageTemplate = 'The payment due date must be a relative date such as "{{ example }}".';
-            $parameters = ['{{ example }}' => '+14 days'];
-
-            $violations->add(new ConstraintViolation(
-                message: str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate),
-                messageTemplate: $messageTemplate,
-                parameters: $parameters,
-                root: null,
-                propertyPath: $command->getPath() . '/config/paymentDueDate',
-                invalidValue: $paymentDueDate,
-                code: self::INVALID_PAYMENT_DUE_DATE,
-            ));
+            $this->validatePaymentDueDate($command, $violations);
+            $this->validateFilenameInfixes($command, $violations);
         }
 
         if ($violations->count() > 0) {
@@ -77,7 +62,233 @@ class DocumentBaseConfigValidator implements EventSubscriberInterface
         }
     }
 
-    private function isValid(string $value): bool
+    private function validatePaymentDueDate(WriteCommand $command, ConstraintViolationList $violations): void
+    {
+        if (!$command->hasField('config')) {
+            return;
+        }
+
+        $encodedConfig = $command->getPayload()['config'];
+        if (!\is_string($encodedConfig)) {
+            return;
+        }
+
+        $config = json_decode($encodedConfig, true, 512, \JSON_THROW_ON_ERROR);
+        $paymentDueDate = $config['paymentDueDate'] ?? null;
+
+        if ($paymentDueDate === null || $paymentDueDate === '') {
+            return;
+        }
+
+        if (\is_string($paymentDueDate) && $this->isValidDateModifier($paymentDueDate)) {
+            return;
+        }
+
+        $messageTemplate = 'The payment due date must be a relative date such as "{{ example }}".';
+        $parameters = ['{{ example }}' => '+14 days'];
+
+        $violations->add(new ConstraintViolation(
+            message: str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate),
+            messageTemplate: $messageTemplate,
+            parameters: $parameters,
+            root: null,
+            propertyPath: $command->getPath() . '/config/paymentDueDate',
+            invalidValue: $paymentDueDate,
+            code: self::INVALID_PAYMENT_DUE_DATE,
+        ));
+    }
+
+    /**
+     * Formats of one document type that share a file extension need distinct infixes, or they render to the same
+     * filename. A sales-channel config is checked with the global infixes merged in, a global config against the
+     * sales-channel configs that inherit from it.
+     */
+    private function validateFilenameInfixes(WriteCommand $command, ConstraintViolationList $violations): void
+    {
+        $writesInfixes = $command->hasField('filename_infixes');
+        if (!$writesInfixes && !$this->changesScope($command)) {
+            return;
+        }
+
+        $scope = $this->resolveScope($command, needsStoredInfixes: !$writesInfixes);
+        if ($scope === null) {
+            return;
+        }
+
+        ['typeName' => $typeName, 'global' => $global, 'storedInfixes' => $storedInfixes] = $scope;
+        $infixes = $this->decodeInfixes($writesInfixes ? $command->getPayload()['filename_infixes'] : $storedInfixes);
+
+        $rendererRegistry = ($this->documentRendererRegistry)();
+        $extensionByFormat = [];
+        foreach ($this->documentTypeRegistry->getSupportedFormats($typeName) as $format) {
+            $extension = $rendererRegistry->getFileExtension($format);
+            if ($extension !== null) {
+                $extensionByFormat[$format] = $extension;
+            }
+        }
+
+        if (\count(array_unique($extensionByFormat)) === \count($extensionByFormat)) {
+            return;
+        }
+
+        if (!$global) {
+            $infixes = DocumentConfigLoader::mergeFilenameInfixes($this->fetchGlobalInfixes($typeName, $command), $infixes);
+        }
+
+        $candidates = [['infixes' => $infixes, 'overridden' => [], 'salesChannelConfig' => null]];
+        if ($global) {
+            foreach ($this->fetchAssignedSalesChannelConfigs($typeName, $command) as $salesChannelConfig) {
+                $overrides = $this->decodeInfixes($salesChannelConfig['filename_infixes']);
+                $candidates[] = [
+                    'infixes' => DocumentConfigLoader::mergeFilenameInfixes($infixes, $overrides),
+                    'overridden' => array_keys($overrides),
+                    'salesChannelConfig' => (string) $salesChannelConfig['name'],
+                ];
+            }
+        }
+
+        $clashes = [];
+        foreach ($candidates as ['infixes' => $effectiveInfixes, 'overridden' => $overriddenFormats, 'salesChannelConfig' => $salesChannelConfigName]) {
+            $formatsByFilename = [];
+            foreach ($extensionByFormat as $format => $extension) {
+                $formatsByFilename[mb_strtolower(($effectiveInfixes[$format] ?? '') . '.' . $extension)][] = $format;
+            }
+
+            foreach ($formatsByFilename as $clashingFormats) {
+                if (\count($clashingFormats) < 2) {
+                    continue;
+                }
+
+                foreach (array_diff($clashingFormats, $overriddenFormats) as $format) {
+                    $clash = $clashes[$format] ?? ['formats' => [], 'configs' => []];
+                    $clash['formats'] = array_values(array_unique([...$clash['formats'], ...array_diff($clashingFormats, [$format])]));
+                    if ($salesChannelConfigName !== null) {
+                        $clash['configs'] = array_values(array_unique([...$clash['configs'], $salesChannelConfigName]));
+                    }
+                    $clashes[$format] = $clash;
+                }
+            }
+        }
+
+        foreach ($clashes as $format => $clash) {
+            $parameters = [
+                '{{ infix }}' => $infixes[$format] ?? '',
+                '{{ format }}' => $format,
+                '{{ formats }}' => implode(', ', $clash['formats']),
+                '{{ extension }}' => $extensionByFormat[$format],
+            ];
+            $messageTemplate = 'The filename infix "{{ infix }}" for "{{ format }}" produces the same ".{{ extension }}" filename as: {{ formats }}';
+            if ($clash['configs'] !== []) {
+                $parameters['{{ configs }}'] = implode(', ', $clash['configs']);
+                $messageTemplate .= ' in the sales channel configuration: {{ configs }}';
+            }
+
+            $violations->add(new ConstraintViolation(
+                message: str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate . '.'),
+                messageTemplate: $messageTemplate . '.',
+                parameters: $parameters,
+                root: null,
+                propertyPath: $command->getPath() . '/filenameInfixes/' . $format,
+                invalidValue: $parameters['{{ infix }}'],
+                code: self::DUPLICATE_FILENAME_INFIX,
+            ));
+        }
+    }
+
+    private function changesScope(WriteCommand $command): bool
+    {
+        if (!$command instanceof UpdateCommand) {
+            return false;
+        }
+
+        foreach (self::SCOPE_FIELDS as $field) {
+            if ($command->hasField($field)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{typeName: string, global: bool, storedInfixes: string|null}|null
+     */
+    private function resolveScope(WriteCommand $command, bool $needsStoredInfixes): ?array
+    {
+        $payload = $command->getPayload();
+        $typeName = $command->hasField('type_name') ? $payload['type_name'] : null;
+        $global = $command->hasField('global') ? $payload['global'] : null;
+        $storedInfixes = null;
+
+        if ($command instanceof UpdateCommand && ($typeName === null || $global === null || $needsStoredInfixes)) {
+            $existing = $this->connection->fetchAssociative(
+                'SELECT `type_name`, `global`, `filename_infixes` FROM `document_base_config` WHERE `id` = :id',
+                ['id' => $command->getPrimaryKey()['id']],
+            );
+
+            if (\is_array($existing)) {
+                $typeName ??= $existing['type_name'];
+                $global ??= $existing['global'];
+                $storedInfixes = $existing['filename_infixes'];
+            }
+        }
+
+        if (!\is_string($typeName) || $global === null) {
+            return null;
+        }
+
+        return ['typeName' => $typeName, 'global' => (bool) $global, 'storedInfixes' => \is_string($storedInfixes) ? $storedInfixes : null];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fetchGlobalInfixes(string $typeName, WriteCommand $command): array
+    {
+        return $this->decodeInfixes($this->connection->fetchOne(
+            'SELECT `filename_infixes` FROM `document_base_config` WHERE `type_name` = :typeName AND `global` = 1 AND `id` != :id LIMIT 1',
+            ['typeName' => $typeName, 'id' => $command->getPrimaryKey()['id']],
+        ));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchAssignedSalesChannelConfigs(string $typeName, WriteCommand $command): array
+    {
+        return $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT `config`.`name`, `config`.`filename_infixes`
+                FROM `document_base_config` AS `config`
+                WHERE `config`.`type_name` = :typeName
+                  AND `config`.`global` = 0
+                  AND `config`.`id` != :id
+                  AND EXISTS (
+                      SELECT 1
+                      FROM `document_base_config_sales_channel` AS `assignment`
+                      WHERE `assignment`.`document_base_config_id` = `config`.`id`
+                  )
+                ORDER BY `config`.`name`
+                SQL,
+            ['typeName' => $typeName, 'id' => $command->getPrimaryKey()['id']],
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeInfixes(mixed $encodedInfixes): array
+    {
+        if (!\is_string($encodedInfixes)) {
+            return [];
+        }
+
+        $infixes = json_decode($encodedInfixes, true, 512, \JSON_THROW_ON_ERROR);
+
+        return DocumentConfigLoader::configuredFilenameInfixes(\is_array($infixes) ? $infixes : []);
+    }
+
+    private function isValidDateModifier(string $value): bool
     {
         try {
             $this->clock->now()->modify($value);

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
@@ -18,6 +18,9 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * @internal
+ *
+ * @phpstan-type Candidate array{infixes: array<string, string>, overridden: list<string>, salesChannelConfig: string|null}
+ * @phpstan-type Collision array{infix: string, extension: string, formats: list<string>, configs: list<string>}
  */
 #[Package('after-sales')]
 class DocumentBaseConfigValidator implements EventSubscriberInterface
@@ -118,81 +121,153 @@ class DocumentBaseConfigValidator implements EventSubscriberInterface
         ['typeName' => $typeName, 'global' => $global, 'storedInfixes' => $storedInfixes] = $scope;
         $infixes = $this->decodeInfixes($writesInfixes ? $command->getPayload()['filename_infixes'] : $storedInfixes);
 
+        $extensionByFormat = $this->sharedExtensions($typeName);
+        if ($extensionByFormat === []) {
+            return;
+        }
+
+        $candidates = $global
+            ? $this->globalCandidates($infixes, $typeName, $command)
+            : [self::candidate(DocumentConfigLoader::mergeFilenameInfixes($this->fetchGlobalInfixes($typeName, $command), $infixes))];
+
+        foreach ($this->collisions($candidates, $extensionByFormat) as $format => $collision) {
+            $violations->add($this->duplicateFilenameInfix($command, $format, $collision));
+        }
+    }
+
+    /**
+     * @return array<string, string> the formats whose file extension another format of the type shares
+     */
+    private function sharedExtensions(string $typeName): array
+    {
         $rendererRegistry = ($this->documentRendererRegistry)();
         $extensionByFormat = [];
+
         foreach ($this->documentTypeRegistry->getSupportedFormats($typeName) as $format) {
             $extension = $rendererRegistry->getFileExtension($format);
+
             if ($extension !== null) {
                 $extensionByFormat[$format] = $extension;
             }
         }
 
-        if (\count(array_unique($extensionByFormat)) === \count($extensionByFormat)) {
-            return;
+        $formatsPerExtension = array_count_values($extensionByFormat);
+
+        return array_filter($extensionByFormat, static fn (string $extension): bool => $formatsPerExtension[$extension] > 1);
+    }
+
+    /**
+     * @param array<string, string> $infixes
+     *
+     * @return list<Candidate>
+     */
+    private function globalCandidates(array $infixes, string $typeName, WriteCommand $command): array
+    {
+        $candidates = [self::candidate($infixes)];
+
+        foreach ($this->fetchAssignedSalesChannelConfigs($typeName, $command) as $salesChannelConfig) {
+            $overrides = $this->decodeInfixes($salesChannelConfig['filename_infixes']);
+
+            $candidates[] = self::candidate(
+                DocumentConfigLoader::mergeFilenameInfixes($infixes, $overrides),
+                array_keys($overrides),
+                (string) $salesChannelConfig['name'],
+            );
         }
 
-        if (!$global) {
-            $infixes = DocumentConfigLoader::mergeFilenameInfixes($this->fetchGlobalInfixes($typeName, $command), $infixes);
-        }
+        return $candidates;
+    }
 
-        $candidates = [['infixes' => $infixes, 'overridden' => [], 'salesChannelConfig' => null]];
-        if ($global) {
-            foreach ($this->fetchAssignedSalesChannelConfigs($typeName, $command) as $salesChannelConfig) {
-                $overrides = $this->decodeInfixes($salesChannelConfig['filename_infixes']);
-                $candidates[] = [
-                    'infixes' => DocumentConfigLoader::mergeFilenameInfixes($infixes, $overrides),
-                    'overridden' => array_keys($overrides),
-                    'salesChannelConfig' => (string) $salesChannelConfig['name'],
-                ];
-            }
-        }
+    /**
+     * @param array<string, string> $infixes
+     * @param list<string> $overridden
+     *
+     * @return Candidate
+     */
+    private static function candidate(array $infixes, array $overridden = [], ?string $salesChannelConfig = null): array
+    {
+        return ['infixes' => $infixes, 'overridden' => $overridden, 'salesChannelConfig' => $salesChannelConfig];
+    }
 
-        $clashes = [];
-        foreach ($candidates as ['infixes' => $effectiveInfixes, 'overridden' => $overriddenFormats, 'salesChannelConfig' => $salesChannelConfigName]) {
-            $formatsByFilename = [];
-            foreach ($extensionByFormat as $format => $extension) {
-                $formatsByFilename[mb_strtolower(($effectiveInfixes[$format] ?? '') . '.' . $extension)][] = $format;
-            }
+    /**
+     * @param list<Candidate> $candidates
+     * @param array<string, string> $extensionByFormat
+     *
+     * @return array<string, Collision>
+     */
+    private function collisions(array $candidates, array $extensionByFormat): array
+    {
+        $collisions = [];
 
-            foreach ($formatsByFilename as $clashingFormats) {
-                if (\count($clashingFormats) < 2) {
-                    continue;
-                }
+        foreach ($candidates as $candidate) {
+            foreach ($this->collidingFormats($candidate['infixes'], $extensionByFormat) as $group) {
+                foreach (array_diff($group, $candidate['overridden']) as $format) {
+                    $collision = $collisions[$format] ?? [
+                        'infix' => $candidate['infixes'][$format] ?? '',
+                        'extension' => $extensionByFormat[$format],
+                        'formats' => [],
+                        'configs' => [],
+                    ];
 
-                foreach (array_diff($clashingFormats, $overriddenFormats) as $format) {
-                    $clash = $clashes[$format] ?? ['formats' => [], 'configs' => []];
-                    $clash['formats'] = array_values(array_unique([...$clash['formats'], ...array_diff($clashingFormats, [$format])]));
-                    if ($salesChannelConfigName !== null) {
-                        $clash['configs'] = array_values(array_unique([...$clash['configs'], $salesChannelConfigName]));
+                    $collision['formats'] = array_values(array_unique([...$collision['formats'], ...array_diff($group, [$format])]));
+
+                    if ($candidate['salesChannelConfig'] !== null) {
+                        $collision['configs'] = array_values(array_unique([...$collision['configs'], $candidate['salesChannelConfig']]));
                     }
-                    $clashes[$format] = $clash;
+
+                    $collisions[$format] = $collision;
                 }
             }
         }
 
-        foreach ($clashes as $format => $clash) {
-            $parameters = [
-                '{{ infix }}' => $infixes[$format] ?? '',
-                '{{ format }}' => $format,
-                '{{ formats }}' => implode(', ', $clash['formats']),
-                '{{ extension }}' => $extensionByFormat[$format],
-            ];
-            $messageTemplate = 'The filename infix "{{ infix }}" for "{{ format }}" produces the same ".{{ extension }}" filename as: {{ formats }}';
-            if ($clash['configs'] !== []) {
-                $parameters['{{ configs }}'] = implode(', ', $clash['configs']);
-                $messageTemplate .= ' in the sales channel configuration: {{ configs }}';
-            }
+        return $collisions;
+    }
 
-            $violations->add(new ConstraintViolation(
-                message: str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate . '.'),
-                messageTemplate: $messageTemplate . '.',
-                parameters: $parameters,
-                root: null,
-                propertyPath: $command->getPath() . '/filenameInfixes/' . $format,
-                invalidValue: $parameters['{{ infix }}'],
-                code: self::DUPLICATE_FILENAME_INFIX,
-            ));
+    /**
+     * @param array<string, string> $infixes
+     * @param array<string, string> $extensionByFormat
+     *
+     * @return list<list<string>> formats that render to the same filename
+     */
+    private function collidingFormats(array $infixes, array $extensionByFormat): array
+    {
+        $formatsByFilename = [];
+
+        foreach ($extensionByFormat as $format => $extension) {
+            $formatsByFilename[mb_strtolower(($infixes[$format] ?? '') . '.' . $extension)][] = $format;
         }
+
+        return array_values(array_filter($formatsByFilename, static fn (array $formats): bool => \count($formats) > 1));
+    }
+
+    /**
+     * @param Collision $collision
+     */
+    private function duplicateFilenameInfix(WriteCommand $command, string $format, array $collision): ConstraintViolation
+    {
+        $parameters = [
+            '{{ infix }}' => $collision['infix'],
+            '{{ format }}' => $format,
+            '{{ formats }}' => implode(', ', $collision['formats']),
+            '{{ extension }}' => $collision['extension'],
+        ];
+
+        $messageTemplate = 'The filename infix "{{ infix }}" for "{{ format }}" produces the same ".{{ extension }}" filename as: {{ formats }}';
+
+        if ($collision['configs'] !== []) {
+            $parameters['{{ configs }}'] = implode(', ', $collision['configs']);
+            $messageTemplate .= ' in the sales channel configuration: {{ configs }}';
+        }
+
+        return new ConstraintViolation(
+            message: str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate . '.'),
+            messageTemplate: $messageTemplate . '.',
+            parameters: $parameters,
+            root: null,
+            propertyPath: $command->getPath() . '/filenameInfixes/' . $format,
+            invalidValue: $collision['infix'],
+            code: self::DUPLICATE_FILENAME_INFIX,
+        );
     }
 
     private function changesScope(WriteCommand $command): bool

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -26,8 +26,8 @@ use Symfony\Contracts\Service\ResetInterface;
  * Loads the merged document configuration (global + sales-channel override)
  * for a document type. Reads typed columns directly; falls back to the JSON
  * `config` blob only for fields not yet migrated to columns.
- * Sales-channel configured values override global. For the filename prefix
- * and suffix, '' counts as unconfigured.
+ * Sales-channel configured values override global. For the filename prefix,
+ * suffix, and infixes, '' counts as unconfigured.
  *
  * @internal
  */
@@ -152,6 +152,34 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
     }
 
     /**
+     * @param array<string, mixed> $global
+     * @param array<string, mixed> $salesChannel
+     *
+     * @return array<string, string>
+     */
+    public static function mergeFilenameInfixes(array $global, array $salesChannel): array
+    {
+        return array_merge(self::configuredFilenameInfixes($global), self::configuredFilenameInfixes($salesChannel));
+    }
+
+    /**
+     * @param array<string, mixed> $infixes
+     *
+     * @return array<string, string>
+     */
+    public static function configuredFilenameInfixes(array $infixes): array
+    {
+        $configured = [];
+        foreach ($infixes as $format => $infix) {
+            if (\is_scalar($infix) && (string) $infix !== '') {
+                $configured[(string) $format] = (string) $infix;
+            }
+        }
+
+        return $configured;
+    }
+
+    /**
      * @return array<string, mixed>|null
      */
     private function resolveCompanyInfoFromSystemConfig(string $salesChannelId): ?array
@@ -220,7 +248,7 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
             itemsPerPage: $itemsPerPage,
             filenamePrefix: self::firstConfiguredValue($salesChannelRow?->getFilenamePrefix(), $globalRow?->getFilenamePrefix()),
             filenameSuffix: self::firstConfiguredValue($salesChannelRow?->getFilenameSuffix(), $globalRow?->getFilenameSuffix()),
-            filenameInfixes: array_merge(
+            filenameInfixes: self::mergeFilenameInfixes(
                 $globalRow?->getFilenameInfixes() ?? [],
                 $salesChannelRow?->getFilenameInfixes() ?? [],
             ),

--- a/tests/integration/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidatorTest.php
+++ b/tests/integration/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidatorTest.php
@@ -1,0 +1,226 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Document\Aggregate\DocumentBaseConfig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
+use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
+use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigValidator;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class DocumentBaseConfigValidatorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const BOTH_PDF_FORMATS = ['/0/filenameInfixes/pdf', '/0/filenameInfixes/zugferd_embedded_pdf'];
+
+    private Context $context;
+
+    /**
+     * @var EntityRepository<DocumentBaseConfigCollection>
+     */
+    private EntityRepository $documentBaseConfigRepository;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+        $this->documentBaseConfigRepository = static::getContainer()->get('document_base_config.repository');
+    }
+
+    public function testRejectsSameInfixForBothPdfFormats(): void
+    {
+        try {
+            $this->documentBaseConfigRepository->create([
+                $this->salesChannelConfig('invoice', ['pdf' => '_same', 'zugferd_embedded_pdf' => '_same']),
+            ], $this->context);
+            static::fail('Expected the write to be rejected.');
+        } catch (WriteException $exception) {
+            static::assertSame(self::BOTH_PDF_FORMATS, $this->duplicateInfixPaths($exception));
+        }
+    }
+
+    public function testMergesSeededGlobalInfixesIntoSalesChannelConfig(): void
+    {
+        $this->assertGlobalInvoiceInfixIsSeeded();
+
+        try {
+            $this->documentBaseConfigRepository->create([
+                $this->salesChannelConfig('invoice', ['pdf' => '_zugferd']),
+            ], $this->context);
+            static::fail('Expected the write to be rejected.');
+        } catch (WriteException $exception) {
+            static::assertSame(self::BOTH_PDF_FORMATS, $this->duplicateInfixPaths($exception));
+        }
+    }
+
+    public function testResolvesTypeAndScopeFromDatabaseWhenOnlyInfixesAreUpdated(): void
+    {
+        $config = $this->salesChannelConfig('invoice', ['pdf' => '_pdf']);
+        $this->documentBaseConfigRepository->create([$config], $this->context);
+
+        try {
+            $this->documentBaseConfigRepository->update([[
+                'id' => $config['id'],
+                'filenameInfixes' => ['pdf' => '_same', 'zugferd_embedded_pdf' => '_same'],
+            ]], $this->context);
+            static::fail('Expected the write to be rejected.');
+        } catch (WriteException $exception) {
+            static::assertSame(self::BOTH_PDF_FORMATS, $this->duplicateInfixPaths($exception));
+        }
+    }
+
+    public function testRevalidatesStoredInfixesWhenTheDocumentTypeChanges(): void
+    {
+        $this->assertGlobalInvoiceInfixIsSeeded();
+
+        $config = $this->salesChannelConfig('delivery_note', ['pdf' => '_zugferd']);
+        $this->documentBaseConfigRepository->create([$config], $this->context);
+
+        try {
+            $this->documentBaseConfigRepository->update([[
+                'id' => $config['id'],
+                'documentTypeId' => $this->documentTypeId('invoice'),
+            ]], $this->context);
+            static::fail('Expected the write to be rejected.');
+        } catch (WriteException $exception) {
+            static::assertSame(self::BOTH_PDF_FORMATS, $this->duplicateInfixPaths($exception));
+        }
+    }
+
+    public function testRejectsGlobalInfixThatCollidesWithAnAssignedSalesChannelOverride(): void
+    {
+        $this->documentBaseConfigRepository->create([
+            $this->salesChannelConfig('invoice', ['pdf' => '_shared'], name: 'Storefront invoice'),
+        ], $this->context);
+
+        try {
+            $this->documentBaseConfigRepository->update([[
+                'id' => $this->globalInvoiceConfigId(),
+                'filenameInfixes' => ['zugferd_embedded_pdf' => '_shared'],
+            ]], $this->context);
+            static::fail('Expected the write to be rejected.');
+        } catch (WriteException $exception) {
+            static::assertSame(['/0/filenameInfixes/zugferd_embedded_pdf'], $this->duplicateInfixPaths($exception));
+            static::assertSame('Storefront invoice', $this->firstViolation($exception)->getParameters()['{{ configs }}']);
+        }
+    }
+
+    public function testIgnoresSalesChannelConfigsWithoutAnAssignment(): void
+    {
+        $unassigned = $this->salesChannelConfig('invoice', ['pdf' => '_shared']);
+        unset($unassigned['salesChannels']);
+        $this->documentBaseConfigRepository->create([$unassigned], $this->context);
+
+        $this->documentBaseConfigRepository->update([[
+            'id' => $this->globalInvoiceConfigId(),
+            'filenameInfixes' => ['zugferd_embedded_pdf' => '_shared'],
+        ]], $this->context);
+
+        $written = $this->documentBaseConfigRepository->search(new Criteria([$this->globalInvoiceConfigId()]), $this->context)->getEntities()->first();
+        static::assertInstanceOf(DocumentBaseConfigEntity::class, $written);
+        static::assertSame(['zugferd_embedded_pdf' => '_shared'], $written->getFilenameInfixes());
+    }
+
+    public function testAcceptsDistinctInfixes(): void
+    {
+        $config = $this->salesChannelConfig('invoice', ['pdf' => '_pdf', 'zugferd_embedded_pdf' => '_e-invoice']);
+
+        $this->documentBaseConfigRepository->create([$config], $this->context);
+
+        $written = $this->documentBaseConfigRepository->search(new Criteria([$config['id']]), $this->context)->getEntities()->first();
+        static::assertInstanceOf(DocumentBaseConfigEntity::class, $written);
+        static::assertSame(['pdf' => '_pdf', 'zugferd_embedded_pdf' => '_e-invoice'], $written->getFilenameInfixes());
+    }
+
+    /**
+     * @param array<string, string> $filenameInfixes
+     *
+     * @return array<string, mixed>
+     */
+    private function salesChannelConfig(string $documentType, array $filenameInfixes, string $name = 'config under test'): array
+    {
+        $documentTypeId = $this->documentTypeId($documentType);
+
+        return [
+            'id' => Uuid::randomHex(),
+            'name' => $name,
+            'documentTypeId' => $documentTypeId,
+            'global' => false,
+            'filenameInfixes' => $filenameInfixes,
+            'salesChannels' => [[
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'documentTypeId' => $documentTypeId,
+            ]],
+        ];
+    }
+
+    private function documentTypeId(string $technicalName): string
+    {
+        $id = static::getContainer()->get('document_type.repository')
+            ->searchIds((new Criteria())->addFilter(new EqualsFilter('technicalName', $technicalName)), $this->context)
+            ->firstId();
+        static::assertIsString($id);
+
+        return $id;
+    }
+
+    private function globalInvoiceConfigId(): string
+    {
+        $id = $this->documentBaseConfigRepository
+            ->searchIds((new Criteria())->addFilter(new EqualsFilter('typeName', 'invoice'), new EqualsFilter('global', true)), $this->context)
+            ->firstId();
+        static::assertIsString($id);
+
+        return $id;
+    }
+
+    private function firstViolation(WriteException $exception): ConstraintViolationInterface
+    {
+        $inner = $exception->getExceptions()[0] ?? null;
+        static::assertInstanceOf(WriteConstraintViolationException::class, $inner);
+
+        return $inner->getViolations()->get(0);
+    }
+
+    private function assertGlobalInvoiceInfixIsSeeded(): void
+    {
+        $globalInfixes = $this->documentBaseConfigRepository
+            ->search((new Criteria())->addFilter(new EqualsFilter('typeName', 'invoice'), new EqualsFilter('global', true)), $this->context)
+            ->getEntities()
+            ->first()
+            ?->getFilenameInfixes();
+
+        static::assertSame(['zugferd_embedded_pdf' => '_zugferd'], $globalInfixes, 'The migration seed this test relies on is missing.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function duplicateInfixPaths(WriteException $exception): array
+    {
+        $paths = [];
+        foreach ($exception->getExceptions() as $inner) {
+            static::assertInstanceOf(WriteConstraintViolationException::class, $inner);
+            foreach ($inner->getViolations() as $violation) {
+                static::assertSame(DocumentBaseConfigValidator::DUPLICATE_FILENAME_INFIX, $violation->getCode());
+                $paths[] = $violation->getPropertyPath();
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/tests/unit/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidatorTest.php
+++ b/tests/unit/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidatorTest.php
@@ -2,12 +2,24 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Document\Aggregate\DocumentBaseConfig;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigDefinition;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigValidator;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\Renderer\DocumentRendererRegistry;
+use Shopware\Core\Checkout\DocumentV2\Type\AbstractDocumentType;
+use Shopware\Core\Checkout\DocumentV2\Type\DeliveryNoteDocumentType;
+use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
+use Shopware\Core\Checkout\DocumentV2\Type\InvoiceDocumentType;
+use Shopware\Core\Framework\App\Feature\AppFeatureStorage;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
@@ -16,7 +28,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentRenderer;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -26,18 +40,19 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[CoversClass(DocumentBaseConfigValidator::class)]
 class DocumentBaseConfigValidatorTest extends TestCase
 {
-    private Context $context;
+    private const GLOBAL_ZUGFERD_INFIXES = '{"zugferd_embedded_pdf":"_zugferd"}';
 
-    private DocumentBaseConfigValidator $documentBaseConfigValidator;
+    private const PDF = '/0/filenameInfixes/pdf';
+
+    private const ZUGFERD = '/0/filenameInfixes/zugferd_embedded_pdf';
+
+    private Context $context;
 
     private StaticDefinitionInstanceRegistry $definitionInstanceRegistry;
 
     protected function setUp(): void
     {
         $this->context = Context::createDefaultContext();
-        $this->documentBaseConfigValidator = new DocumentBaseConfigValidator(
-            new MockClock('2026-01-01 12:00:00'),
-        );
         $this->definitionInstanceRegistry = new StaticDefinitionInstanceRegistry(
             [DocumentBaseConfigDefinition::class],
             static::createStub(ValidatorInterface::class),
@@ -47,89 +62,366 @@ class DocumentBaseConfigValidatorTest extends TestCase
 
     public function testValidateWithNoConfigKeyShouldBeValid(): void
     {
-        $event = $this->createEventWithValue([]);
+        $event = $this->createEvent($this->updateCommand([]));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateWithEmptyConfigKeyShouldBeValid(): void
     {
-        $event = $this->createEventWithValue(['config' => null]);
+        $event = $this->createEvent($this->updateCommand(['config' => null]));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateWithSimpleDateModifierShouldBeValid(): void
     {
-        $payload = $this->createPayload('+30 day');
-        $event = $this->createEventWithValue($payload);
+        $event = $this->createEvent($this->updateCommand($this->paymentDueDate('+30 day')));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateWithNullShouldBeValid(): void
     {
-        $payload = $this->createPayload(null);
-        $event = $this->createEventWithValue($payload);
+        $event = $this->createEvent($this->updateCommand($this->paymentDueDate(null)));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateWithEmptyStringShouldBeValid(): void
     {
-        $payload = $this->createPayload('');
-        $event = $this->createEventWithValue($payload);
+        $event = $this->createEvent($this->updateCommand($this->paymentDueDate('')));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateWithInvalidValueShouldBeInvalid(): void
     {
-        $payload = $this->createPayload('anyInvalidValue');
-        $event = $this->createEventWithValue($payload);
+        $event = $this->createEvent($this->updateCommand($this->paymentDueDate('anyInvalidValue')));
 
-        $this->documentBaseConfigValidator->validate($event);
+        $this->createValidator()->validate($event);
 
-        static::assertCount(1, $event->getExceptions()->getExceptions());
-        $exception = $event->getExceptions()->getExceptions()[0];
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
-        static::assertSame('DOCUMENT_BASE_CONFIG_INVALID_PAYMENT_DUE_DATE', $exception->getViolations()->get(0)->getCode());
+        $violations = $this->violations($event);
+        static::assertCount(1, $violations);
+        static::assertSame(DocumentBaseConfigValidator::INVALID_PAYMENT_DUE_DATE, $violations->get(0)->getCode());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $connectionReturns
+     * @param list<string> $expectedPaths
+     */
+    #[DataProvider('filenameInfixCases')]
+    #[TestDox('$_dataName')]
+    public function testFilenameInfixes(bool $insert, array $payload, array $connectionReturns, array $expectedPaths): void
+    {
+        $command = $insert ? $this->insertCommand($payload) : $this->updateCommand($payload);
+        $event = $this->createEvent($command);
+
+        $this->createValidator($this->createConnection(...$connectionReturns))->validate($event);
+
+        if ($expectedPaths === []) {
+            static::assertCount(0, $event->getExceptions()->getExceptions());
+
+            return;
+        }
+
+        static::assertSame($expectedPaths, $this->violationPaths($event));
+    }
+
+    public static function filenameInfixCases(): \Generator
+    {
+        $globalInvoice = ['type_name' => 'invoice', 'global' => 1];
+        $channelInvoice = ['type_name' => 'invoice', 'global' => 0];
+        $seededGlobal = ['fetchOne' => self::GLOBAL_ZUGFERD_INFIXES];
+
+        yield 'global config: same infix for both PDF formats is rejected' => [
+            true, $globalInvoice + self::infixes(['pdf' => '_x', 'zugferd_embedded_pdf' => '_x']), [], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'global config: distinct infixes are accepted' => [
+            true, $globalInvoice + self::infixes(['zugferd_embedded_pdf' => '_zugferd']), [], [],
+        ];
+        yield 'global config: a missing infix counts as empty' => [
+            true, $globalInvoice + self::infixes(['zugferd_embedded_pdf' => '']), [], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'global config: a null map counts as empty' => [
+            true, $globalInvoice + self::infixes(null), [], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'global config: infixes are compared case-insensitively' => [
+            true, $globalInvoice + self::infixes(['pdf' => '_A', 'zugferd_embedded_pdf' => '_a']), [], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'global config: non-string values count as unconfigured instead of failing' => [
+            true, $globalInvoice + ['filename_infixes' => '{"pdf":null,"zugferd_embedded_pdf":["_x"]}'], [], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'delivery note: equal infixes are accepted because no formats share an extension' => [
+            true, ['type_name' => 'delivery_note', 'global' => 1] + self::infixes(['html' => '', 'pdf' => '']), [], [],
+        ];
+        yield 'unknown document type is skipped' => [
+            true, ['type_name' => 'unknown_type', 'global' => 1] + self::infixes(['pdf' => '', 'zugferd_embedded_pdf' => '']), [], [],
+        ];
+        yield 'sales channel config: the global infixes are merged in' => [
+            true, $channelInvoice + self::infixes(['pdf' => '_zugferd']), $seededGlobal, [self::PDF, self::ZUGFERD],
+        ];
+        yield 'sales channel config: no infixes inherit the global infixes' => [
+            true, $channelInvoice + self::infixes(null), $seededGlobal, [],
+        ];
+        yield 'sales channel config: an empty infix inherits the global infix' => [
+            true, $channelInvoice + self::infixes(['zugferd_embedded_pdf' => '']), $seededGlobal, [],
+        ];
+        yield 'sales channel config: without a global row it is checked on its own' => [
+            true, $channelInvoice + self::infixes(['pdf' => '', 'zugferd_embedded_pdf' => '']), ['fetchOne' => false], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'update: type and scope are read from the row when the payload only carries infixes' => [
+            false, self::infixes(['pdf' => '_x', 'zugferd_embedded_pdf' => '_x']), ['fetchAssociative' => $globalInvoice + ['filename_infixes' => null]], [self::PDF, self::ZUGFERD],
+        ];
+        yield 'update: stored infixes are re-validated when the document type changes' => [
+            false, ['type_name' => 'invoice'], ['fetchAssociative' => $channelInvoice + ['filename_infixes' => '{"pdf":"_zugferd"}']] + $seededGlobal, [self::PDF, self::ZUGFERD],
+        ];
+        yield 'update: neither infixes nor scope changed, nothing is checked' => [
+            false, ['name' => 'renamed'], ['fetchAssociative' => $globalInvoice + ['filename_infixes' => '{"pdf":"_x","zugferd_embedded_pdf":"_x"}']], [],
+        ];
+        yield 'update: an unknown row is skipped' => [
+            false, self::infixes(['pdf' => '_x', 'zugferd_embedded_pdf' => '_x']), ['fetchAssociative' => false], [],
+        ];
+        yield 'global config: an infix colliding with an assigned sales channel override is rejected on the global field only' => [
+            true, $globalInvoice + self::infixes(['zugferd_embedded_pdf' => '_x']), ['fetchAllAssociative' => [['name' => 'Storefront invoice', 'filename_infixes' => '{"pdf":"_x"}']]], [self::ZUGFERD],
+        ];
+        yield 'global config: a clash a sales channel config causes on its own is not blamed on the global write' => [
+            true, $globalInvoice + self::infixes(['zugferd_embedded_pdf' => '_zugferd']), ['fetchAllAssociative' => [['name' => 'Broken', 'filename_infixes' => '{"pdf":"_x","zugferd_embedded_pdf":"_x"}']]], [],
+        ];
+        yield 'global config: an empty sales channel override still inherits the clashing global infix' => [
+            true, $globalInvoice + self::infixes(['zugferd_embedded_pdf' => '_x']), ['fetchAllAssociative' => [['name' => 'Storefront invoice', 'filename_infixes' => '{"pdf":"_x","zugferd_embedded_pdf":""}']]], [self::ZUGFERD],
+        ];
+    }
+
+    public function testViolationNamesTheOtherFormatAndCarriesTheInfix(): void
+    {
+        $event = $this->createEvent($this->insertCommand(
+            ['type_name' => 'invoice', 'global' => 1] + self::infixes(['pdf' => '_x', 'zugferd_embedded_pdf' => '_x']),
+        ));
+
+        $this->createValidator()->validate($event);
+
+        $pdf = $this->violations($event)->get(0);
+        static::assertSame(DocumentBaseConfigValidator::DUPLICATE_FILENAME_INFIX, $pdf->getCode());
+        static::assertSame(self::PDF, $pdf->getPropertyPath());
+        static::assertSame('_x', $pdf->getInvalidValue());
+        static::assertSame([
+            '{{ infix }}' => '_x',
+            '{{ format }}' => 'pdf',
+            '{{ formats }}' => 'zugferd_embedded_pdf',
+            '{{ extension }}' => 'pdf',
+        ], $pdf->getParameters());
+        static::assertSame(
+            'The filename infix "_x" for "pdf" produces the same ".pdf" filename as: zugferd_embedded_pdf.',
+            $pdf->getMessage(),
+        );
+    }
+
+    public function testViolationOnAGlobalWriteNamesEveryAffectedSalesChannelConfig(): void
+    {
+        $connection = $this->createConnection(fetchAllAssociative: [
+            ['name' => 'B2B invoice', 'filename_infixes' => '{"pdf":"_x"}'],
+            ['name' => 'Storefront invoice', 'filename_infixes' => '{"pdf":"_X"}'],
+        ]);
+        $event = $this->createEvent($this->insertCommand(
+            ['type_name' => 'invoice', 'global' => 1] + self::infixes(['zugferd_embedded_pdf' => '_x']),
+        ));
+
+        $this->createValidator($connection)->validate($event);
+
+        $violations = $this->violations($event);
+        static::assertCount(1, $violations);
+        static::assertSame('B2B invoice, Storefront invoice', $violations->get(0)->getParameters()['{{ configs }}']);
+        static::assertSame(
+            'The filename infix "_x" for "zugferd_embedded_pdf" produces the same ".pdf" filename as: pdf in the sales channel configuration: B2B invoice, Storefront invoice.',
+            $violations->get(0)->getMessage(),
+        );
+    }
+
+    public function testViolationListsEveryOtherClashingFormat(): void
+    {
+        $rendererRegistry = new DocumentRendererRegistry([
+            new StaticDocumentRenderer(DocumentFormat::PDF),
+            new StaticDocumentRenderer(DocumentFormat::ZUGFERD_EMBEDDED_PDF),
+            new StaticDocumentRenderer('xrechnung_pdf', fileExtension: 'pdf'),
+        ]);
+        $event = $this->createEvent($this->insertCommand(
+            ['type_name' => ThreePdfFormatsDocumentType::TECHNICAL_NAME, 'global' => 1] + self::infixes(null),
+        ));
+
+        $this->createValidator(rendererRegistry: $rendererRegistry, documentTypes: [new ThreePdfFormatsDocumentType()])->validate($event);
+
+        $violations = $this->violations($event);
+        static::assertCount(3, $violations);
+        static::assertSame('zugferd_embedded_pdf, xrechnung_pdf', $violations->get(0)->getParameters()['{{ formats }}']);
+        static::assertSame('pdf, xrechnung_pdf', $violations->get(1)->getParameters()['{{ formats }}']);
+    }
+
+    public function testFormatsWithoutARegisteredRendererAreSkipped(): void
+    {
+        $rendererRegistry = new DocumentRendererRegistry([
+            new StaticDocumentRenderer(DocumentFormat::HTML),
+            new StaticDocumentRenderer(DocumentFormat::PDF),
+        ]);
+        $event = $this->createEvent($this->insertCommand(
+            ['type_name' => 'invoice', 'global' => 1] + self::infixes(['pdf' => '', 'zugferd_embedded_pdf' => '']),
+        ));
+
+        $this->createValidator(rendererRegistry: $rendererRegistry)->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    /**
+     * @param list<AbstractDocumentType>|null $documentTypes
+     */
+    private function createValidator(
+        ?Connection $connection = null,
+        ?DocumentRendererRegistry $rendererRegistry = null,
+        ?array $documentTypes = null,
+    ): DocumentBaseConfigValidator {
+        $rendererRegistry ??= new DocumentRendererRegistry([
+            new StaticDocumentRenderer(DocumentFormat::HTML),
+            new StaticDocumentRenderer(DocumentFormat::PDF),
+            new StaticDocumentRenderer(DocumentFormat::ZUGFERD_XML),
+            new StaticDocumentRenderer(DocumentFormat::ZUGFERD_EMBEDDED_PDF),
+        ]);
+        $appFeatureStorage = static::createStub(AppFeatureStorage::class);
+        $appFeatureStorage->method('forActiveApps')->willReturn([]);
+
+        return new DocumentBaseConfigValidator(
+            new MockClock('2026-01-01 12:00:00'),
+            $connection ?? $this->createConnection(),
+            new DocumentTypeRegistry($documentTypes ?? [new InvoiceDocumentType(), new DeliveryNoteDocumentType()], $appFeatureStorage),
+            static fn (): DocumentRendererRegistry => $rendererRegistry,
+        );
+    }
+
+    /**
+     * @param array<string, mixed>|false $fetchAssociative
+     * @param list<array<string, mixed>> $fetchAllAssociative
+     */
+    private function createConnection(
+        array|false $fetchAssociative = false,
+        mixed $fetchOne = false,
+        array $fetchAllAssociative = [],
+    ): Connection {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAssociative')->willReturn($fetchAssociative);
+        $connection->method('fetchOne')->willReturn($fetchOne);
+        $connection->method('fetchAllAssociative')->willReturn($fetchAllAssociative);
+
+        return $connection;
     }
 
     /**
      * @return array<string, string|null>
      */
-    private function createPayload(?string $value): array
+    private function paymentDueDate(?string $value): array
     {
         return ['config' => \json_encode(['paymentDueDate' => $value], \JSON_THROW_ON_ERROR)];
     }
 
     /**
+     * @param array<string, string>|null $map
+     *
+     * @return array<string, string|null>
+     */
+    private static function infixes(?array $map): array
+    {
+        return ['filename_infixes' => $map === null ? null : \json_encode($map, \JSON_THROW_ON_ERROR)];
+    }
+
+    /**
      * @param array<string, mixed> $payload
      */
-    private function createEventWithValue(array $payload): PreWriteValidationEvent
+    private function insertCommand(array $payload): InsertCommand
     {
-        $writeCommand = new UpdateCommand(
+        return new InsertCommand(
             $this->definitionInstanceRegistry->get(DocumentBaseConfigDefinition::class),
             $payload,
             ['id' => Uuid::randomBytes()],
             static::createStub(EntityExistence::class),
-            '/0/'
+            '/0'
         );
+    }
 
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function updateCommand(array $payload): UpdateCommand
+    {
+        return new UpdateCommand(
+            $this->definitionInstanceRegistry->get(DocumentBaseConfigDefinition::class),
+            $payload,
+            ['id' => Uuid::randomBytes()],
+            static::createStub(EntityExistence::class),
+            '/0'
+        );
+    }
+
+    private function createEvent(WriteCommand $command): PreWriteValidationEvent
+    {
         return new PreWriteValidationEvent(
             WriteContext::createFromContext($this->context),
-            [$writeCommand]
+            [$command]
         );
+    }
+
+    private function violations(PreWriteValidationEvent $event): ConstraintViolationListInterface
+    {
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+
+        return $exceptions[0]->getViolations();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function violationPaths(PreWriteValidationEvent $event): array
+    {
+        $paths = [];
+        foreach ($this->violations($event) as $violation) {
+            static::assertSame(DocumentBaseConfigValidator::DUPLICATE_FILENAME_INFIX, $violation->getCode());
+            $paths[] = $violation->getPropertyPath();
+        }
+
+        return $paths;
+    }
+}
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+final readonly class ThreePdfFormatsDocumentType extends AbstractDocumentType
+{
+    public const TECHNICAL_NAME = 'three_pdf_formats';
+
+    public function getTechnicalName(): string
+    {
+        return self::TECHNICAL_NAME;
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return [
+            DocumentFormat::PDF->value,
+            DocumentFormat::ZUGFERD_EMBEDDED_PDF->value,
+            'xrechnung_pdf',
+        ];
     }
 }

--- a/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
@@ -195,6 +195,55 @@ class DocumentConfigLoaderTest extends TestCase
         static::assertSame(['zugferd_embedded_pdf' => '_zugferd'], $bundle->config->filenameInfixes);
     }
 
+    public function testLoadTreatsEmptySalesChannelFilenameInfixAsUnconfigured(): void
+    {
+        $matchingSalesChannelId = Uuid::randomHex();
+
+        $globalRow = $this->createBaseConfig(
+            global: true,
+            pageSize: 'A4',
+            companyName: 'Global GmbH',
+            filenameInfixes: ['zugferd_embedded_pdf' => '_zugferd'],
+        );
+
+        $matchingRow = $this->createBaseConfig(
+            global: false,
+            pageSize: 'A4',
+            companyName: 'Matching Channel GmbH',
+            salesChannelId: $matchingSalesChannelId,
+            filenameInfixes: ['zugferd_embedded_pdf' => '', 'pdf' => '_channel'],
+        );
+
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([$globalRow, $matchingRow])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+            $this->documentTypeRegistry,
+        );
+
+        $bundle = $loader->load(
+            DocumentType::INVOICE->value,
+            $matchingSalesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(
+            ['zugferd_embedded_pdf' => '_zugferd', 'pdf' => '_channel'],
+            $bundle->config->filenameInfixes,
+        );
+    }
+
     public function testLoadMergesFilenameInfixesPerFormat(): void
     {
         $matchingSalesChannelId = Uuid::randomHex();


### PR DESCRIPTION
resolves #19260

PDF and ZUGFeRD embedded PDF share the `.pdf` extension, so equal or empty infixes rendered both to the same filename and the second file only survived through the `(1)` suffix from `FileNameProvider`. `DocumentBaseConfigValidator` now rejects a `document_base_config` write whose effective infixes collide, with the global and sales-channel maps merged the way `DocumentConfigLoader` does it, one violation per affected format, and the admin shows them under the infix fields.

- a sales-channel `''` infix now inherits the global one, matching prefix and suffix since #19623
- the `??= {}` in the save `catch` also restores the infix map after a rejected save, follow-up fix to #19859
- equal infixes across two sales channels stay allowed, the seeded `_zugferd` is the same on every channel 

Global invoice config with both PDF formats set to `_zugferd`:

<img width="960" height="545" alt="Screen Shot 2026-09-03 at 11 58 17" src="https://github.com/user-attachments/assets/288ec2f6-5164-492a-810f-99ab20bafab8" />

Global invoice config with ZUGFeRD embedded PDF set to `_x`, while a sales-channel config of the same type overrides PDF with `_x`:

<img width="960" height="561" alt="Screen Shot 2026-09-03 at 12 05 05" src="https://github.com/user-attachments/assets/2d5c9264-5155-4d9d-9a7e-28c5ddc76f9d" />

Sales-channel invoice config with PDF set to `_zugferd` and ZUGFeRD embedded PDF left empty, so it inherits the global `_zugferd`:

<img width="960" height="567" alt="Screen Shot 2026-09-03 at 12 00 25" src="https://github.com/user-attachments/assets/c9d6f5ae-9add-446a-8b70-719b11337c06" />

Switching a delivery-note config with PDF `_zugferd` to the invoice type ends in the same state.