### PR TITLE
feat(administration): add hotkeys to toggle the navigation and switch the appearance

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -33,6 +33,15 @@ export default {
         Mixin.getByName('notification'),
     ],
 
+    shortcuts: {
+        S: {
+            active() {
+                return !this.isMobileViewport;
+            },
+            method: 'onToggleSidebar',
+        },
+    },
+
     data() {
         return {
             activeEntry: null,

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -35,8 +35,8 @@ export default {
 
     shortcuts: {
         S: {
-            active() {
-                return !this.isMobileViewport;
+            active(event) {
+                return !this.isMobileViewport && !(event?.ctrlKey || event?.altKey || event?.metaKey);
             },
             method: 'onToggleSidebar',
         },

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/shortcuts.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/shortcuts.spec.js
@@ -1,0 +1,46 @@
+/**
+ * @sw-package framework
+ */
+
+import { config } from '@vue/test-utils';
+import createWrapper, { registerAdminModules } from './create-wrapper';
+
+describe('src/app/component/structure/sw-admin-menu: shortcuts', () => {
+    let wrapper;
+
+    beforeAll(() => {
+        Shopware.Store.get('session').currentLocale = 'en-GB';
+        Shopware.Context.app.fallbackLocale = 'en-GB';
+
+        registerAdminModules();
+    });
+
+    beforeEach(async () => {
+        config.global.stubs = {
+            ...config.global.stubs,
+            transition: false,
+        };
+
+        jest.spyOn(Shopware.Utils.debug, 'error').mockImplementation(() => true);
+
+        Shopware.Store.get('session').setCurrentUser(null);
+        Shopware.Store.get('settingsItems').settingsGroups.shop = [];
+        Shopware.Store.get('settingsItems').settingsGroups.system = [];
+        Shopware.Store.get('shopwareApps').apps = [];
+
+        wrapper = await createWrapper();
+        await flushPromises();
+    });
+
+    it('should toggle the sidebar with the S shortcut on desktop viewports only', async () => {
+        const shortcut = wrapper.vm.$options.shortcuts.S;
+
+        expect(shortcut.method).toBe('onToggleSidebar');
+
+        wrapper.vm.viewportWidth = 1920;
+        expect(shortcut.active.call(wrapper.vm)).toBe(true);
+
+        wrapper.vm.viewportWidth = 1280;
+        expect(shortcut.active.call(wrapper.vm)).toBe(false);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/shortcuts.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/shortcuts.spec.js
@@ -38,9 +38,18 @@ describe('src/app/component/structure/sw-admin-menu: shortcuts', () => {
         expect(shortcut.method).toBe('onToggleSidebar');
 
         wrapper.vm.viewportWidth = 1920;
-        expect(shortcut.active.call(wrapper.vm)).toBe(true);
+        expect(shortcut.active.call(wrapper.vm, { key: 's' })).toBe(true);
 
         wrapper.vm.viewportWidth = 1280;
-        expect(shortcut.active.call(wrapper.vm)).toBe(false);
+        expect(shortcut.active.call(wrapper.vm, { key: 's' })).toBe(false);
+    });
+
+    it('should not toggle the sidebar with the S shortcut while a modifier key is held', async () => {
+        const shortcut = wrapper.vm.$options.shortcuts.S;
+        wrapper.vm.viewportWidth = 1920;
+
+        expect(shortcut.active.call(wrapper.vm, { key: 's', ctrlKey: true })).toBe(false);
+        expect(shortcut.active.call(wrapper.vm, { key: 's', metaKey: true })).toBe(false);
+        expect(shortcut.active.call(wrapper.vm, { key: 's', altKey: true })).toBe(false);
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
@@ -1,7 +1,20 @@
 import template from './sw-desktop.html.twig';
+import useTheme from 'src/app/composables/use-theme';
 import './sw-desktop.scss';
 
 const { hasOwnProperty } = Shopware.Utils.object;
+
+const THEME_CYCLE = [
+    'system',
+    'light',
+    'dark',
+];
+
+const THEME_LABELS = {
+    system: 'global.sw-desktop.theme.names.system',
+    light: 'global.sw-desktop.theme.names.light',
+    dark: 'global.sw-desktop.theme.names.dark',
+};
 
 /**
  * @sw-package framework
@@ -14,7 +27,12 @@ export default {
     inject: [
         'shopIdChangeService',
         'userActivityApiService',
+        'snackbarService',
     ],
+
+    shortcuts: {
+        CT: 'onCycleTheme',
+    },
 
     data() {
         return {
@@ -98,6 +116,30 @@ export default {
 
         closeModal() {
             this.shopIdCheck = null;
+        },
+
+        async onCycleTheme() {
+            const currentTheme = useTheme().theme.value;
+            const nextTheme = THEME_CYCLE[(THEME_CYCLE.indexOf(currentTheme) + 1) % THEME_CYCLE.length];
+
+            try {
+                await useTheme().saveUserTheme(nextTheme);
+            } catch {
+                useTheme().setTheme(currentTheme);
+                this.snackbarService.addSnackbar({
+                    message: this.$t('global.sw-desktop.theme.saveError'),
+                    variant: 'error',
+                });
+
+                return;
+            }
+
+            this.snackbarService.addSnackbar({
+                message: this.$t('global.sw-desktop.theme.changed', {
+                    theme: this.$t(THEME_LABELS[nextTheme]),
+                }),
+                variant: 'success',
+            });
         },
 
         onUpdateSearchFrequently() {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
@@ -1,20 +1,8 @@
 import template from './sw-desktop.html.twig';
-import useTheme from 'src/app/composables/use-theme';
+import useTheme, { THEMES, THEME_LABELS } from 'src/app/composables/use-theme';
 import './sw-desktop.scss';
 
 const { hasOwnProperty } = Shopware.Utils.object;
-
-const THEME_CYCLE = [
-    'system',
-    'light',
-    'dark',
-];
-
-const THEME_LABELS = {
-    system: 'global.sw-desktop.theme.names.system',
-    light: 'global.sw-desktop.theme.names.light',
-    dark: 'global.sw-desktop.theme.names.dark',
-};
 
 /**
  * @sw-package framework
@@ -120,7 +108,7 @@ export default {
 
         async onCycleTheme() {
             const currentTheme = useTheme().theme.value;
-            const nextTheme = THEME_CYCLE[(THEME_CYCLE.indexOf(currentTheme) + 1) % THEME_CYCLE.length];
+            const nextTheme = THEMES[(THEMES.indexOf(currentTheme) + 1) % THEMES.length];
 
             try {
                 await useTheme().saveUserTheme(nextTheme);

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
@@ -4,6 +4,9 @@
 
 import { mount, config } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
+import useTheme from 'src/app/composables/use-theme';
+
+const addSnackbar = jest.fn();
 
 const routes = [
     {
@@ -142,6 +145,9 @@ async function createWrapper({ checkShopId = jest.fn(() => Promise.resolve()) } 
                 userActivityApiService: {
                     increment: jest.fn(() => Promise.resolve()),
                 },
+                snackbarService: {
+                    addSnackbar,
+                },
             },
         },
     });
@@ -165,6 +171,12 @@ describe('src/app/component/structure/sw-desktop', () => {
             appUrlReachable: true,
             enableStagingMode: false,
         };
+    });
+
+    afterEach(() => {
+        addSnackbar.mockClear();
+        useTheme().setTheme('system');
+        localStorage.removeItem('mt-theme');
     });
 
     it('should be update userConfig when at index route', async () => {
@@ -284,5 +296,45 @@ describe('src/app/component/structure/sw-desktop', () => {
         const wrapper = await createWrapper();
         expect(wrapper.vm).toBeTruthy();
         expect(wrapper.find('.sw-staging-bar').exists()).toBeFalsy();
+    });
+    it('should cycle the theme with the C T shortcut and confirm the change', async () => {
+        const wrapper = await createWrapper();
+        useTheme().setTheme('system');
+
+        expect(wrapper.vm.$options.shortcuts.CT).toBe('onCycleTheme');
+
+        await wrapper.vm.onCycleTheme();
+        expect(useTheme().theme.value).toBe('light');
+
+        await wrapper.vm.onCycleTheme();
+        expect(useTheme().theme.value).toBe('dark');
+
+        await wrapper.vm.onCycleTheme();
+        expect(useTheme().theme.value).toBe('system');
+
+        expect(Shopware.Service('userConfigService').upsert).toHaveBeenLastCalledWith({
+            'core.userTheme': { theme: 'system' },
+        });
+        expect(addSnackbar).toHaveBeenCalledTimes(3);
+        expect(addSnackbar).toHaveBeenLastCalledWith({
+            message: 'global.sw-desktop.theme.changed',
+            variant: 'success',
+        });
+    });
+
+    it('should show an error when the theme could not be saved', async () => {
+        Shopware.Service('userConfigService').upsert.mockRejectedValueOnce(new Error('failed'));
+
+        const wrapper = await createWrapper();
+        useTheme().setTheme('system');
+
+        await wrapper.vm.onCycleTheme();
+
+        expect(useTheme().theme.value).toBe('system');
+        expect(addSnackbar).toHaveBeenCalledTimes(1);
+        expect(addSnackbar).toHaveBeenCalledWith({
+            message: 'global.sw-desktop.theme.saveError',
+            variant: 'error',
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
@@ -4,9 +4,24 @@
 
 import { mount, config } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
-import useTheme from 'src/app/composables/use-theme';
+import useTheme, { DEFAULT_THEME } from 'src/app/composables/use-theme';
+import shortcutPlugin from 'src/app/plugin/shortcut.plugin';
 
 const addSnackbar = jest.fn();
+const wrappers = [];
+
+// The shortcut plugin relies on the debounce delay to collect key sequences, the global mock runs immediately
+Shopware.Utils.debounce = function debounce(callback, delay) {
+    let timeout = null;
+
+    const execFunction = jest.fn(() => {
+        clearTimeout(timeout);
+        timeout = setTimeout(callback, delay);
+    });
+    execFunction.cancel = jest.fn(() => clearTimeout(timeout));
+
+    return execFunction;
+};
 
 const routes = [
     {
@@ -122,10 +137,12 @@ async function createWrapper({ checkShopId = jest.fn(() => Promise.resolve()) } 
 
     await router.push({ name: 'sw.dashboard.index' });
 
-    return mount(await wrapTestComponent('sw-desktop', { sync: true }), {
+    const wrapper = mount(await wrapTestComponent('sw-desktop', { sync: true }), {
+        attachTo: document.body,
         global: {
             plugins: [
                 router,
+                shortcutPlugin,
             ],
             stubs: {
                 'sw-admin-menu': true,
@@ -151,6 +168,18 @@ async function createWrapper({ checkShopId = jest.fn(() => Promise.resolve()) } 
             },
         },
     });
+
+    wrappers.push(wrapper);
+
+    return wrapper;
+}
+
+async function pressKeys(wrapper, ...keys) {
+    for (const key of keys) {
+        await wrapper.trigger('keydown', { key });
+    }
+
+    await flushPromises();
 }
 
 describe('src/app/component/structure/sw-desktop', () => {
@@ -174,8 +203,9 @@ describe('src/app/component/structure/sw-desktop', () => {
     });
 
     afterEach(() => {
+        wrappers.splice(0).forEach((wrapper) => wrapper.unmount());
         addSnackbar.mockClear();
-        useTheme().setTheme('system');
+        useTheme().setTheme(DEFAULT_THEME);
         localStorage.removeItem('mt-theme');
     });
 
@@ -299,21 +329,18 @@ describe('src/app/component/structure/sw-desktop', () => {
     });
     it('should cycle the theme with the C T shortcut and confirm the change', async () => {
         const wrapper = await createWrapper();
-        useTheme().setTheme('system');
 
-        expect(wrapper.vm.$options.shortcuts.CT).toBe('onCycleTheme');
-
-        await wrapper.vm.onCycleTheme();
-        expect(useTheme().theme.value).toBe('light');
-
-        await wrapper.vm.onCycleTheme();
+        await pressKeys(wrapper, 'c', 't');
         expect(useTheme().theme.value).toBe('dark');
 
-        await wrapper.vm.onCycleTheme();
+        await pressKeys(wrapper, 'c', 't');
         expect(useTheme().theme.value).toBe('system');
 
+        await pressKeys(wrapper, 'c', 't');
+        expect(useTheme().theme.value).toBe('light');
+
         expect(Shopware.Service('userConfigService').upsert).toHaveBeenLastCalledWith({
-            'core.userTheme': { theme: 'system' },
+            'core.userTheme': { theme: 'light' },
         });
         expect(addSnackbar).toHaveBeenCalledTimes(3);
         expect(addSnackbar).toHaveBeenLastCalledWith({
@@ -326,11 +353,10 @@ describe('src/app/component/structure/sw-desktop', () => {
         Shopware.Service('userConfigService').upsert.mockRejectedValueOnce(new Error('failed'));
 
         const wrapper = await createWrapper();
-        useTheme().setTheme('system');
 
-        await wrapper.vm.onCycleTheme();
+        await pressKeys(wrapper, 'c', 't');
 
-        expect(useTheme().theme.value).toBe('system');
+        expect(useTheme().theme.value).toBe(DEFAULT_THEME);
         expect(addSnackbar).toHaveBeenCalledTimes(1);
         expect(addSnackbar).toHaveBeenCalledWith({
             message: 'global.sw-desktop.theme.saveError',

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
@@ -87,6 +87,16 @@ export default {
                     },
                     {
                         id: utils.createId(),
+                        title: this.$t('sw-shortcut-overview.functionSpecialShortcutToggleNavigation'),
+                        content: this.$t('sw-shortcut-overview.keyboardShortcutSpecialShortcutToggleNavigation'),
+                    },
+                    {
+                        id: utils.createId(),
+                        title: this.$t('sw-shortcut-overview.functionSpecialShortcutCycleTheme'),
+                        content: this.$t('sw-shortcut-overview.keyboardShortcutSpecialShortcutCycleTheme'),
+                    },
+                    {
+                        id: utils.createId(),
                         title: this.$t('sw-shortcut-overview.functionAccessibilityCloseDialog'),
                         content: this.$t('sw-shortcut-overview.keyboardShortcutAccessibilityCloseDialog'),
                     },

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/sw-shortcut-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/sw-shortcut-overview.spec.js
@@ -112,6 +112,14 @@ describe('app/component/utils/sw-shortcut-overview', () => {
                     content: 'sw-shortcut-overview.keyboardShortcutSpecialShortcutOpenFilters',
                 }),
                 expect.objectContaining({
+                    title: 'sw-shortcut-overview.functionSpecialShortcutToggleNavigation',
+                    content: 'sw-shortcut-overview.keyboardShortcutSpecialShortcutToggleNavigation',
+                }),
+                expect.objectContaining({
+                    title: 'sw-shortcut-overview.functionSpecialShortcutCycleTheme',
+                    content: 'sw-shortcut-overview.keyboardShortcutSpecialShortcutCycleTheme',
+                }),
+                expect.objectContaining({
                     title: 'sw-shortcut-overview.functionAccessibilityCloseDialog',
                     content: 'sw-shortcut-overview.keyboardShortcutAccessibilityCloseDialog',
                 }),

--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
@@ -23,6 +23,28 @@ export const USER_THEME_CONFIG_KEY = 'core.userTheme';
  */
 export const DEFAULT_THEME: Theme = 'light';
 
+/**
+ * Selectable theme preferences in the order the appearance shortcut cycles through them.
+ *
+ * @private
+ */
+export const THEMES: readonly Theme[] = [
+    'light',
+    'dark',
+    'system',
+];
+
+/**
+ * Snippet keys of the theme preference names.
+ *
+ * @private
+ */
+export const THEME_LABELS: Readonly<Record<Theme, string>> = {
+    light: 'global.theme.names.light',
+    dark: 'global.theme.names.dark',
+    system: 'global.theme.names.system',
+};
+
 type UseAdminThemeReturn = UseThemeReturn & {
     /**
      * Loads the persisted theme preference of the current user from the
@@ -40,7 +62,7 @@ type UseAdminThemeReturn = UseThemeReturn & {
 let themeState: UseAdminThemeReturn | null = null;
 
 function isTheme(value: unknown): value is Theme {
-    return value === 'light' || value === 'dark' || value === 'system';
+    return THEMES.includes(value as Theme);
 }
 
 async function loadUserTheme(): Promise<void> {

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -58,6 +58,16 @@ export default {
             });
         }
 
+        function isNavigationSequence(sequence) {
+            const registry = Shopware.Application.getContainer('factory')?.shortcut?.getShortcutRegistry?.();
+
+            if (!registry) {
+                return false;
+            }
+
+            return [...registry.keys()].some((combination) => combination.toUpperCase().startsWith(sequence));
+        }
+
         function getMatchedShortcut(shortcutKey) {
             if (isSystemShortcut(shortcutKey)) {
                 resetSequenceNow();
@@ -83,7 +93,7 @@ export default {
                 return matchedShortcut;
             }
 
-            if (hasLongerSequenceThan(sequence)) {
+            if (hasLongerSequenceThan(sequence) || isNavigationSequence(sequence)) {
                 return null;
             }
 
@@ -93,6 +103,10 @@ export default {
         }
 
         function handleKeyDown(event) {
+            if (event.repeat) {
+                return;
+            }
+
             if (areShortcutsDisabled()) {
                 resetComponentShortcutState();
 
@@ -101,7 +115,7 @@ export default {
 
             // Check if event originates from within a modal
             const eventTarget = event.target instanceof Element ? event.target : null;
-            const isFromModal = eventTarget?.closest('.sw-modal') || eventTarget?.closest('.sw-modal__dialog');
+            const isFromModal = eventTarget?.closest('.sw-modal, .sw-modal__dialog, .mt-modal');
 
             if (isFromModal) {
                 resetComponentShortcutState();
@@ -111,13 +125,14 @@ export default {
 
             // The 'this' context is the component instance, bound via .call()
             const systemKey = this.$device.getSystemKey();
-            const { key, altKey, ctrlKey } = event;
+            const { key, altKey, ctrlKey, metaKey } = event;
             const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey : altKey;
 
             // create combined key name and look for matching shortcut
             const combinedKey = (systemKeyPressed ? 'SYSTEMKEY+' : '') + key.toUpperCase();
+            const isModifiedKey = altKey || ctrlKey || metaKey;
 
-            if (!isSystemShortcut(combinedKey) && isRestrictedSource(event)) {
+            if (!isSystemShortcut(combinedKey) && (isModifiedKey || isRestrictedSource(event))) {
                 resetComponentShortcutState();
 
                 return;

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -145,7 +145,7 @@ export default {
                 return;
             }
 
-            if (!matchedShortcut.active()) {
+            if (!matchedShortcut.active(event)) {
                 return;
             }
 

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -68,8 +68,8 @@ export default {
             return [...registry.keys()].some((combination) => combination.toUpperCase().startsWith(sequence));
         }
 
-        function getMatchedShortcut(shortcutKey) {
-            if (isSystemShortcut(shortcutKey)) {
+        function getMatchedShortcut(shortcutKey, allowSequence) {
+            if (isSystemShortcut(shortcutKey) || !allowSequence) {
                 resetSequenceNow();
 
                 return findShortcut(shortcutKey);
@@ -130,15 +130,16 @@ export default {
 
             // create combined key name and look for matching shortcut
             const combinedKey = (systemKeyPressed ? 'SYSTEMKEY+' : '') + key.toUpperCase();
-            const isModifiedKey = altKey || ctrlKey || metaKey;
 
-            if (!isSystemShortcut(combinedKey) && (isModifiedKey || isRestrictedSource(event))) {
+            if (!isSystemShortcut(combinedKey) && isRestrictedSource(event)) {
                 resetComponentShortcutState();
 
                 return;
             }
 
-            const matchedShortcut = getMatchedShortcut(combinedKey);
+            // Browser shortcuts like Ctrl+C keep matching single keys, but never start or continue a key sequence
+            const isModifiedKey = altKey || ctrlKey || metaKey;
+            const matchedShortcut = getMatchedShortcut(combinedKey, !isModifiedKey);
 
             if (!matchedShortcut) {
                 return;

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
@@ -685,4 +685,125 @@ describe('app/plugins/shortcut.plugin', () => {
 
         expect(onSaveMock).toHaveBeenCalledTimes(1);
     });
+    it('should not trigger a single key shortcut while a navigation shortcut sequence is typed', async () => {
+        const onToggleMock = jest.fn();
+        const shortcutFactory = Shopware.Application.getContainer('factory').shortcut;
+        shortcutFactory.register('GS', '/sw/settings/index');
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                S: 'onToggle',
+            },
+            methods: {
+                onToggle() {
+                    onToggleMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 'g',
+        });
+        await wrapper.trigger('keydown', {
+            key: 's',
+        });
+
+        expect(onToggleMock).not.toHaveBeenCalled();
+
+        await wrapper.trigger('keydown', {
+            key: 'x',
+        });
+        await wrapper.trigger('keydown', {
+            key: 's',
+        });
+
+        expect(onToggleMock).toHaveBeenCalledTimes(1);
+
+        shortcutFactory.getShortcutRegistry().clear();
+        wrapper.unmount();
+    });
+
+    it('should not trigger a single key shortcut when a modifier key is pressed', async () => {
+        const onToggleMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                S: 'onToggle',
+            },
+            methods: {
+                onToggle() {
+                    onToggleMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 's',
+            metaKey: true,
+        });
+        await wrapper.trigger('keydown', {
+            key: 's',
+            ctrlKey: true,
+        });
+
+        expect(onToggleMock).not.toHaveBeenCalled();
+
+        wrapper.unmount();
+    });
+
+    it('should not trigger shortcuts from inside a meteor modal', async () => {
+        const onToggleMock = jest.fn();
+
+        const modal = document.createElement('div');
+        modal.className = 'mt-modal';
+        document.body.appendChild(modal);
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                S: 'onToggle',
+            },
+            methods: {
+                onToggle() {
+                    onToggleMock();
+                },
+            },
+        });
+
+        const event = new KeyboardEvent('keydown', { key: 's', bubbles: true });
+        Object.defineProperty(event, 'target', { value: modal, enumerable: true });
+
+        document.dispatchEvent(event);
+
+        expect(onToggleMock).not.toHaveBeenCalled();
+
+        document.body.removeChild(modal);
+        wrapper.unmount();
+    });
+
+    it('should ignore repeated keydown events while a key is held', async () => {
+        const onToggleMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                S: 'onToggle',
+            },
+            methods: {
+                onToggle() {
+                    onToggleMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 's',
+        });
+        await wrapper.trigger('keydown', {
+            key: 's',
+            repeat: true,
+        });
+
+        expect(onToggleMock).toHaveBeenCalledTimes(1);
+
+        wrapper.unmount();
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
@@ -21,9 +21,14 @@ import 'src/app/component/form/sw-checkbox-field';
 import 'src/app/component/base/sw-container';
 import 'src/app/component/base/sw-button';
 
-Shopware.Utils.debounce = function debounce() {
-    const execFunction = jest.fn();
-    execFunction.cancel = jest.fn();
+Shopware.Utils.debounce = function debounce(callback, delay) {
+    let timeout = null;
+
+    const execFunction = jest.fn(() => {
+        clearTimeout(timeout);
+        timeout = setTimeout(callback, delay);
+    });
+    execFunction.cancel = jest.fn(() => clearTimeout(timeout));
 
     return execFunction;
 };
@@ -723,8 +728,10 @@ describe('app/plugins/shortcut.plugin', () => {
         wrapper.unmount();
     });
 
-    it('should not trigger a single key shortcut when a modifier key is pressed', async () => {
+    it('should trigger the standalone shortcut again once the sequence delay has passed', async () => {
         const onToggleMock = jest.fn();
+        const shortcutFactory = Shopware.Application.getContainer('factory').shortcut;
+        shortcutFactory.register('GS', '/sw/settings/index');
 
         wrapper = await createWrapper({
             shortcuts: {
@@ -737,16 +744,79 @@ describe('app/plugins/shortcut.plugin', () => {
             },
         });
 
+        jest.useFakeTimers();
+
+        await wrapper.trigger('keydown', {
+            key: 'g',
+        });
+        jest.advanceTimersByTime(1000);
         await wrapper.trigger('keydown', {
             key: 's',
+        });
+
+        expect(onToggleMock).toHaveBeenCalledTimes(1);
+
+        jest.useRealTimers();
+        shortcutFactory.getShortcutRegistry().clear();
+        wrapper.unmount();
+    });
+
+    it('should still trigger a single key shortcut when a non system modifier key is pressed', async () => {
+        const onFocusMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                f: 'onFocus',
+            },
+            methods: {
+                onFocus() {
+                    onFocusMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 'f',
+            metaKey: true,
+        });
+
+        expect(onFocusMock).toHaveBeenCalledTimes(1);
+
+        wrapper.unmount();
+    });
+
+    it('should not start a key sequence when a modifier key is pressed', async () => {
+        const onCycleMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                CT: 'onCycle',
+            },
+            methods: {
+                onCycle() {
+                    onCycleMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 'c',
             metaKey: true,
         });
         await wrapper.trigger('keydown', {
-            key: 's',
-            ctrlKey: true,
+            key: 't',
         });
 
-        expect(onToggleMock).not.toHaveBeenCalled();
+        expect(onCycleMock).not.toHaveBeenCalled();
+
+        await wrapper.trigger('keydown', {
+            key: 'c',
+        });
+        await wrapper.trigger('keydown', {
+            key: 't',
+        });
+
+        expect(onCycleMock).toHaveBeenCalledTimes(1);
 
         wrapper.unmount();
     });

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
@@ -821,6 +821,39 @@ describe('app/plugins/shortcut.plugin', () => {
         wrapper.unmount();
     });
 
+    it('should pass the keydown event to the active check of a shortcut', async () => {
+        const activeMock = jest.fn(() => true);
+        const onToggleMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                S: {
+                    active: activeMock,
+                    method: 'onToggle',
+                },
+            },
+            methods: {
+                onToggle() {
+                    onToggleMock();
+                },
+            },
+        });
+
+        await wrapper.trigger('keydown', {
+            key: 's',
+            metaKey: true,
+        });
+
+        expect(activeMock).toHaveBeenCalledTimes(1);
+        const [event] = activeMock.mock.calls[0];
+        expect(event).toBeInstanceOf(KeyboardEvent);
+        expect(event.key).toBe('s');
+        expect(event.metaKey).toBe(true);
+        expect(onToggleMock).toHaveBeenCalledTimes(1);
+
+        wrapper.unmount();
+    });
+
     it('should not trigger shortcuts from inside a meteor modal', async () => {
         const onToggleMock = jest.fn();
 

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1561,7 +1561,7 @@
     "keyboardShortcutSpecialShortcutOpenFilters": "O F",
     "functionSpecialShortcutToggleNavigation": "Navigation umschalten",
     "keyboardShortcutSpecialShortcutToggleNavigation": "S",
-    "functionSpecialShortcutCycleTheme": "Erscheinungsbild wechseln",
+    "functionSpecialShortcutCycleTheme": "Erscheinungsbild ändern",
     "keyboardShortcutSpecialShortcutCycleTheme": "C T",
     "functionSpecialShortcutShortcutListing": "Tastenkürzel",
     "keyboardShortcutSpecialShortcutShortcutListing": "Shift ?",

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1559,7 +1559,7 @@
     "keyboardShortcutSpecialShortcutFocusSearch": "f",
     "functionSpecialShortcutOpenFilters": "Filter öffnen",
     "keyboardShortcutSpecialShortcutOpenFilters": "O F",
-    "functionSpecialShortcutToggleNavigation": "Navigation ein- oder ausklappen",
+    "functionSpecialShortcutToggleNavigation": "Navigation umschalten",
     "keyboardShortcutSpecialShortcutToggleNavigation": "S",
     "functionSpecialShortcutCycleTheme": "Erscheinungsbild wechseln",
     "keyboardShortcutSpecialShortcutCycleTheme": "C T",

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -68,7 +68,16 @@
       "notificationLoadingDataErrorMessage": "Fehler beim Laden der Daten"
     },
     "sw-desktop": {
-      "stagingBarText": "Der Shop befindet sich im Staging-Modus."
+      "stagingBarText": "Der Shop befindet sich im Staging-Modus.",
+      "theme": {
+        "changed": "Erscheinungsbild zu \"{theme}\" geändert",
+        "saveError": "Erscheinungsbild konnte nicht gewechselt werden",
+        "names": {
+          "system": "System",
+          "light": "Hell",
+          "dark": "Dunkel"
+        }
+      }
     },
     "sw-skip-link": {
       "label": "Navigation überspringen"
@@ -1550,6 +1559,10 @@
     "keyboardShortcutSpecialShortcutFocusSearch": "f",
     "functionSpecialShortcutOpenFilters": "Filter öffnen",
     "keyboardShortcutSpecialShortcutOpenFilters": "O F",
+    "functionSpecialShortcutToggleNavigation": "Navigation ein- oder ausklappen",
+    "keyboardShortcutSpecialShortcutToggleNavigation": "S",
+    "functionSpecialShortcutCycleTheme": "Erscheinungsbild wechseln",
+    "keyboardShortcutSpecialShortcutCycleTheme": "C T",
     "functionSpecialShortcutShortcutListing": "Tastenkürzel",
     "keyboardShortcutSpecialShortcutShortcutListing": "Shift ?",
     "functionSpecialShortcutSaveDetailView": "Aktuelle Ansicht speichern",

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -71,12 +71,14 @@
       "stagingBarText": "Der Shop befindet sich im Staging-Modus.",
       "theme": {
         "changed": "Erscheinungsbild zu \"{theme}\" geändert",
-        "saveError": "Erscheinungsbild konnte nicht gewechselt werden",
-        "names": {
-          "system": "System",
-          "light": "Hell",
-          "dark": "Dunkel"
-        }
+        "saveError": "Erscheinungsbild konnte nicht gewechselt werden"
+      }
+    },
+    "theme": {
+      "names": {
+        "light": "Hell",
+        "dark": "Dunkel",
+        "system": "System"
       }
     },
     "sw-skip-link": {

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -68,7 +68,16 @@
       "notificationLoadingDataErrorMessage": "Error loading data"
     },
     "sw-desktop": {
-      "stagingBarText": "The Shop is in staging mode."
+      "stagingBarText": "The Shop is in staging mode.",
+      "theme": {
+        "changed": "Appearance changed to \"{theme}\"",
+        "saveError": "The appearance could not be changed",
+        "names": {
+          "system": "System",
+          "light": "Light",
+          "dark": "Dark"
+        }
+      }
     },
     "sw-skip-link": {
       "label": "Skip to content"
@@ -1550,6 +1559,10 @@
     "keyboardShortcutSpecialShortcutFocusSearch": "F",
     "functionSpecialShortcutOpenFilters": "Open filters",
     "keyboardShortcutSpecialShortcutOpenFilters": "O F",
+    "functionSpecialShortcutToggleNavigation": "Toggle navigation",
+    "keyboardShortcutSpecialShortcutToggleNavigation": "S",
+    "functionSpecialShortcutCycleTheme": "Switch appearance",
+    "keyboardShortcutSpecialShortcutCycleTheme": "C T",
     "functionSpecialShortcutShortcutListing": "Keyboard shortcuts",
     "keyboardShortcutSpecialShortcutShortcutListing": "Shift-?",
     "functionSpecialShortcutSaveDetailView": "Save current view",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -71,12 +71,14 @@
       "stagingBarText": "The Shop is in staging mode.",
       "theme": {
         "changed": "Appearance changed to \"{theme}\"",
-        "saveError": "The appearance could not be changed",
-        "names": {
-          "system": "System",
-          "light": "Light",
-          "dark": "Dark"
-        }
+        "saveError": "The appearance could not be changed"
+      }
+    },
+    "theme": {
+      "names": {
+        "light": "Light",
+        "dark": "Dark",
+        "system": "System"
       }
     },
     "sw-skip-link": {

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
@@ -50,7 +50,7 @@ export default {
             mediaDefaultFolderId: null,
             showMediaModal: false,
             timezoneOptions: [],
-            userTheme: useTheme().theme.value,
+            userThemeSelection: null,
             userModuleIconColors: useModuleIconColors().enabled.value,
         };
     },
@@ -62,6 +62,10 @@ export default {
     },
 
     computed: {
+        userTheme() {
+            return this.userThemeSelection ?? useTheme().theme.value;
+        },
+
         minSearchTermLength() {
             return Store.get('swProfile').minSearchTermLength;
         },
@@ -163,6 +167,9 @@ export default {
 
     methods: {
         createdComponent() {
+            // Create the theme singleton before the first render — creating it inside a computed would trigger Vue's onMounted warning
+            useTheme();
+
             this.isUserLoading = true;
 
             const languagePromise = new Promise((resolve) => {
@@ -462,7 +469,7 @@ export default {
         },
 
         onChangeUserTheme(userTheme) {
-            this.userTheme = userTheme;
+            this.userThemeSelection = userTheme;
         },
 
         onChangeUserModuleIconColors(userModuleIconColors) {
@@ -472,6 +479,9 @@ export default {
         saveUserTheme() {
             return useTheme()
                 .saveUserTheme(this.userTheme)
+                .then(() => {
+                    this.userThemeSelection = null;
+                })
                 .catch(() => {
                     this.createErrorMessage(this.$t('sw-profile.index.notificationSaveErrorMessage'));
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.spec.js
@@ -446,6 +446,28 @@ describe('src/module/sw-profile/page/sw-profile-index', () => {
             });
         });
 
+        it('should save the theme applied by the appearance shortcut while the page is open', async () => {
+            const wrapper = await createWrapper(
+                ['user.update_profile'],
+                { isSso: true },
+                jest.fn(() => Promise.resolve({})),
+            );
+            await flushPromises();
+
+            await useTheme().saveUserTheme('dark');
+            await flushPromises();
+
+            expect(wrapper.vm.userTheme).toBe('dark');
+
+            await wrapper.find('.sw-profile__save-action').trigger('click');
+            await flushPromises();
+
+            expect(useTheme().theme.value).toBe('dark');
+            expect(Shopware.Service('userConfigService').upsert).toHaveBeenNthCalledWith(2, {
+                [USER_THEME_CONFIG_KEY]: { theme: 'dark' },
+            });
+        });
+
         it('should not persist the theme before saving', async () => {
             const wrapper = await createWrapper();
             await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -61,7 +61,7 @@ export default {
             mediaDefaultFolderId: null,
             showMediaModal: false,
             // Only edited for the own user — the theme select is hidden otherwise.
-            userTheme: useTheme().theme.value,
+            userThemeSelection: null,
         };
     },
 
@@ -72,6 +72,15 @@ export default {
     },
 
     computed: {
+        userTheme: {
+            get() {
+                return this.userThemeSelection ?? useTheme().theme.value;
+            },
+            set(theme) {
+                this.userThemeSelection = theme;
+            },
+        },
+
         ...mapPropertyErrors('user', [
             'firstName',
             'lastName',
@@ -219,6 +228,9 @@ export default {
 
     methods: {
         createdComponent() {
+            // Create the theme singleton before the first render — creating it inside a computed would trigger Vue's onMounted warning
+            useTheme();
+
             Shopware.ExtensionAPI.publishData({
                 id: 'sw-users-permissions-user-detail__currentUser',
                 path: 'currentUser',
@@ -427,6 +439,7 @@ export default {
                     }
                     await this.updateCurrentUser();
                     await useTheme().saveUserTheme(this.userTheme);
+                    this.userThemeSelection = null;
                 }
 
                 this.createdComponent();


### PR DESCRIPTION
### 1. Why is this change necessary?

The reworked navigation and the new appearance setting can only be operated with the mouse. Both are toggled often, so they should have keyboard shortcuts like the rest of the Administration.

### 2. What does this change do, exactly?

- `S` toggles the navigation between collapsed and expanded. Registered on `sw-admin-menu` via the existing `shortcuts` component option; inactive on the mobile viewport, where the menu is an off-canvas.
- `C` `T` cycles the appearance system → light → dark and persists it like the profile settings do. A success snackbar confirms the change, an error snackbar reverts to the previous appearance when saving fails.
- Both shortcuts are listed in the shortcut overview (`?`).
- `shortcut.plugin.js` is hardened so that a single-letter shortcut behaves: navigation sequences such as `g` `s` take precedence over single keys, browser combinations like Cmd/Ctrl+S are ignored, keys typed inside Meteor modals are ignored like in `sw-modal`, and held keys no longer auto-repeat. Side effects: Ctrl+F on Windows/Linux now opens the browser search instead of focusing the admin search, and Escape inside a Meteor modal no longer cancels the detail page behind it.

### 3. Describe each step to reproduce the issue or behaviour.

1. Log in and press `s`. The navigation collapses or expands. Typing `s` in the search field does nothing, `g` `s` opens the settings without toggling.
2. Press `c` then `t`. The appearance switches and a snackbar confirms it. Repeating cycles through system, light and dark; the setting survives a reload.
3. Press `?`. Both shortcuts are listed under general shortcuts.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/meteor/issues/1359 (the snackbar takes focus on mount, visible as a focus ring after the shortcut)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
