### PR TITLE
feat: colour media folders with the module colour setting

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
@@ -1,5 +1,6 @@
 import template from './sw-media-folder-item.html.twig';
 import './sw-media-folder-item.scss';
+import useModuleIconColors from 'src/app/composables/use-module-icon-colors';
 
 const { Application, Mixin, Context } = Shopware;
 const { warn } = Shopware.Utils.debug;
@@ -44,6 +45,7 @@ export default {
             lastDefaultFolderId: null,
             iconConfig: {
                 name: '',
+                color: '',
             },
         };
     },
@@ -67,6 +69,15 @@ export default {
 
         iconName() {
             return 'folder-thumbnail';
+        },
+
+        // Module color of a default folder while the user has module colors enabled
+        folderColor() {
+            return useModuleIconColors().enabled.value && this.iconConfig.color ? this.iconConfig.color : undefined;
+        },
+
+        moduleIconColor() {
+            return this.folderColor ?? 'var(--color-icon-secondary-default)';
         },
 
         assetFilter() {
@@ -113,6 +124,7 @@ export default {
             }
 
             this.iconConfig.name = module.manifest?.icon ?? '';
+            this.iconConfig.color = module.manifest?.color ?? '';
         },
 
         async onChangeName(updatedName, item, endInlineEdit) {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
@@ -20,12 +20,15 @@
         <span
             v-else-if="!!item.defaultFolderId"
         >
-            <sw-media-folder-thumbnail class="sw-media-folder-item__folder-thumbnails" />
+            <sw-media-folder-thumbnail
+                class="sw-media-folder-item__folder-thumbnails"
+                :color="folderColor"
+            />
             <mt-icon
                 v-if="iconConfig.name"
                 class="sw-media-folder-item__folder-thumbnails is--inner"
                 :name="iconConfig.name"
-                color="var(--color-icon-secondary-default)"
+                :color="moduleIconColor"
                 size="12cqw"
             />
         </span>

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
+import useModuleIconColors from 'src/app/composables/use-module-icon-colors';
 
 const { Module } = Shopware;
 
@@ -9,6 +10,7 @@ const { Module } = Shopware;
 const modulesToCreate = new Map();
 modulesToCreate.set('sw-product', {
     icon: 'regular-products',
+    color: '#57D9A3',
     entity: 'product',
 });
 modulesToCreate.set('sw-mail-template', {
@@ -22,6 +24,7 @@ Array.from(modulesToCreate.keys()).forEach((moduleName) => {
 
     Module.register(moduleName, {
         icon: currentModuleValues.icon,
+        color: currentModuleValues.color,
         entity: currentModuleValues.entity,
         routes: {
             index: {
@@ -147,6 +150,13 @@ async function createWrapper(defaultFolderId, privileges = []) {
                     template: '<div><slot></slot></div>',
                 },
                 'sw-text-field': true,
+                'sw-media-folder-thumbnail': {
+                    props: [
+                        'color',
+                        'variant',
+                    ],
+                    template: '<svg class="sw-media-folder-thumbnail"></svg>',
+                },
                 'sw-media-modal-folder-settings': true,
                 'sw-media-modal-folder-dissolve': true,
                 'sw-media-modal-move': true,
@@ -158,6 +168,10 @@ async function createWrapper(defaultFolderId, privileges = []) {
 }
 
 describe('components/media/sw-media-folder-item', () => {
+    afterEach(() => {
+        useModuleIconColors().enabled.value = false;
+    });
+
     it.each([
         [
             'product module',
@@ -189,6 +203,37 @@ describe('components/media/sw-media-folder-item', () => {
         const innerIcon = wrapper.findComponent('.sw-media-folder-item__folder-thumbnails.is--inner');
         expect(innerIcon.props('name')).toBe('regular-products');
         expect(innerIcon.props('color')).toBe('var(--color-icon-secondary-default)');
+        expect(wrapper.findComponent('svg.sw-media-folder-thumbnail').props('color')).toBeUndefined();
+    });
+
+    it('should paint the default folder and its icon in the module color when module colors are enabled', async () => {
+        useModuleIconColors().enabled.value = true;
+        const wrapper = await createWrapper(ID_PRODUCTS_FOLDER);
+        await flushPromises();
+
+        expect(wrapper.findComponent('svg.sw-media-folder-thumbnail').props('color')).toBe('#57D9A3');
+        expect(wrapper.findComponent('.sw-media-folder-item__folder-thumbnails.is--inner').props('color')).toBe('#57D9A3');
+    });
+
+    it('should keep the folder neutral for a module without a color when module colors are enabled', async () => {
+        useModuleIconColors().enabled.value = true;
+        const wrapper = await createWrapper(ID_CONTENT_FOLDER);
+        await flushPromises();
+
+        expect(wrapper.findComponent('svg.sw-media-folder-thumbnail').props('color')).toBeUndefined();
+        expect(wrapper.findComponent('.sw-media-folder-item__folder-thumbnails.is--inner').props('color')).toBe(
+            'var(--color-icon-secondary-default)',
+        );
+    });
+
+    it('should switch the folder color when the user toggles module colors', async () => {
+        const wrapper = await createWrapper(ID_PRODUCTS_FOLDER);
+        await flushPromises();
+
+        useModuleIconColors().enabled.value = true;
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findComponent('svg.sw-media-folder-thumbnail').props('color')).toBe('#57D9A3');
     });
 
     it('should not be able to delete', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/index.ts
@@ -11,7 +11,7 @@ import './sw-media-folder-thumbnail.scss';
 /**
  * @private
  */
-export default {
+export default Shopware.Component.wrapComponentConfig({
     template,
 
     props: {
@@ -27,5 +27,22 @@ export default {
                 ].includes(value);
             },
         },
+
+        // Strokes the default variant in this color with a tinted fill, back variants ignore it
+        color: {
+            type: String,
+            required: false,
+            default: null,
+        },
     },
-};
+
+    computed: {
+        isColored(): boolean {
+            return !!this.color;
+        },
+
+        colorStyle(): Record<string, string> | null {
+            return this.isColored ? { '--sw-media-folder-thumbnail-color': this.color } : null;
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.html.twig
@@ -44,6 +44,8 @@
 <svg
     v-else
     class="sw-media-folder-thumbnail"
+    :class="{ 'is--colored': isColored }"
+    :style="colorStyle"
     viewBox="0 0 65 56"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.scss
@@ -22,6 +22,6 @@
 
 // Mixed into the page background so the tint follows the theme
 .sw-media-folder-thumbnail.is--colored path {
-    fill: color-mix(in srgb, var(--sw-media-folder-thumbnail-color) 12%, var(--color-background-primary-default));
+    fill: color-mix(in srgb, var(--sw-media-folder-thumbnail-color) 12%, var(--color-background-secondary-default));
     stroke: var(--sw-media-folder-thumbnail-color);
 }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.scss
@@ -19,3 +19,9 @@
         aspect-ratio: 32 / 28;
     }
 }
+
+// Mixed into the page background so the tint follows the theme
+.sw-media-folder-thumbnail.is--colored path {
+    fill: color-mix(in srgb, var(--sw-media-folder-thumbnail-color) 12%, var(--color-background-primary-default));
+    stroke: var(--sw-media-folder-thumbnail-color);
+}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-thumbnail/sw-media-folder-thumbnail.spec.ts
@@ -44,8 +44,39 @@ describe('components/media/sw-media-folder-thumbnail', () => {
         expect(svg.findAll('path')[1].attributes('fill')).toBe('var(--color-icon-brand-default)');
     });
 
+    it('should paint the default folder in the given color', async () => {
+        const wrapper = await createWrapper({ color: '#57D9A3' });
+        const svg = wrapper.find('svg.sw-media-folder-thumbnail');
+
+        expect(svg.classes()).toContain('is--colored');
+        expect(svg.attributes('style')).toContain('--sw-media-folder-thumbnail-color: #57D9A3');
+    });
+
+    it('should stay neutral without a color', async () => {
+        const wrapper = await createWrapper();
+        const svg = wrapper.find('svg.sw-media-folder-thumbnail');
+
+        expect(svg.classes()).not.toContain('is--colored');
+        expect(svg.attributes('style')).toBeUndefined();
+    });
+
+    it.each([
+        'back',
+        'back-breadcrumb',
+    ])('should ignore the color on the %s variant', async (variant) => {
+        const wrapper = await createWrapper({ variant, color: '#57D9A3' });
+        const svg = wrapper.find('svg.sw-media-folder-thumbnail');
+
+        expect(svg.classes()).not.toContain('is--colored');
+        expect(svg.findAll('path')[0].attributes('fill')).toBe('var(--color-background-brand-default)');
+    });
+
     it('should reject unknown variants', () => {
-        const variantProp = swMediaFolderThumbnail.props.variant;
+        const { variant: variantProp } = (
+            swMediaFolderThumbnail as unknown as {
+                props: { variant: { validator: (value: string) => boolean } };
+            }
+        ).props;
 
         expect(variantProp.validator('default')).toBe(true);
         expect(variantProp.validator('back')).toBe(true);

--- a/src/Administration/Resources/app/administration/src/app/composables/use-module-icon-colors.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-module-icon-colors.ts
@@ -47,8 +47,8 @@ async function saveUserModuleIconColors(next: boolean): Promise<void> {
 
 /**
  * App-wide singleton for the opt-in preference that paints the admin menu and search bar
- * icons in the color of their module (`Module.register({ color })`). The state lives at
- * module scope, so it is shared by every consumer without a store registration.
+ * icons and the default media folders in the color of their module (`Module.register({ color })`).
+ * The state lives at module scope, so it is shared by every consumer without a store registration.
  *
  * @private
  */


### PR DESCRIPTION
Relates to: https://github.com/shopware/shopware/pull/18798

### 1. Why is this change necessary?

#18798 replaced the static media folder SVGs with the inline `sw-media-folder-thumbnail` component and dropped the per-module folder colors. The profile setting "Module colours" already lets users opt into module colors for the admin menu and search bar. Media folders should follow the same preference.

### 2. What does this change do, exactly?

**Colored media folders**
- Adds an optional `color` prop to the private `sw-media-folder-thumbnail`. The default variant is stroked in that color and filled with a `color-mix` tint into the page background, so it follows the theme. Back variants ignore it.
- `sw-media-folder-item` passes the module manifest `color` to the thumbnail and the overlaid module icon while `useModuleIconColors().enabled` is true. Folders without a module color stay neutral.

The module colours are aligned separately in https://github.com/shopware/shopware/pull/20103.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Media module. All folders render neutral.
2. In your profile, set "Module colours" to "Coloured" and return to Media.
3. Default folders like Product Media or Promotion Media take their module color; custom folders stay neutral.
4. Switch the admin theme. Folder fills and strokes follow it.

### 4. Screenshots

<img width="1370" height="1330" alt="Bildschirmfoto 2026-09-04 um 12 21 05" src="https://github.com/user-attachments/assets/527d2da6-e4a4-458e-a773-e7a1f7314f82" />
<img width="1933" height="1329" alt="Bildschirmfoto 2026-09-04 um 12 21 15" src="https://github.com/user-attachments/assets/b95d7caa-62b0-4e4c-a132-1480f9c64190" />


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
