### PR TITLE
fix(inventory): skip product export validation in batch mode (#19635)

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -268,9 +268,13 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             return null;
         }
 
+        $errors = $exportBehavior->batchMode() && !$exportBehavior->generateHeader() && !$exportBehavior->generateFooter()
+            ? []
+            : $this->productExportValidator->validate($productExport, $encodingEvent->getEncodedContent());
+
         return new ProductExportResult(
             $encodingEvent->getEncodedContent(),
-            $this->productExportValidator->validate($productExport, $encodingEvent->getEncodedContent()),
+            $errors,
             offset: $iterator->getOffset(),
             hasNextBatch: $exportBehavior->batchMode() && $fetched === $this->readBufferSize
         );

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -738,7 +738,7 @@ class ProductExportGeneratorTest extends TestCase
             ->with($productExport, $context, static::callback(static fn (array $data): bool => $data['product'] === $simple))
             ->willReturn(" \n\t ");
         $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->with('', '', $context)->willReturn('');
-        $this->productExportValidator->expects($this->once())->method('validate')->with($productExport, '')->willReturn([]);
+        $this->productExportValidator->expects($this->never())->method('validate');
         $this->connection->expects($this->once())->method('delete');
         $this->breadcrumbBuilder->expects($this->never())->method('getProductSeoCategory');
 
@@ -746,6 +746,38 @@ class ProductExportGeneratorTest extends TestCase
 
         static::assertNotNull($result);
         static::assertSame('', $result->getContent());
+        static::assertSame([], $result->getErrors());
+    }
+
+    public function testGenerateValidatesBatchModeWhenFullDocumentIsGenerated(): void
+    {
+        $productExport = $this->getProductExportEntity();
+        $productExport->setEncoding(ProductExportEntity::ENCODING_UTF8);
+        $productExport->setFileFormat(ProductExportEntity::FILE_FORMAT_CSV);
+        $productExport->setBodyTemplate('{{ product.id }}');
+        $productExport->setIncludeVariants(false);
+
+        $context = $this->createSalesChannelContext();
+        $product = $this->createProduct('product-id');
+
+        $this->prepareGeneratorDependencies($context, '{{ product.id }}');
+        $this->productRepository->expects($this->once())
+            ->method('search')
+            ->willReturn($this->createProductSearchResult($product, $context));
+
+        $this->productExportRender->expects($this->once())->method('renderHeader')->willReturn('header');
+        $this->productExportRender->expects($this->once())->method('renderBody')->willReturn('product');
+        $this->productExportRender->expects($this->once())->method('renderFooter')->willReturn('footer');
+        $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->with('headerproductfooter', '', $context)->willReturnArgument(0);
+        $this->productExportValidator->expects($this->once())->method('validate')->with($productExport, 'headerproductfooter')->willReturn([]);
+        $this->connection->expects($this->once())->method('delete');
+        $this->breadcrumbBuilder->expects($this->never())->method('getProductSeoCategory');
+
+        $result = $this->createGenerator()->generate($productExport, new ExportBehavior(false, false, true));
+
+        static::assertNotNull($result);
+        static::assertSame('headerproductfooter', $result->getContent());
+        static::assertSame([], $result->getErrors());
     }
 
     public function testGenerateBatchModeSignalsNextBatchWithKeysetCursor(): void
@@ -770,7 +802,7 @@ class ProductExportGeneratorTest extends TestCase
 
         $this->productExportRender->expects($this->once())->method('renderBody')->willReturn('product');
         $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->willReturnArgument(0);
-        $this->productExportValidator->expects($this->once())->method('validate')->willReturn([]);
+        $this->productExportValidator->expects($this->never())->method('validate');
         $this->connection->expects($this->once())->method('delete');
         $this->breadcrumbBuilder->expects($this->never())->method('getProductSeoCategory');
 
@@ -779,6 +811,7 @@ class ProductExportGeneratorTest extends TestCase
         static::assertNotNull($result);
         static::assertTrue($result->hasNextBatch());
         static::assertSame(42, $result->getOffset());
+        static::assertSame([], $result->getErrors());
     }
 
     public function testGenerateBatchModeStopsWhenBufferIsNotFilled(): void
@@ -802,7 +835,7 @@ class ProductExportGeneratorTest extends TestCase
 
         $this->productExportRender->expects($this->never())->method('renderBody');
         $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->willReturnArgument(0);
-        $this->productExportValidator->expects($this->once())->method('validate')->willReturn([]);
+        $this->productExportValidator->expects($this->never())->method('validate');
         $this->connection->expects($this->once())->method('delete');
         $this->breadcrumbBuilder->expects($this->never())->method('getProductSeoCategory');
 
@@ -811,6 +844,7 @@ class ProductExportGeneratorTest extends TestCase
         static::assertNotNull($result);
         static::assertFalse($result->hasNextBatch());
         static::assertSame(41, $result->getOffset());
+        static::assertSame([], $result->getErrors());
     }
 
     public function testGeneratePopulatesSeoCategoryForExportedProducts(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Product exports generated in batch mode validate each partial batch although the generated content is incomplete by design. For document formats such as XML, that validation fails because the fragment is not a complete document; its result is discarded during batch generation.

### 2. What does this change do, exactly?

The product export generator skips validation for partial batch fragments generated without header and footer and returns an empty error list for those batch results. Full export documents, including Admin preview and validate requests that use batch mode for preview sizing, still validate the generated content as before.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure an XML product export that is generated in batch mode.
2. Generate an export batch.
3. The generated batch content is validated as if it were a complete export document.
4. The validation fails for incomplete batch content, and the failing validation result is discarded.

### 4. Please link to the relevant issues (if any).

- fixes #19635

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
