### PR TITLE
fix(checkout): reject ordering a cart that was already consumed

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -209,6 +209,12 @@ Two consequences for operators:
 
 Product breadcrumbs are generated again when the product's main category — or its only assigned category — is configured with "Hide in navigation". The flag only removes a category from the navigation menus; it no longer prevents the category from serving as the breadcrumb source on product detail pages, in `GET /store-api/breadcrumb/{id}`, and in product exports. When the breadcrumb category is determined automatically from several assigned categories, visible categories are still preferred over hidden ones. Inactive categories remain excluded.
 
+### An already ordered cart cannot be ordered a second time
+
+`POST /store-api/checkout/order` re-checks inside its cart lock whether the cart is still stored, and answers `404 CHECKOUT__CART_TOKEN_NOT_FOUND` when it is not. Two overlapping submits of the same cart — two browser tabs on the checkout confirm page, a retried request — previously produced two orders whenever the second request had loaded its cart before the first one deleted it, because that stale cart still passed the cart hash check.
+
+`Shopware\Core\Checkout\Cart\AbstractCartPersister` gained `exists()` for this. The abstract class carries a default implementation that delegates to the decorated persister, so existing implementations keep working, but the method becomes abstract with 6.8.0.0 — implement it in every cart persister of yours before upgrading.
+
 ## API
 
 ### Store API currency headers validate sales channel availability

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -314,6 +314,19 @@ Previously, these routes could return unrelated records or fail because the unde
 
 <details>
 
+## `AbstractCartPersister::exists()` is abstract
+
+`Shopware\Core\Checkout\Cart\AbstractCartPersister::exists()` was introduced in 6.7.15.0 with a default implementation that delegated to the decorated persister. It is abstract now, so every cart persister declares it itself:
+
+```php
+public function exists(string $token, SalesChannelContext $context): bool
+{
+    return $this->getDecorated()->exists($token, $context);
+}
+```
+
+Answer it from the storage a persister that does not decorate another one owns. Placing an order rejects a cart token that `exists()` reports as gone, so a persister that always answers `true` reintroduces duplicate orders on overlapping checkout submits.
+
 ## `AbstractCartLoadRoute::load()` takes the cart
 
 `Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute::load()` takes the cart to respond with as an optional third parameter. Call sites are unaffected, but decorations had to add the parameter to their own `load()` declaration and forward it, otherwise the declaration is no longer compatible:

--- a/src/Core/Checkout/Cart/AbstractCartPersister.php
+++ b/src/Core/Checkout/Cart/AbstractCartPersister.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Checkout\Cart;
 use Shopware\Core\Checkout\Cart\Delivery\DeliveryProcessor;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\CheckoutPermissions;
+use Shopware\Core\Framework\Deprecation\BCChange\BecomesAbstract;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -19,6 +21,20 @@ abstract class AbstractCartPersister
     abstract public function getDecorated(): AbstractCartPersister;
 
     abstract public function load(string $token, SalesChannelContext $context): Cart;
+
+    /**
+     * Checks if a cart is stored for the given token, without loading and deserializing it.
+     */
+    #[BecomesAbstract(version: 'v6.8.0')]
+    public function exists(string $token, SalesChannelContext $context): bool
+    {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'AbstractCartPersister::exists() will become abstract in v6.8.0.0. Please implement it in your cart persister class.'
+        );
+
+        return $this->getDecorated()->exists($token, $context);
+    }
 
     abstract public function save(Cart $cart, SalesChannelContext $context): void;
 

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -72,6 +72,15 @@ class CartPersister extends AbstractCartPersister
         return $cart;
     }
 
+    public function exists(string $token, SalesChannelContext $context): bool
+    {
+        return (bool) $this->connection->fetchOne(
+            '#cart-persister::exists
+            SELECT 1 FROM cart WHERE `token` = :token',
+            ['token' => $token]
+        );
+    }
+
     /**
      * @throws InvalidUuidException
      */

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -92,6 +92,11 @@ class RedisCartPersister extends AbstractCartPersister
         return $cart;
     }
 
+    public function exists(string $token, SalesChannelContext $context): bool
+    {
+        return (bool) $this->redis->exists(self::PREFIX . $token);
+    }
+
     public function save(Cart $cart, SalesChannelContext $context): void
     {
         $shouldPersist = $this->shouldPersist($cart);

--- a/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
@@ -83,6 +83,10 @@ class CartOrderRoute extends AbstractCartOrderRoute
         }
 
         return $this->cartLocker->locked($context, function () use ($cart, $context, $data) {
+            if ($cart->isPersisted() && !$this->cartPersister->exists($cart->getToken(), $context)) {
+                throw CartException::tokenNotFound($cart->getToken());
+            }
+
             // we use this state in stock updater class, to prevent duplicate available stock updates
             $context->addState('checkout-order-route');
 

--- a/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
+++ b/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
@@ -183,6 +183,29 @@ class CartPersisterTest extends TestCase
         static::assertFalse($token);
     }
 
+    public function testExistsReflectsStoredCart(): void
+    {
+        $cart = new Cart('existing');
+        $cart->add(
+            (new LineItem('A', 'test'))
+                ->setPrice(new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()))
+                ->setLabel('test')
+        );
+
+        $persister = static::getContainer()->get(CartPersister::class);
+        $context = $this->getSalesChannelContext($cart->getToken());
+
+        static::assertFalse($persister->exists($cart->getToken(), $context));
+
+        $persister->save($cart, $context);
+
+        static::assertTrue($persister->exists($cart->getToken(), $context));
+
+        $persister->delete($cart->getToken(), $context);
+
+        static::assertFalse($persister->exists($cart->getToken(), $context));
+    }
+
     public function testRetokenizedCartIsInsertedUnderTheNewToken(): void
     {
         $cart = new Cart(Uuid::randomHex());

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
@@ -5,9 +5,11 @@ namespace Shopware\Tests\Integration\Core\Checkout\Cart\SalesChannel;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\CartLocker;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedCriteriaEvent;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
@@ -25,7 +27,10 @@ use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehavi
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 use Shopware\Core\Test\Integration\PaymentHandler\TestPaymentHandler;
@@ -540,6 +545,27 @@ class CartOrderRouteTest extends TestCase
             // Release lock after test
             $lock->release();
         }
+    }
+
+    public function testOrderIsRejectedWhenTheCartWasAlreadyOrdered(): void
+    {
+        $token = $this->createCustomerAndLogin();
+        $this->addProductToCart();
+
+        $context = static::getContainer()->get(SalesChannelContextService::class)
+            ->get(new SalesChannelContextServiceParameters($this->ids->get('sales-channel'), $token));
+
+        $cartService = static::getContainer()->get(CartService::class);
+
+        // both requests read the cart before either of them places an order
+        $cart = $cartService->getCart($token, $context, caching: false);
+        $staleCart = $cartService->getCart($token, $context, caching: false);
+
+        $cartService->order($cart, $context, new RequestDataBag());
+
+        $this->expectExceptionObject(CartException::tokenNotFound($token));
+
+        $cartService->order($staleCart, $context, new RequestDataBag());
     }
 
     protected function catchEvent(string $eventName, ?Event &$eventResult): void

--- a/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
@@ -224,6 +224,30 @@ class RedisCartPersisterTest extends TestCase
         static::assertFalse($redis->exists(RedisCartPersister::PREFIX . $token));
     }
 
+    public function testExistsReflectsStoredCart(): void
+    {
+        $token = Uuid::randomHex();
+
+        $dispatcher = static::createStub(EventDispatcher::class);
+        $cartSerializationCleaner = static::createStub(CartSerializationCleaner::class);
+
+        $redis = new RedisStub();
+
+        $persister = new RedisCartPersister($redis, $dispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'), 90);
+
+        $context = static::createStub(SalesChannelContext::class);
+
+        static::assertFalse($persister->exists($token, $context));
+
+        $redis->set(RedisCartPersister::PREFIX . $token, 'test');
+
+        static::assertTrue($persister->exists($token, $context));
+
+        $persister->delete($token, $context);
+
+        static::assertFalse($persister->exists($token, $context));
+    }
+
     public function testLoadWithDifferentCompression(): void
     {
         $token = Uuid::randomHex();

--- a/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
@@ -333,6 +333,79 @@ class CartOrderRouteTest extends TestCase
         $this->buildRoute(cartLocker: $cartLocker)->order($cart, $this->context, $data);
     }
 
+    public function testOrderIsPlacedWhenTheStoredCartStillExists(): void
+    {
+        $cart = new Cart('token');
+        $cart->setPersisted(true);
+        $cart->add(new LineItem('id', 'type'));
+
+        $calculatedCart = new Cart('calculated');
+
+        $cartCalculator = $this->createMock(CartCalculator::class);
+        $cartCalculator->expects($this->once())
+            ->method('calculate')
+            ->with($cart, $this->context)
+            ->willReturn($calculatedCart);
+
+        $orderId = 'order-id';
+
+        $orderPersister = $this->createMock(OrderPersister::class);
+        $orderPersister->expects($this->once())
+            ->method('persist')
+            ->with($calculatedCart, $this->context)
+            ->willReturn($orderId);
+
+        $orderEntity = new OrderEntity();
+        $orderEntity->setId($orderId);
+
+        $searchResult = static::createStub(EntitySearchResult::class);
+        $searchResult->method('getEntities')->willReturn(new OrderCollection([$orderEntity]));
+
+        $orderRepository = $this->createMock(EntityRepository::class);
+        $orderRepository->expects($this->once())
+            ->method('search')
+            ->willReturn($searchResult);
+
+        $cartPersister = $this->createMock(AbstractCartPersister::class);
+        $cartPersister->expects($this->once())
+            ->method('exists')
+            ->with('token', $this->context)
+            ->willReturn(true);
+
+        $route = $this->buildRoute(
+            cartCalculator: $cartCalculator,
+            orderRepository: $orderRepository,
+            orderPersister: $orderPersister,
+            cartPersister: $cartPersister,
+        );
+
+        $response = $route->order($cart, $this->context, new RequestDataBag());
+
+        static::assertSame($orderEntity, $response->getObject());
+    }
+
+    public function testOrderIsRejectedWhenTheStoredCartWasAlreadyConsumed(): void
+    {
+        $cart = new Cart('token');
+        $cart->setPersisted(true);
+        $cart->add(new LineItem('id', 'type'));
+
+        $cartPersister = $this->createMock(AbstractCartPersister::class);
+        $cartPersister->method('exists')
+            ->with('token', $this->context)
+            ->willReturn(false);
+        $cartPersister->expects($this->never())->method('delete');
+
+        $orderPersister = $this->createMock(OrderPersister::class);
+        $orderPersister->expects($this->never())->method('persist');
+
+        $route = $this->buildRoute(orderPersister: $orderPersister, cartPersister: $cartPersister);
+
+        $this->expectExceptionObject(CartException::tokenNotFound('token'));
+
+        $route->order($cart, $this->context, new RequestDataBag());
+    }
+
     public function testExtensionIsDispatched(): void
     {
         $cart = new Cart('test');
@@ -373,12 +446,13 @@ class CartOrderRouteTest extends TestCase
         ?EventDispatcherInterface $eventDispatcher = null,
         ?CartLocker $cartLocker = null,
         ?ExtensionDispatcher $extensions = null,
+        ?AbstractCartPersister $cartPersister = null,
     ): CartOrderRoute {
         return new CartOrderRoute(
             $cartCalculator ?? $this->cartCalculator,
             $orderRepository ?? $this->orderRepository,
             $orderPersister ?? $this->orderPersister,
-            static::createStub(AbstractCartPersister::class),
+            $cartPersister ?? static::createStub(AbstractCartPersister::class),
             $eventDispatcher ?? $this->eventDispatcher,
             static::createStub(PaymentProcessor::class),
             static::createStub(TaxProviderProcessor::class),


### PR DESCRIPTION
### 1. Why is this change necessary?

Submitting the same cart from two checkout tabs can create two orders. The `CartLocker` added in #9098 only rejects genuinely overlapping requests; it does nothing for the second request that read its cart *before* the first one deleted it and acquires the lock *after* it was released. That snapshot is complete, so the cart hash matches and nothing else in the route asks whether the cart still exists.

The underlying problem is that "is there still a cart to order?" is answered from the request's in-memory snapshot, which is a copy of state the other request has meanwhile destroyed.

### 2. What does this change do, exactly?

Moves that question inside the lock and asks the persister instead of the snapshot: if the cart claims to come from storage but is no longer there, the order is rejected with `CHECKOUT__CART_TOKEN_NOT_FOUND`.

The `isPersisted()` half of the condition is what keeps the check from changing anything else. A cart that never came from storage — an empty one, an in-memory cart built by a service — is not covered by this rule and still falls through to `OrderPersister` and its existing `CHECKOUT__CART_EMPTY`. Only a snapshot that claims a storage entry has to still have one.

`AbstractCartPersister::exists()` is new because the alternative, a second full `load()`, would decompress the payload and re-dispatch `CartLoadedEvent` on the order hot path for a yes/no answer. It ships with a delegating default so current implementations keep working, and is marked `#[BecomesAbstract(version: 'v6.8.0')]` — a persister backed by its own storage is the only thing that can answer this correctly, so guessing `true` on its behalf past 6.8 is not a useful default.

This closes the reported window, not the whole class of duplicates: if `CartLocker`'s 5s TTL expires while a slow request is still placing its order, a second request acquires the lock, finds the cart present, and both proceed. Covering that needs an idempotency key on order creation, which is a schema change and belongs in its own ticket.

### 3. Describe each step to reproduce the issue or behaviour.

Log in, put a product in the cart, open `/checkout/confirm` in two tabs and submit both within the first request's window — before, tab 2 produced a second order. `CartOrderRouteTest::testOrderIsRejectedWhenTheCartWasAlreadyOrdered` is the deterministic equivalent and fails without the fix.

### 4. Please link to the relevant issues (if any).

closes #19943

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
