### PR TITLE
fix(inventory): count grouped listing totals (#14064)

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -161,6 +161,11 @@ public function addSorting(ProductListingCollectSortingEvent $event): void
     $event->getSortings()->add($mySorting);
 }
 ```
+
+### Store API product listing totals count grouped products
+
+`POST /store-api/product-listing/{categoryId}` now returns the number of grouped listing products in `total` for manually assigned categories with product variants. Headless storefronts and other API clients can use the value for pagination without counting ungrouped variants.
+
 ### Adding a product to an existing order applies line item factory decorators
 
 `POST /api/_action/order/{orderId}/product/{productId}` now builds the line item through the `LineItemFactoryRegistry` instead of creating a plain `product` line item directly, so extensions that decorate a `LineItemFactoryInterface` are applied when a product is added to an existing order, the same way they already are in the cart. A decorator that returns a different line item type — or a cart collector that replaces the line item with several others — therefore takes effect in the administration order detail page as well.

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -183,7 +183,7 @@ class ProductListingLoader
 
         $this->addExtensions($clone, $idResult, $productSearchResult, $mapping);
 
-        $result = new EntitySearchResult(ProductDefinition::ENTITY_NAME, $idResult->getTotal(), $productSearchResult->getEntities(), $aggregations, $criteria, $context->getContext());
+        $result = new EntitySearchResult(ProductDefinition::ENTITY_NAME, $this->getTotal($clone, $idResult, $ids, $context), $productSearchResult->getEntities(), $aggregations, $criteria, $context->getContext());
         $result->addState(...$idResult->getStates());
         $result->addExtensions($productSearchResult->getExtensions());
 
@@ -420,6 +420,27 @@ class ProductListingLoader
         }
 
         return !$isSearchRoute;
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    private function getTotal(Criteria $criteria, IdSearchResult $idResult, array $ids, SalesChannelContext $context): int
+    {
+        if ($this->shouldSkipGrouping($criteria) || $criteria->getTotalCountMode() !== Criteria::TOTAL_COUNT_MODE_EXACT || !array_filter($criteria->getGroupFields(), static fn (FieldGrouping $grouping): bool => $grouping->getField() === 'displayGroup')) {
+            return $idResult->getTotal();
+        }
+
+        $limit = $criteria->getLimit();
+        if ($limit === null || \count($ids) < $limit) {
+            return ($criteria->getOffset() ?? 0) + \count($ids);
+        }
+
+        $countCriteria = clone $criteria;
+        $countCriteria->setLimit(1);
+        $countCriteria->setOffset(0);
+
+        return $this->productRepository->searchIds($countCriteria, $context)->getTotal();
     }
 
     /**

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -105,6 +105,7 @@ class ProductListingRouteTest extends TestCase
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame('product_listing', $response['apiAlias']);
+        static::assertSame(6, $response['total']);
         static::assertCount(6, $response['elements']);
         static::assertSame('product', $response['elements'][0]['apiAlias']);
     }
@@ -143,6 +144,7 @@ class ProductListingRouteTest extends TestCase
         $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame('product_listing', $payload['apiAlias']);
         static::assertSame(3, $payload['page']);
+        static::assertSame(6, $payload['total']);
     }
 
     public function testReturnsHttpOkOnFirstPageEvenWhenOnlyOnePageOfResults(): void

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Events\ProductListingResolvePreviewEvent;
 use Shopware\Core\Content\Product\Extension\LoadPreviewExtension;
+use Shopware\Core\Content\Product\Extension\ResolveListingIdsExtension;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
@@ -121,6 +122,180 @@ class ProductListingLoaderTest extends TestCase
 
         static::assertSame(['red-l', 'blue-m'], array_values($result->getEntities()->getIds()));
         static::assertSame(2, $result->getTotal());
+    }
+
+    public function testLoadUsesGroupedPartialPageAsExactTotal(): void
+    {
+        $this->systemConfigService
+            ->expects($this->exactly(3))
+            ->method('getBool')
+            ->willReturnCallback(function (string $key, string $salesChannelId): bool {
+                static::assertSame($this->salesChannelContext->getSalesChannelId(), $salesChannelId);
+
+                return match ($key) {
+                    'core.listing.partialDataLoading' => false,
+                    'core.listing.hideCloseoutProductsWhenOutOfStock' => false,
+                    'core.listing.findBestVariant' => false,
+                    default => throw new \RuntimeException('Unexpected config key ' . $key),
+                };
+            });
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('searchIds')
+            ->willReturnCallback(function (Criteria $criteria): IdSearchResult {
+                return $this->createIdSearchResult($criteria, [
+                    'red-l' => ['score' => 10.0],
+                    'blue-m' => ['score' => 5.0],
+                ], total: 4);
+            });
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('aggregate')
+            ->willReturn(new AggregationResultCollection());
+
+        $this->eventDispatcher->addListener(
+            ExtensionDispatcher::pre(LoadPreviewExtension::NAME),
+            static function (LoadPreviewExtension $extension): void {
+                $extension->result = array_combine($extension->ids, $extension->ids);
+                $extension->stopPropagation();
+            }
+        );
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria): EntitySearchResult {
+                return $this->createProductSearchResult($criteria, ['red-l', 'blue-m']);
+            });
+
+        $criteria = new Criteria();
+        $criteria->setLimit(24);
+        $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
+
+        $result = $this->createLoader()->load($criteria, $this->salesChannelContext);
+
+        static::assertSame(2, $result->getTotal());
+    }
+
+    public function testLoadCountsGroupedFullPage(): void
+    {
+        $this->systemConfigService
+            ->expects($this->exactly(3))
+            ->method('getBool')
+            ->willReturnCallback(function (string $key, string $salesChannelId): bool {
+                static::assertSame($this->salesChannelContext->getSalesChannelId(), $salesChannelId);
+
+                return match ($key) {
+                    'core.listing.partialDataLoading' => false,
+                    'core.listing.hideCloseoutProductsWhenOutOfStock' => false,
+                    'core.listing.findBestVariant' => false,
+                    default => throw new \RuntimeException('Unexpected config key ' . $key),
+                };
+            });
+
+        $this->productRepository
+            ->expects($this->exactly(2))
+            ->method('searchIds')
+            ->willReturnCallback(function (Criteria $criteria): IdSearchResult {
+                if ($criteria->getLimit() === 1) {
+                    static::assertSame(0, $criteria->getOffset());
+
+                    return $this->createIdSearchResult($criteria, [
+                        'red-l' => ['score' => 10.0],
+                    ], total: 3);
+                }
+
+                return $this->createIdSearchResult($criteria, [
+                    'red-l' => ['score' => 10.0],
+                    'blue-m' => ['score' => 5.0],
+                ], total: 4);
+            });
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('aggregate')
+            ->willReturn(new AggregationResultCollection());
+
+        $this->eventDispatcher->addListener(
+            ExtensionDispatcher::pre(LoadPreviewExtension::NAME),
+            static function (LoadPreviewExtension $extension): void {
+                $extension->result = array_combine($extension->ids, $extension->ids);
+                $extension->stopPropagation();
+            }
+        );
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria): EntitySearchResult {
+                return $this->createProductSearchResult($criteria, ['red-l', 'blue-m']);
+            });
+
+        $criteria = new Criteria();
+        $criteria->setLimit(2);
+        $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
+
+        $result = $this->createLoader()->load($criteria, $this->salesChannelContext);
+
+        static::assertSame(3, $result->getTotal());
+    }
+
+    public function testLoadKeepsExtensionTotalWhenGroupingIsSkipped(): void
+    {
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->willReturnMap([
+                ['core.listing.partialDataLoading', $this->salesChannelContext->getSalesChannelId(), false],
+            ]);
+
+        $this->eventDispatcher->addListener(
+            ExtensionDispatcher::pre(ResolveListingIdsExtension::NAME),
+            function (ResolveListingIdsExtension $extension): void {
+                $extension->criteria->resetFilters();
+                $extension->criteria->addGroupField(new FieldGrouping('displayGroup'));
+                $extension->result = $this->createIdSearchResult($extension->criteria, [
+                    'red-l' => ['score' => 10.0],
+                    'blue-m' => ['score' => 5.0],
+                ], total: 7);
+                $extension->stopPropagation();
+            }
+        );
+
+        $this->productRepository
+            ->expects($this->never())
+            ->method('searchIds');
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('aggregate')
+            ->willReturn(new AggregationResultCollection());
+
+        $this->eventDispatcher->addListener(
+            ExtensionDispatcher::pre(LoadPreviewExtension::NAME),
+            static function (LoadPreviewExtension $extension): void {
+                $extension->result = array_combine($extension->ids, $extension->ids);
+                $extension->stopPropagation();
+            }
+        );
+
+        $this->productRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria): EntitySearchResult {
+                return $this->createProductSearchResult($criteria, ['red-l', 'blue-m']);
+            });
+
+        $criteria = new Criteria();
+        $criteria->setLimit(24);
+        $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
+        $criteria->addState(ProductListingLoader::STATE_SKIP_ADD_GROUPING);
+
+        $result = $this->createLoader()->load($criteria, $this->salesChannelContext);
+
+        static::assertSame(7, $result->getTotal());
     }
 
     public function testLoadSkipsGroupingAndPreviewWhenDirectVariantStateIsPresent(): void
@@ -387,7 +562,7 @@ class ProductListingLoaderTest extends TestCase
     /**
      * @param array<string, array<string, mixed>> $ids
      */
-    private function createIdSearchResult(Criteria $criteria, array $ids): IdSearchResult
+    private function createIdSearchResult(Criteria $criteria, array $ids, ?int $total = null): IdSearchResult
     {
         $data = [];
         foreach ($ids as $id => $row) {
@@ -397,7 +572,7 @@ class ProductListingLoaderTest extends TestCase
             ];
         }
 
-        return new IdSearchResult(\count($data), $data, $criteria, $this->salesChannelContext->getContext());
+        return new IdSearchResult($total ?? \count($data), $data, $criteria, $this->salesChannelContext->getContext());
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Product listings with manual category assignments can report the ungrouped variant count as `total`, although the returned listing elements are grouped by `displayGroup`.

This breaks Store API pagination because clients calculate the available pages from an inflated total count.

### 2. What does this change do, exactly?

Product listings derive the exact total from the effective grouped ID criteria. Partial pages derive the total directly from the returned grouped IDs. For full pages, a second grouped ID query determines the exact total. Custom ID resolver extensions without effective grouping keep their own total.

The Store API product listing test asserts the expected grouped total for a manual category listing with variants. Unit tests cover partial grouped pages, full grouped pages, and custom ID resolver totals without effective grouping.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a manual category listing.
2. Assign a product with multiple variants to the category.
3. Request the Store API product listing for that category.
4. Observe that the response contains one grouped listing element for the variant product.
5. Observe that `total` counts the ungrouped variants instead of the grouped listing elements.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #14064

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them