### PR TITLE
fix(administration): category/tags description overlap in de-DE

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
@@ -111,7 +111,6 @@
 
     {% block sw_product_category_form_category_field %}
     <sw-container
-        rows="2em 4em 4em"
         class="sw-product-feature-set-form__description"
     >
         {% block sw_product_category_form_categories_title %}


### PR DESCRIPTION
### 1. Why is this change necessary?

In the Administration's product detail page, the "Categories and tags" section's two description paragraphs overlap when the Administration language is set to German (de-DE), making both lines unreadable.

### 2. What does this change do, exactly?

`sw-product-category-form.html.twig` wrapped the section in an `sw-container` with `rows="2em 4em 4em"`, giving each description paragraph a fixed 56px row. At the default 26px line-height that's exactly two lines - the English copy fits, but the German string for `sw-product.categoryForm.descriptionCategories` wraps to three lines. Since `sw-container` renders with `overflow: visible`, the third line spills into the row below and paints over the tags description.

Removed the fixed row heights so each row sizes to its content - the same way the "Visibility" `sw-container` directly above it (which has no `rows` prop at all) already behaves. `sw-container` defaults `rows` to an empty string when unset, which resolves to `grid-template-rows: ''`, i.e. auto-sized - so this isn't a new sizing behavior, just extending the one already used one section up. No other rule in this component's stylesheet depends on these two rows having a fixed height.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set the Administration language to German (de-DE).
2. Go to Catalogues > Products, open any product's General tab.
3. Scroll to the Assignment card's "Categories and tags" section.
4. The last line of the category description overlaps the first line of the tag description.

### 4. Please link to the relevant issues (if any).

closes #19902

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
