### PR TITLE
fix(administration): allow selecting a customer's language on creation

### DIFF
--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -1675,6 +1675,7 @@
  "sw_customer_base_form_email_field",
  "sw_customer_base_form_first_name_field",
  "sw_customer_base_form_first_salutation_field",
+ "sw_customer_base_form_language_field",
  "sw_customer_base_form_last_name_field",
  "sw_customer_base_form_password_field",
  "sw_customer_base_form_sales_channel_field",

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/index.js
@@ -56,6 +56,16 @@ export default {
         isBusinessAccountType() {
             return this.customer?.accountType === CUSTOMER.ACCOUNT_TYPE_BUSINESS;
         },
+
+        languageCriteria() {
+            const criteria = new Criteria(1, 25);
+
+            if (this.customer?.salesChannelId) {
+                criteria.addFilter(Criteria.equals('salesChannels.id', this.customer.salesChannelId));
+            }
+
+            return criteria;
+        },
     },
 
     watch: {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
@@ -152,6 +152,7 @@
             name="sw-field--customer-languageId"
             class="sw-customer-base-form__language-select"
             entity="language"
+            required
             show-clearable-button
             :label="$t('sw-customer.baseForm.labelLanguage')"
             :placeholder="$t('sw-customer.baseForm.placeholderLanguage')"

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
@@ -145,6 +145,19 @@
             :placeholder="$t('sw-datepicker.date.placeholder')"
         />
         {% endblock %}
+
+        {% block sw_customer_base_form_language_field %}
+        <sw-entity-single-select
+            v-model:value="customer.languageId"
+            name="sw-field--customer-languageId"
+            class="sw-customer-base-form__language-select"
+            entity="language"
+            show-clearable-button
+            :label="$t('sw-customer.baseForm.labelLanguage')"
+            :placeholder="$t('sw-customer.baseForm.placeholderLanguage')"
+            :criteria="languageCriteria"
+        />
+        {% endblock %}
     </sw-container>
 
     {% block sw_customer_base_form_tag_field %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.spec.js
@@ -56,4 +56,37 @@ describe('module/sw-customer/page/sw-customer-base-form', () => {
         const accountTypeSelect = wrapper.find('.sw-customer-base-form__account-type-select');
         expect(accountTypeSelect.exists()).toBeTruthy();
     });
+
+    it('should display the language field', async () => {
+        const wrapper = await createWrapper();
+        const languageSelect = wrapper.find('.sw-customer-base-form__language-select');
+        expect(languageSelect.exists()).toBeTruthy();
+    });
+
+    it('should filter the selectable languages by the selected sales channel', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            customer: {
+                ...customer,
+                salesChannelId: 'salesChannelId1',
+            },
+        });
+
+        const criteria = wrapper.vm.languageCriteria;
+
+        expect(criteria.filters).toContainEqual({
+            type: 'equals',
+            field: 'salesChannels.id',
+            value: 'salesChannelId1',
+        });
+    });
+
+    it('should not filter the selectable languages when no sales channel is selected', async () => {
+        const wrapper = await createWrapper();
+
+        const criteria = wrapper.vm.languageCriteria;
+
+        expect(criteria.filters).toHaveLength(0);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
@@ -92,11 +92,21 @@ export default {
                 }
             });
 
-            this.loadLanguage(salesChannelId).then((languageId) => {
-                if (this.customer) {
+            const currentSalesChannelId = salesChannelId;
+
+            this.loadLanguage(currentSalesChannelId)
+                .then((languageId) => {
+                    if (!this.customer || this.customer.salesChannelId !== currentSalesChannelId) {
+                        return;
+                    }
+
                     this.customer.languageId = languageId || Shopware.Context.api.languageId;
-                }
-            });
+                })
+                .catch(() => {
+                    if (this.customer && this.customer.salesChannelId === currentSalesChannelId) {
+                        this.customer.languageId = Shopware.Context.api.languageId;
+                    }
+                });
         },
 
         'customer.accountType'(value) {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
@@ -91,6 +91,12 @@ export default {
                     this.customer.boundSalesChannelId = salesChannelId;
                 }
             });
+
+            this.loadLanguage(salesChannelId).then((languageId) => {
+                if (this.customer) {
+                    this.customer.languageId = languageId;
+                }
+            });
         },
 
         'customer.accountType'(value) {
@@ -127,6 +133,7 @@ export default {
             this.customer.password = '';
             this.customer.vatIds = [];
             this.customer.salutationId = defaultSalutationId;
+            this.customer.languageId = Shopware.Context.api.languageId;
             this.address.salutationId = defaultSalutationId;
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
@@ -94,7 +94,7 @@ export default {
 
             this.loadLanguage(salesChannelId).then((languageId) => {
                 if (this.customer) {
-                    this.customer.languageId = languageId;
+                    this.customer.languageId = languageId || Shopware.Context.api.languageId;
                 }
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
@@ -198,6 +198,34 @@ describe('module/sw-customer/page/sw-customer-create', () => {
         expect(context.languageId).toEqual(Shopware.Context.api.languageId);
     });
 
+    it('should default the customer language to the API context language', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        expect(wrapper.vm.customer.languageId).toBe(Shopware.Context.api.languageId);
+    });
+
+    it('should update the customer language when the sales channel changes', async () => {
+        const languageRepositorySearchIdsMock = jest.fn(() =>
+            Promise.resolve({
+                total: 1,
+                data: ['salesChannelLanguageId'],
+            }),
+        );
+        const wrapper = await createWrapper({ languageRepositorySearchIdsMock });
+        await flushPromises();
+
+        await wrapper.setData({
+            customer: {
+                ...wrapper.vm.customer,
+                salesChannelId: 'a7921464677a4ef591683d144beecd24',
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.vm.customer.languageId).toBe('salesChannelLanguageId');
+    });
+
     it('should get default salutation is value not specified', async () => {
         const wrapper = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
@@ -226,6 +226,27 @@ describe('module/sw-customer/page/sw-customer-create', () => {
         expect(wrapper.vm.customer.languageId).toBe('salesChannelLanguageId');
     });
 
+    it('should fall back to the API context language when the sales channel has no matching language', async () => {
+        const languageRepositorySearchIdsMock = jest.fn(() =>
+            Promise.resolve({
+                total: 0,
+                data: [],
+            }),
+        );
+        const wrapper = await createWrapper({ languageRepositorySearchIdsMock });
+        await flushPromises();
+
+        await wrapper.setData({
+            customer: {
+                ...wrapper.vm.customer,
+                salesChannelId: 'a7921464677a4ef591683d144beecd24',
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.vm.customer.languageId).toBe(Shopware.Context.api.languageId);
+    });
+
     it('should get default salutation is value not specified', async () => {
         const wrapper = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de.json
@@ -117,6 +117,8 @@
       "placeholderCustomerGroup": "Wähle eine Kundengruppe ...",
       "placeholderSalesChannel": "Wähle einen Verkaufskanal ...",
       "placeholderPaymentMethod": "Wähle eine Zahlungsart ...",
+      "labelLanguage": "Sprache",
+      "placeholderLanguage": "Wähle eine Sprache ...",
       "labelTags": "Tags",
       "placeholderTags": "Wähle Tags aus ..."
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en.json
@@ -117,6 +117,8 @@
       "placeholderCustomerGroup": "Select a customer group...",
       "placeholderSalesChannel": "Select a Sales Channel...",
       "placeholderPaymentMethod": "Select a payment method...",
+      "labelLanguage": "Language",
+      "placeholderLanguage": "Select a language...",
       "labelTags": "Tags",
       "placeholderTags": "Select tags..."
     },


### PR DESCRIPTION
### 1. Why is this change necessary?

Creating a customer manually in the Administration offered no way to set the customer's language. It always fell back to the Sales Channel's default, which is a problem for multilingual Sales Channels where Flow-triggered emails should honour the customer's own language.

### 2. What does this change do, exactly?

Adds a language select to the customer creation form, mirroring the field that already exists when editing an existing customer. The field defaults to the Sales Channel's language and updates when the Sales Channel changes, but stays user-editable so a different language can be chosen. The backend already defaulted the customer's `languageId` to the write context on save, so this is purely a missing UI control, not a backend behaviour change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure a Sales Channel with multiple languages, e.g., German, French and Italian, with German as default.
2. Go to Administration > Customers > Add customer.
3. Select the Sales Channel and note the new Language field lets you pick any of its assigned languages instead of only the Sales Channel default.

### 4. Please link to the relevant issues (if any).

closes #20024

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them