### PR TITLE
Handle mapping conflicts gracefully when creating a language

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -209,6 +209,10 @@ Two consequences for operators:
 
 Product breadcrumbs are generated again when the product's main category — or its only assigned category — is configured with "Hide in navigation". The flag only removes a category from the navigation menus; it no longer prevents the category from serving as the breadcrumb source on product detail pages, in `GET /store-api/breadcrumb/{id}`, and in product exports. When the breadcrumb category is determined automatically from several assigned categories, visible categories are still preferred over hidden ones. Inactive categories remain excluded.
 
+### Creating a language no longer fails on a drifted Elasticsearch/OpenSearch mapping
+
+Creating a language could return an uncaught `500` when an Elasticsearch/OpenSearch-indexed entity's live index mapping had drifted from its current definition, for example a sales channel created after the last full reindex. `LanguageSubscriber` now catches the same known-unresolvable mapping conflicts `IndexMappingUpdater` already handles elsewhere, schedules the affected entity for a reindex instead of throwing, and only logs unexpected errors. The language is created successfully; the delayed reindex is picked up by the next indexing run or a manual `es:index`.
+
 ## API
 
 ### Store API currency headers validate sales channel availability

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -529,6 +529,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ElasticsearchHelper::class),
             service(ElasticsearchRegistry::class),
             service(Client::class),
+            service(AbstractKeyValueStorage::class),
         ])
         ->tag('kernel.event_subscriber');
 

--- a/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
@@ -22,7 +22,7 @@ class IndexMappingUpdater
      * mismatches ("has not been configured in mappings"), because analyzers/normalizers are
      * fixed at index creation and cannot be added to a live index.
      */
-    private const REINDEXABLE_MAPPING_ERRORS = [
+    public const REINDEXABLE_MAPPING_ERRORS = [
         'conflicts with existing mapper:\n\tCannot update parameter',
         'cannot be changed from type',
         'can\'t merge a non object mapping',

--- a/src/Elasticsearch/Product/LanguageSubscriber.php
+++ b/src/Elasticsearch/Product/LanguageSubscriber.php
@@ -3,11 +3,16 @@
 namespace Shopware\Elasticsearch\Product;
 
 use OpenSearch\Client;
+use OpenSearch\Exception\BadRequestHttpException;
+use OpenSearch\Exception\NotFoundHttpException;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
+use Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater;
+use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -21,6 +26,7 @@ class LanguageSubscriber implements EventSubscriberInterface
         private readonly ElasticsearchHelper $elasticsearchHelper,
         private readonly ElasticsearchRegistry $registry,
         private readonly Client $client,
+        private readonly AbstractKeyValueStorage $storage,
     ) {
     }
 
@@ -38,6 +44,15 @@ class LanguageSubscriber implements EventSubscriberInterface
         }
 
         $context = $event->getContext();
+        $entitiesToReindex = $this->storage->get(SystemUpdateListener::CONFIG_KEY, []) ?? [];
+
+        if (\is_string($entitiesToReindex)) {
+            $entitiesToReindex = \json_decode($entitiesToReindex, true);
+        }
+
+        if (!\is_array($entitiesToReindex)) {
+            $entitiesToReindex = [];
+        }
 
         foreach ($event->getResults()->only(EntityWriteResult::OPERATION_INSERT) as $writeResult) {
             foreach ($this->registry->getDefinitions() as $definition) {
@@ -48,13 +63,34 @@ class LanguageSubscriber implements EventSubscriberInterface
                     continue;
                 }
 
-                $this->client->indices()->putMapping([
-                    'index' => $indexName,
-                    'body' => [
-                        'properties' => $definition->getMapping($context)['properties'],
-                    ],
-                ]);
+                try {
+                    $this->client->indices()->putMapping([
+                        'index' => $indexName,
+                        'body' => [
+                            'properties' => $definition->getMapping($context)['properties'],
+                        ],
+                    ]);
+                } catch (BadRequestHttpException $exception) {
+                    $errorMessage = $exception->getMessage();
+
+                    foreach (IndexMappingUpdater::REINDEXABLE_MAPPING_ERRORS as $needle) {
+                        if (str_contains($errorMessage, $needle)) {
+                            $entitiesToReindex[] = $definition->getEntityDefinition()->getEntityName();
+                            $exception = ElasticsearchProductException::cannotChangeFieldType($exception);
+
+                            break;
+                        }
+                    }
+
+                    $this->elasticsearchHelper->logAndThrowException($exception);
+                } catch (NotFoundHttpException $exception) {
+                    $this->elasticsearchHelper->logAndThrowException($exception);
+                }
             }
+        }
+
+        if ($entitiesToReindex !== []) {
+            $this->storage->set(SystemUpdateListener::CONFIG_KEY, \array_values(\array_unique($entitiesToReindex)));
         }
     }
 }

--- a/tests/unit/Elasticsearch/Product/LanguageSubscriberTest.php
+++ b/tests/unit/Elasticsearch/Product/LanguageSubscriberTest.php
@@ -20,6 +20,7 @@ use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
 use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
+use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 use Shopware\Elasticsearch\Product\LanguageSubscriber;
 
 /**

--- a/tests/unit/Elasticsearch/Product/LanguageSubscriberTest.php
+++ b/tests/unit/Elasticsearch/Product/LanguageSubscriberTest.php
@@ -3,11 +3,13 @@
 namespace Shopware\Tests\Unit\Elasticsearch\Product;
 
 use OpenSearch\Client;
+use OpenSearch\Exception\BadRequestHttpException;
 use OpenSearch\Namespaces\IndicesNamespace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
@@ -16,6 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
+use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
 use Shopware\Elasticsearch\Product\LanguageSubscriber;
 
@@ -42,6 +45,7 @@ class LanguageSubscriberTest extends TestCase
             $esHelper,
             static::createStub(ElasticsearchRegistry::class),
             static::createStub(Client::class),
+            static::createStub(AbstractKeyValueStorage::class),
         );
 
         $event = $this->createMock(EntityWrittenEvent::class);
@@ -63,6 +67,7 @@ class LanguageSubscriberTest extends TestCase
             $esHelper,
             static::createStub(ElasticsearchRegistry::class),
             static::createStub(Client::class),
+            static::createStub(AbstractKeyValueStorage::class),
         );
 
         $event = $this->createMock(EntityWrittenEvent::class);
@@ -86,6 +91,7 @@ class LanguageSubscriberTest extends TestCase
             $esHelper,
             $registry,
             static::createStub(Client::class),
+            static::createStub(AbstractKeyValueStorage::class),
         );
 
         $event = $this->createMock(EntityWrittenEvent::class);
@@ -118,6 +124,7 @@ class LanguageSubscriberTest extends TestCase
             $esHelper,
             $registry,
             $client,
+            static::createStub(AbstractKeyValueStorage::class),
         );
 
         $event = $this->createMock(EntityWrittenEvent::class);
@@ -166,12 +173,82 @@ class LanguageSubscriberTest extends TestCase
             $esHelper,
             $registry,
             $client,
+            static::createStub(AbstractKeyValueStorage::class),
         );
 
         $event = $this->createMock(EntityWrittenEvent::class);
         $event
             ->expects($this->once())
             ->method('getResults')->willReturn(new EntityWriteResultCollection([$writeResult]));
+
+        $subscriber->onLanguageWritten($event);
+    }
+
+    public function testOnLanguageWrittenSchedulesReindexForReindexableMappingError(): void
+    {
+        $esHelper = $this->createMock(ElasticsearchHelper::class);
+        $esHelper->expects($this->once())->method('allowIndexing')->willReturn(true);
+        $esHelper->expects($this->once())->method('getIndexName')->willReturn('sw_product');
+        $esHelper->expects($this->once())->method('logAndThrowException')->with(
+            static::callback(static function (ElasticsearchProductException $exception): bool {
+                return $exception->getMessage() === 'One or more fields already exist in the index with different types. Please reset the index and rebuild it.';
+            }),
+        )->willReturn(false);
+
+        $writeResult = new EntityWriteResult(Uuid::randomHex(), [], LanguageDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_INSERT);
+        $esProductDefinition = $this->createMock(ElasticsearchProductDefinition::class);
+        $esProductDefinition->expects($this->exactly(2))->method('getEntityDefinition')->willReturn(new ProductDefinition());
+        $esProductDefinition->expects($this->once())->method('getMapping')->willReturn(['properties' => []]);
+        $registry = new ElasticsearchRegistry([$esProductDefinition]);
+
+        $client = static::createStub(Client::class);
+        $namespace = $this->createMock(IndicesNamespace::class);
+        $namespace->expects($this->once())->method('exists')->with(['index' => 'sw_product'])->willReturn(true);
+        $namespace->expects($this->once())->method('putMapping')->willThrowException(
+            new BadRequestHttpException('mapper [field] cannot be changed from type [text] to [keyword]'),
+        );
+        $client->method('indices')->willReturn($namespace);
+
+        $storage = $this->createMock(AbstractKeyValueStorage::class);
+        $storage->expects($this->once())->method('get')->with(SystemUpdateListener::CONFIG_KEY, [])->willReturn([]);
+        $storage->expects($this->once())->method('set')->with(SystemUpdateListener::CONFIG_KEY, [ProductDefinition::ENTITY_NAME]);
+
+        $subscriber = new LanguageSubscriber($esHelper, $registry, $client, $storage);
+
+        $event = $this->createMock(EntityWrittenEvent::class);
+        $event->expects($this->once())->method('getResults')->willReturn(new EntityWriteResultCollection([$writeResult]));
+
+        $subscriber->onLanguageWritten($event);
+    }
+
+    public function testOnLanguageWrittenDoesNotScheduleReindexForNonReindexableMappingError(): void
+    {
+        $exception = new BadRequestHttpException('unrelated mapping error');
+        $esHelper = $this->createMock(ElasticsearchHelper::class);
+        $esHelper->expects($this->once())->method('allowIndexing')->willReturn(true);
+        $esHelper->expects($this->once())->method('getIndexName')->willReturn('sw_product');
+        $esHelper->expects($this->once())->method('logAndThrowException')->with($exception)->willReturn(false);
+
+        $writeResult = new EntityWriteResult(Uuid::randomHex(), [], LanguageDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_INSERT);
+        $esProductDefinition = $this->createMock(ElasticsearchProductDefinition::class);
+        $esProductDefinition->expects($this->once())->method('getEntityDefinition')->willReturn(new ProductDefinition());
+        $esProductDefinition->expects($this->once())->method('getMapping')->willReturn(['properties' => []]);
+        $registry = new ElasticsearchRegistry([$esProductDefinition]);
+
+        $client = static::createStub(Client::class);
+        $namespace = $this->createMock(IndicesNamespace::class);
+        $namespace->expects($this->once())->method('exists')->with(['index' => 'sw_product'])->willReturn(true);
+        $namespace->expects($this->once())->method('putMapping')->willThrowException($exception);
+        $client->method('indices')->willReturn($namespace);
+
+        $storage = $this->createMock(AbstractKeyValueStorage::class);
+        $storage->expects($this->once())->method('get')->with(SystemUpdateListener::CONFIG_KEY, [])->willReturn([]);
+        $storage->expects($this->never())->method('set');
+
+        $subscriber = new LanguageSubscriber($esHelper, $registry, $client, $storage);
+
+        $event = $this->createMock(EntityWrittenEvent::class);
+        $event->expects($this->once())->method('getResults')->willReturn(new EntityWriteResultCollection([$writeResult]));
 
         $subscriber->onLanguageWritten($event);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Creating a language fails with an uncaught 500 whenever any Elasticsearch/OpenSearch-indexed entity's live index mapping has drifted from what `getMapping()` produces today - for example a sales channel created after the last full reindex, or a per-language analyzer already set by an earlier language. `LanguageSubscriber::onLanguageWritten()` calls `putMapping()` with no error handling, so OpenSearch rejecting the conflicting fields propagates straight to the HTTP response, even though the language row was already committed to the database by that point.

### 2. What does this change do, exactly?

`IndexMappingUpdater::update()` already solves this exact problem one layer over: it catches `BadRequestHttpException`/`NotFoundHttpException`, matches the message against `REINDEXABLE_MAPPING_ERRORS`, schedules the entity for a reindex via `SystemUpdateListener::CONFIG_KEY` when it's one of those known-unresolvable-on-a-live-index errors, and otherwise logs rather than throwing (outside test/throw-exception mode) via `ElasticsearchHelper::logAndThrowException()`.

Applied the same handling to `LanguageSubscriber`'s `putMapping` call, reusing `IndexMappingUpdater::REINDEXABLE_MAPPING_ERRORS` (made `public` - no other change to that class) instead of duplicating the list. Left the existing per-definition `indices()->exists()` check and loop structure as-is; this only wraps the `putMapping` call itself.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have an Elasticsearch/OpenSearch-indexed entity whose live index mapping has drifted from the current `getMapping()` output (e.g. a sales channel added after the index was built, so its `visibility_<id>` field only exists via a dynamic template with a different type than the explicit mapping declares).
2. Create a new language in the Administration.
3. The request returns a 500 with the raw OpenSearch conflict error, even though the language row is already persisted.

### 4. Please link to the relevant issues (if any).

closes #20098

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
