### PR TITLE
ci: read the pull request live in the milestone label check

### DIFF
--- a/.github/bin/js/milestone-label.test.ts
+++ b/.github/bin/js/milestone-label.test.ts
@@ -175,7 +175,7 @@ function mergeGroupToolkit(
                                 throw new Error(`unexpected pulls.get for #${pull_number}`);
                             }
 
-                            return { data: { number: pull_number, draft: pull.draft ?? false, base: { ref: pull.base }, labels: pull.labels.map((name) => ({ name })) } };
+                            return { data: { number: pull_number, draft: pull.draft ?? false, base: { ref: pull.base }, head: { sha: `head-${pull_number}` }, labels: pull.labels.map((name) => ({ name })) } };
                         },
                     },
                     repos: {
@@ -212,9 +212,17 @@ function mergeGroupToolkit(
     };
 }
 
-/** Toolkit stub for the single pull-request path (pull_request_target / merge_group's sibling). */
-function pullRequestToolkit(eventName: string, pull: { base: string; labels: string[]; draft?: boolean; sha?: string }) {
-    const statuses: { state: string; description: string }[] = [];
+/**
+ * Toolkit stub for the single pull-request path (pull_request_target / merge_group's sibling).
+ * `pull` is the state the API reports, `stale` what the event payload still claims — they
+ * diverge whenever a label lands after the event fired, or the run is a re-run.
+ */
+function pullRequestToolkit(
+    eventName: string,
+    pull: { base: string; labels: string[]; draft?: boolean; sha?: string },
+    stale: { base?: string; labels?: string[]; draft?: boolean; sha?: string } = {},
+) {
+    const statuses: { state: string; description: string; sha: string }[] = [];
 
     return {
         statuses,
@@ -224,10 +232,21 @@ function pullRequestToolkit(eventName: string, pull: { base: string; labels: str
                     repository: { refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: VERSION_BRANCHES.map((name) => ({ name })) } },
                 }),
                 rest: {
+                    pulls: {
+                        get: async ({ pull_number }: { pull_number: number }) => ({
+                            data: {
+                                number: pull_number,
+                                draft: pull.draft ?? false,
+                                base: { ref: pull.base },
+                                head: { sha: pull.sha ?? 'cccc' },
+                                labels: pull.labels.map((name) => ({ name })),
+                            },
+                        }),
+                    },
                     repos: {
-                        createCommitStatus: async ({ state, description, context: ctx }: { state: string; description: string; context: string }) => {
+                        createCommitStatus: async ({ state, description, sha, context: ctx }: { state: string; description: string; sha: string; context: string }) => {
                             assert.equal(ctx, STATUS_CONTEXT);
-                            statuses.push({ state, description });
+                            statuses.push({ state, description, sha });
 
                             return {};
                         },
@@ -246,7 +265,13 @@ function pullRequestToolkit(eventName: string, pull: { base: string; labels: str
                 repo: { owner: 'shopware', repo: 'shopware' },
                 payload: {
                     repository: { default_branch: 'trunk' },
-                    pull_request: { number: 1, base: { ref: pull.base }, head: { sha: pull.sha ?? 'cccc' }, draft: pull.draft ?? false, labels: pull.labels.map((name) => ({ name })) },
+                    pull_request: {
+                        number: 1,
+                        base: { ref: stale.base ?? pull.base },
+                        head: { sha: stale.sha ?? pull.sha ?? 'cccc' },
+                        draft: stale.draft ?? pull.draft ?? false,
+                        labels: (stale.labels ?? pull.labels).map((name) => ({ name })),
+                    },
                 },
             },
         },
@@ -264,6 +289,33 @@ for (const eventName of ['pull_request_target', 'pull_request']) {
         assert.equal(statuses[0].state, 'failure');
     });
 }
+
+test('the single-PR path judges the label the API reports, not the one the payload froze', async () => {
+    // The labeler wins the race by a second, so the payload of the event that started this
+    // run has no label yet while the pull request already carries the right one (#20073).
+    const { toolkit, statuses } = pullRequestToolkit(
+        'pull_request_target',
+        { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.14.0`] },
+        { labels: [] },
+    );
+
+    await checkMilestoneLabel(toolkit as never);
+
+    assert.equal(statuses[0].state, 'success');
+});
+
+test('the single-PR path posts the status on the head the API reports', async () => {
+    // A re-run replays the original payload, so its head can be several pushes behind.
+    const { toolkit, statuses } = pullRequestToolkit(
+        'pull_request_target',
+        { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.14.0`], sha: 'dddd' },
+        { sha: 'cccc' },
+    );
+
+    await checkMilestoneLabel(toolkit as never);
+
+    assert.equal(statuses[0].sha, 'dddd');
+});
 
 test('the single-PR path never fails the job, even when the label is wrong', async () => {
     const { toolkit } = pullRequestToolkit('pull_request_target', { base: 'trunk', labels: [] });

--- a/.github/bin/js/milestone-label.ts
+++ b/.github/bin/js/milestone-label.ts
@@ -196,13 +196,18 @@ type IssuesClient = {
     };
 };
 
-type MergeGroupClient = {
+type PullRequestClient = {
     rest: {
         pulls: {
             get(options: { owner: string; repo: string; pull_number: number }): Promise<{
-                data: { number: number; draft?: boolean; base: { ref: string }; labels: { name: string }[] };
+                data: { number: number; draft?: boolean; base: { ref: string }; head: { sha: string }; labels: { name: string }[] };
             }>;
         };
+    };
+};
+
+type MergeGroupClient = {
+    rest: {
         repos: {
             compareCommitsWithBasehead(options: { owner: string; repo: string; basehead: string }): Promise<{ data: { commits: { sha: string }[] } }>;
             listPullRequestsAssociatedWithCommit(options: { owner: string; repo: string; commit_sha: string }): Promise<{ data: { number: number }[] }>;
@@ -285,7 +290,7 @@ type PullRequestContext = {
 };
 
 type Toolkit = {
-    github: GraphqlClient & IssuesClient & MergeGroupClient & StatusClient;
+    github: GraphqlClient & IssuesClient & PullRequestClient & MergeGroupClient & StatusClient;
     core: Logger;
     context: PullRequestContext;
 };
@@ -306,7 +311,7 @@ function defaultBranchOf(context: PullRequestContext): string {
 /** `refs/heads/gh-readonly-queue/trunk/pr-18791-<base sha>` -> 18791 */
 const MERGE_GROUP_REF_PATTERN = /\/pr-(\d+)-[0-9a-f]+$/;
 
-type CheckedPullRequest = { number: number; baseRefName: string; labels: string[]; isDraft: boolean; labelerPending: boolean };
+type CheckedPullRequest = { number: number; baseRefName: string; headSha: string; labels: string[]; isDraft: boolean; labelerPending: boolean };
 
 /**
  * The queue may batch several PRs into one group while the ref names only the last,
@@ -344,34 +349,37 @@ export async function pullRequestNumbersInMergeGroup(github: MergeGroupClient, c
     return [...numbers].sort((left, right) => left - right);
 }
 
+/**
+ * Deliberately the API and not `context.payload.pull_request`: the payload is frozen at the
+ * moment the event fired, so a label the labeler adds a second later stays invisible to the
+ * run racing it — and nothing re-judges the PR afterwards, because a re-run replays that same
+ * payload and a label set with the `GITHUB_TOKEN` emits no event of its own (#20073).
+ */
+async function fetchPullRequest(github: PullRequestClient, repo: Repo, number: number, labelerPending: boolean): Promise<CheckedPullRequest> {
+    const { data } = await github.rest.pulls.get({ ...repo, pull_number: number });
+
+    return {
+        number: data.number,
+        baseRefName: data.base.ref,
+        headSha: data.head.sha,
+        labels: data.labels.map((label) => label.name),
+        isDraft: data.draft ?? false,
+        labelerPending,
+    };
+}
+
 async function pullRequestsToCheck({ github, core, context }: Toolkit): Promise<CheckedPullRequest[]> {
     const mergeGroup = context.payload.merge_group;
 
     if (context.eventName !== 'merge_group' || !mergeGroup) {
-        const pullRequest = pullRequestOf(context);
+        const labelerPending = context.payload.action === 'opened' || context.payload.action === 'reopened';
 
-        return [{
-            number: pullRequest.number,
-            baseRefName: pullRequest.base.ref,
-            labels: (pullRequest.labels ?? []).map((label) => label.name),
-            isDraft: pullRequest.draft ?? false,
-            labelerPending: context.payload.action === 'opened' || context.payload.action === 'reopened',
-        }];
+        return [await fetchPullRequest(github, context.repo, pullRequestOf(context).number, labelerPending)];
     }
 
     const numbers = await pullRequestNumbersInMergeGroup(github, core, context.repo, mergeGroup);
 
-    return Promise.all(numbers.map(async (number) => {
-        const { data } = await github.rest.pulls.get({ ...context.repo, pull_number: number });
-
-        return {
-            number: data.number,
-            baseRefName: data.base.ref,
-            labels: data.labels.map((label) => label.name),
-            isDraft: data.draft ?? false,
-            labelerPending: false,
-        };
-    }));
+    return Promise.all(numbers.map((number) => fetchPullRequest(github, context.repo, number, false)));
 }
 
 export const STATUS_CONTEXT = 'milestone/label';
@@ -384,10 +392,10 @@ function truncate(text: string): string {
 }
 
 /** The commit the status belongs to: the merge group for the queue, the head otherwise. */
-function statusShaOf(context: PullRequestContext): string {
+function statusShaOf(context: PullRequestContext, pullRequests: CheckedPullRequest[]): string {
     const mergeGroup = context.payload.merge_group;
 
-    return context.eventName === 'merge_group' && mergeGroup ? mergeGroup.head_sha : pullRequestOf(context).head.sha;
+    return context.eventName === 'merge_group' && mergeGroup ? mergeGroup.head_sha : pullRequests[0].headSha;
 }
 
 /** The only link a commit status carries, so point it at the run holding the long form. */
@@ -406,13 +414,13 @@ function runUrl({ owner, repo }: Repo): string | undefined {
  * is keyed by context: the next run overwrites it and the pull request turns green
  * without a new commit.
  */
-async function postVerdictStatus(toolkit: Toolkit, state: 'success' | 'failure', description: string): Promise<void> {
+async function postVerdictStatus(toolkit: Toolkit, pullRequests: CheckedPullRequest[], state: 'success' | 'failure', description: string): Promise<void> {
     const { github, context } = toolkit;
     const target = runUrl(context.repo);
 
     await github.rest.repos.createCommitStatus({
         ...context.repo,
-        sha: statusShaOf(context),
+        sha: statusShaOf(context, pullRequests),
         state,
         context: STATUS_CONTEXT,
         description: truncate(description),
@@ -460,7 +468,7 @@ export async function checkMilestoneLabel(toolkit: Toolkit): Promise<void> {
             ? `all ${judged.length} queued pull requests carry a valid milestone label`
             : invalid.map(({ pullRequest, verdict }) => `#${pullRequest.number} ${verdict.short}`).join('; ');
 
-    await postVerdictStatus(toolkit, invalid.length === 0 ? 'success' : 'failure', description);
+    await postVerdictStatus(toolkit, pullRequests, invalid.length === 0 ? 'success' : 'failure', description);
 }
 
 /**


### PR DESCRIPTION
### 1. Why is this change necessary?

The check judged the labels from `context.payload.pull_request`, a snapshot of the moment the event fired. On #20073 the labeler set the label three seconds after the check had read that payload without it, and nothing could clear the red status again: a re-run replays the same payload, and a label set with the `GITHUB_TOKEN` emits no `labeled` event.

### 2. What does this change do, exactly?

Both paths now load the pull request through `pulls.get`, the way the merge-group path already did, and the status is posted on the head that call reports, so a re-run lands on the current commit.

### 3. Describe each step to reproduce the issue or behaviour.

Push to a PR whose `milestone/*` label the labeler still has to set: `Check milestone label` reads the label-less payload and stays red, and re-running the job changes nothing.

### 4. Please link to the relevant issues (if any).

relates #20073

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them