### PR TITLE
fix: exclude feed sales channels from currency validation

### DIFF
--- a/src/Core/System/SalesChannel/Validation/SalesChannelData.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelData.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 class SalesChannelData
 {
+    public ?string $typeId = null;
+
     public ?string $currentDefault = null;
 
     public ?string $newDefault = null;

--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\SalesChannel\Validation;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
@@ -47,6 +48,15 @@ class SalesChannelValidator implements EventSubscriberInterface
     private const CURRENCY_DELETE_VALIDATION_CODE = 'SYSTEM__CANNOT_DELETE_DEFAULT_CURRENCY_ID';
 
     /**
+     * These sales channel types are not customer facing and are not required to assign their default currency to the
+     * currency list, so the currency mapping validation is skipped for them.
+     */
+    private const CURRENCY_VALIDATION_EXCLUDED_TYPE_IDS = [
+        Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON,
+        Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE,
+    ];
+
+    /**
      * @internal
      */
     public function __construct(private readonly Connection $connection)
@@ -88,9 +98,13 @@ class SalesChannelValidator implements EventSubscriberInterface
             deleteValidationCode: self::CURRENCY_DELETE_VALIDATION_CODE,
             updateValidationMessage: self::CURRENCY_UPDATE_VALIDATION_MESSAGE,
             updateValidationCode: self::CURRENCY_UPDATE_VALIDATION_CODE,
+            excludedTypeIds: self::CURRENCY_VALIDATION_EXCLUDED_TYPE_IDS,
         );
     }
 
+    /**
+     * @param list<string> $excludedTypeIds
+     */
     private function validateMapping(
         PreWriteValidationEvent $event,
         string $defaultField,
@@ -103,6 +117,7 @@ class SalesChannelValidator implements EventSubscriberInterface
         string $deleteValidationCode,
         string $updateValidationMessage,
         string $updateValidationCode,
+        array $excludedTypeIds = [],
     ): void {
         $mapping = $this->extractMapping($event, $defaultField, $mappingEntity, $mappingField);
         if ($mapping->count() === 0) {
@@ -120,6 +135,7 @@ class SalesChannelValidator implements EventSubscriberInterface
             deleteValidationCode: $deleteValidationCode,
             updateValidationMessage: $updateValidationMessage,
             updateValidationCode: $updateValidationCode,
+            excludedTypeIds: $excludedTypeIds,
         );
     }
 
@@ -152,6 +168,10 @@ class SalesChannelValidator implements EventSubscriberInterface
         if ($salesChannelData === null) {
             $salesChannelData = new SalesChannelData();
             $mapping->set($id, $salesChannelData);
+        }
+
+        if (isset($command->getPayload()['type_id'])) {
+            $salesChannelData->typeId = Uuid::fromBytesToHex($command->getPayload()['type_id']);
         }
 
         if ($command instanceof UpdateCommand) {
@@ -192,6 +212,9 @@ class SalesChannelValidator implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param list<string> $excludedTypeIds
+     */
     private function validateMappingData(
         Mapping $mapping,
         PreWriteValidationEvent $event,
@@ -201,12 +224,17 @@ class SalesChannelValidator implements EventSubscriberInterface
         string $deleteValidationCode,
         string $updateValidationMessage,
         string $updateValidationCode,
+        array $excludedTypeIds = [],
     ): void {
         $inserts = [];
         $deletions = [];
         $updates = [];
 
         foreach ($mapping as $salesChannelId => $salesChannelData) {
+            if ($salesChannelData->typeId !== null && \in_array($salesChannelData->typeId, $excludedTypeIds, true)) {
+                continue;
+            }
+
             if ($salesChannelData->inserts !== null) {
                 if ($this->isInvalidInsertCase($salesChannelData)) {
                     $inserts[$salesChannelId] = $salesChannelData->newDefault;
@@ -309,6 +337,7 @@ class SalesChannelValidator implements EventSubscriberInterface
         $result = $this->connection->fetchAllAssociative(
             \sprintf(
                 'SELECT LOWER(HEX(sales_channel.id)) AS sales_channel_id,
+                LOWER(HEX(sales_channel.type_id)) AS type_id,
                 LOWER(HEX(sales_channel.%s)) AS current_default,
                 LOWER(HEX(mapping.%s)) AS %s
                 FROM sales_channel
@@ -344,6 +373,9 @@ class SalesChannelValidator implements EventSubscriberInterface
 
             $salesChannelData = $mapping->get($id);
 
+            if ($salesChannelData->typeId === null) {
+                $salesChannelData->typeId = $record['type_id'];
+            }
             $salesChannelData->currentDefault = $record['current_default'];
             $salesChannelData->state[] = $record[$mappingField];
             $salesChannelData->inserts = array_values(array_filter(

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -569,6 +569,31 @@ class SalesChannelValidatorTest extends TestCase
     }
 
     /**
+     * @return iterable<string, array{string}>
+     */
+    public static function currencyExcludedSalesChannelTypeProvider(): iterable
+    {
+        yield 'product comparison' => [Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON];
+        yield 'agentic commerce' => [Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE];
+    }
+
+    #[DataProvider('currencyExcludedSalesChannelTypeProvider')]
+    public function testExcludedSalesChannelTypeSucceedsWithoutDefaultCurrencyInCurrencyList(string $typeId): void
+    {
+        $id = Uuid::randomHex();
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
+        $data['typeId'] = $typeId;
+        $data['currencies'] = [];
+
+        $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
+
+        $count = (int) static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT COUNT(*) FROM sales_channel_currency WHERE sales_channel_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
+
+        static::assertSame(0, $count);
+    }
+
+    /**
      * @param list<string> $languages
      *
      * @return array<string, mixed>

--- a/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -250,6 +250,62 @@ class SalesChannelValidatorTest extends TestCase
         static::assertSame('SYSTEM__NO_GIVEN_DEFAULT_CURRENCY_ID', $exception->getViolations()->get(0)->getCode());
     }
 
+    #[DataProvider('currencyExcludedSalesChannelTypeProvider')]
+    public function testExcludedSalesChannelTypesDoNotRequireDefaultCurrencyInCurrencyList(string $typeId): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $currencyId = Uuid::randomHex();
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new InsertCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelDefinition::ENTITY_NAME),
+                    [
+                        'type_id' => Uuid::fromHexToBytes($typeId),
+                        'currency_id' => Uuid::fromHexToBytes($currencyId),
+                    ],
+                    ['id' => Uuid::fromHexToBytes($salesChannelId)],
+                    static::createStub(EntityExistence::class),
+                    '/0'
+                ),
+            ]
+        );
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    #[DataProvider('currencyExcludedSalesChannelTypeProvider')]
+    public function testDeletingDefaultCurrencyOfExcludedSalesChannelTypeIsSkipped(string $typeId): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $defaultId = Uuid::randomHex();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new DeleteCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelCurrencyDefinition::ENTITY_NAME),
+                    [
+                        'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                        'currency_id' => Uuid::fromHexToBytes($defaultId),
+                    ],
+                    static::createStub(EntityExistence::class)
+                ),
+            ]
+        );
+
+        $connection = $this->connectionWithCurrencyState($salesChannelId, $defaultId, [$defaultId], $typeId);
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
     public function testUpdatingDefaultCurrencyToUnassignedCurrencyFails(): void
     {
         $salesChannelId = Uuid::randomHex();
@@ -347,6 +403,15 @@ class SalesChannelValidatorTest extends TestCase
         yield 'agentic commerce' => [Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE];
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function currencyExcludedSalesChannelTypeProvider(): iterable
+    {
+        yield 'product comparison' => [Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON];
+        yield 'agentic commerce' => [Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE];
+    }
+
     private function updateDefaultLanguageCommand(string $salesChannelId, string $languageId): UpdateCommand
     {
         return new UpdateCommand(
@@ -379,6 +444,7 @@ class SalesChannelValidatorTest extends TestCase
         foreach ($assignedLanguageIds as $languageId) {
             $states[] = [
                 'sales_channel_id' => $salesChannelId,
+                'type_id' => Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
                 'current_default' => $currentDefaultId,
                 'language_id' => $languageId,
             ];
@@ -393,12 +459,13 @@ class SalesChannelValidatorTest extends TestCase
     /**
      * @param list<string> $assignedCurrencyIds
      */
-    private function connectionWithCurrencyState(string $salesChannelId, string $currentDefaultId, array $assignedCurrencyIds): Connection
+    private function connectionWithCurrencyState(string $salesChannelId, string $currentDefaultId, array $assignedCurrencyIds, string $typeId = Defaults::SALES_CHANNEL_TYPE_STOREFRONT): Connection
     {
         $states = [];
         foreach ($assignedCurrencyIds as $currencyId) {
             $states[] = [
                 'sales_channel_id' => $salesChannelId,
+                'type_id' => $typeId,
                 'current_default' => $currentDefaultId,
                 'currency_id' => $currencyId,
             ];


### PR DESCRIPTION
### 1. Why is this change necessary?

PR #19836 introduced default-currency validation in `SalesChannelValidator` that runs for every sales channel type. Product Comparison and Agentic Commerce channels intentionally have no `sales_channel_currency` mappings, so creating them fails with `SYSTEM__NO_GIVEN_DEFAULT_CURRENCY_ID` (issue #20111).

### 2. What does this change do, exactly?

Skips the default sales channel currency validation for sales channels of type `Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` and `Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE`, since these types are not required to assign their default currency to the currency list. The validator now resolves the sales channel `type_id` (from the write payload for inserts, from the DB for existing channels) and excludes those types from the currency check only; language validation is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

  1. In the Administration, create a new Product Comparison (or Agentic Commerce) sales channel.
  2. Before the fix, saving fails with `SYSTEM__NO_GIVEN_DEFAULT_CURRENCY_ID`.
  3. With the fix, the sales channel is created successfully without a currency assignment.

  ### 4. Please link to the relevant issues (if any).

  - closes #20111
  - relates #19836

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them