### PR TITLE
fix(content-system): align app registry persistence

### DIFF
--- a/src/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandler.php
@@ -2,8 +2,11 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Handler;
 
+use Shopware\Core\Framework\App\Lifecycle\Context\AppActivationContext;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppRemovalContext;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemElementTypePersister;
+use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\AbstractContentSystemElementTypeRegistry;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -14,6 +17,7 @@ class ContentSystemElementTypeLifecycleHandler extends AbstractLifecycleHandler
 {
     public function __construct(
         private readonly ContentSystemElementTypePersister $persister,
+        private readonly AbstractContentSystemElementTypeRegistry $registry,
     ) {
     }
 
@@ -25,5 +29,25 @@ class ContentSystemElementTypeLifecycleHandler extends AbstractLifecycleHandler
     public function update(AppPersistContext $context): void
     {
         $this->persister->persist($context);
+    }
+
+    public function activate(AppActivationContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function deactivate(AppActivationContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function uninstall(AppRemovalContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function delete(AppRemovalContext $context): void
+    {
+        $this->registry->invalidate();
     }
 }

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemBindingSpecificationPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemBindingSpecificationPersister.php
@@ -68,7 +68,7 @@ class ContentSystemBindingSpecificationPersister
         // Serialize concurrent same-app persists: read the existing set, compute the delta, and write it
         // as one lock-held unit, so a racing install cannot diff against a stale snapshot and leave a
         // superset of the intended final state.
-        $lock = $this->lockFactory->createLock('content_system_binding_persist_' . $appId, 5.0);
+        $lock = $this->lockFactory->createLock('content_system_binding_persist_' . $appId, 15.0);
         $lock->acquire(true);
 
         try {

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemElementTypePersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemElementTypePersister.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Persister;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemElementType\AppContentSystemElementTypeCollection;
 use Shopware\Core\Framework\App\AppException;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Lock\LockFactory;
 
 /**
  * Sole write path for app element types into the database. Called during app
@@ -41,6 +43,8 @@ class ContentSystemElementTypePersister
         private readonly ElementTypeCollisionDetector $collisionDetector,
         private readonly AbstractContentSystemElementTypeRegistry $registry,
         private readonly ElementTypeSpecificationSerializer $serializer,
+        private readonly Connection $connection,
+        private readonly LockFactory $lockFactory,
     ) {
     }
 
@@ -54,45 +58,58 @@ class ContentSystemElementTypePersister
         $appId = $context->app->getId();
 
         $resolvedDtos = $this->loadDtos($context);
-        $existing = $this->getExistingTypes($appId, $context->context);
 
-        if ($resolvedDtos === [] && $existing->count() === 0) {
-            return;
-        }
+        // Serialize concurrent same-app persists so the delta is never computed from a stale snapshot.
+        $lock = $this->lockFactory->createLock('content_system_element_type_persist_' . $appId, 15.0);
+        $lock->acquire(true);
 
-        if ($resolvedDtos !== []) {
-            $proposedNames = $this->buildProposedNames($resolvedDtos);
-            $inactiveNames = $this->loadInactiveAppTypeNames($appId, $context->context);
+        try {
+            $existing = $this->getExistingTypes($appId, $context->context);
 
-            // Exclude own source to prevent self-collision when updating existing types
-            $this->collisionDetector->validate(
-                $proposedNames,
-                'app:' . $context->app->getName(),
-                $inactiveNames,
-            );
-        }
+            if ($resolvedDtos === [] && $existing->count() === 0) {
+                return;
+            }
 
-        $upserts = $this->buildUpserts($resolvedDtos, $existing, $context);
-        $deleteIds = $this->buildDeletes($resolvedDtos, $existing);
+            if ($resolvedDtos !== []) {
+                $proposedNames = $this->buildProposedNames($resolvedDtos);
+                $inactiveNames = $this->loadInactiveAppTypeNames($appId, $context->context);
 
-        if ($upserts !== []) {
-            try {
-                $this->contentElementTypeRepository->upsert($upserts, $context->context);
-            } catch (UniqueConstraintViolationException $e) {
-                throw AppException::contentSystemElementTypeDuplicate(
-                    array_column($upserts, 'name'),
+                // Exclude own source to prevent self-collision when updating existing types
+                $this->collisionDetector->validate(
+                    $proposedNames,
                     'app:' . $context->app->getName(),
-                    $e,
+                    $inactiveNames,
                 );
             }
-        }
 
-        if ($deleteIds !== []) {
-            $this->contentElementTypeRepository->delete($deleteIds, $context->context);
-        }
+            $upserts = $this->buildUpserts($resolvedDtos, $existing, $context);
+            $deleteIds = $this->buildDeletes($resolvedDtos, $existing);
 
-        if ($upserts !== [] || $deleteIds !== []) {
-            $this->registry->invalidate();
+            // Upsert and delete are one atomic unit so a partial failure cannot leave a half-synced type set.
+            $this->connection->transactional(function () use ($upserts, $deleteIds, $context): void {
+                if ($upserts !== []) {
+                    try {
+                        $this->contentElementTypeRepository->upsert($upserts, $context->context);
+                    } catch (UniqueConstraintViolationException $e) {
+                        throw AppException::contentSystemElementTypeDuplicate(
+                            array_column($upserts, 'name'),
+                            'app:' . $context->app->getName(),
+                            $e,
+                        );
+                    }
+                }
+
+                if ($deleteIds !== []) {
+                    $this->contentElementTypeRepository->delete($deleteIds, $context->context);
+                }
+            });
+
+            // Keep invalidation inside the lock and after commit so no concurrent persist can repopulate stale data.
+            if ($upserts !== [] || $deleteIds !== []) {
+                $this->registry->invalidate();
+            }
+        } finally {
+            $lock->release();
         }
     }
 

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemStyleOptionPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemStyleOptionPersister.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Lock\LockFactory;
 
 /**
  * Sole write path for app style options into the database. Called during app install and update.
@@ -43,6 +44,7 @@ class ContentSystemStyleOptionPersister
         private readonly AbstractContentSystemStyleOptionRegistry $registry,
         private readonly StyleOptionSpecificationSerializer $serializer,
         private readonly Connection $connection,
+        private readonly LockFactory $lockFactory,
     ) {
     }
 
@@ -55,51 +57,59 @@ class ContentSystemStyleOptionPersister
         $appId = $context->app->getId();
 
         $resolvedDtos = $this->loadDtos($context);
-        $existing = $this->getExistingOptions($appId, $context->context);
 
-        if ($resolvedDtos === [] && $existing->count() === 0) {
-            return;
-        }
+        // Serialize concurrent same-app persists so the delta is never computed from a stale snapshot.
+        $lock = $this->lockFactory->createLock('content_system_style_option_persist_' . $appId, 15.0);
+        $lock->acquire(true);
 
-        if ($resolvedDtos !== []) {
-            $proposedNames = $this->buildProposedNames($resolvedDtos);
-            $inactiveNames = $this->loadInactiveAppOptionNames($appId, $context->context);
+        try {
+            $existing = $this->getExistingOptions($appId, $context->context);
 
-            // Exclude own source to prevent self-collision when updating existing options
-            $this->collisionDetector->validate(
-                $proposedNames,
-                'app:' . $context->app->getName(),
-                $inactiveNames,
-            );
-        }
+            if ($resolvedDtos === [] && $existing->count() === 0) {
+                return;
+            }
 
-        $upserts = $this->buildUpserts($resolvedDtos, $existing, $context);
-        $deleteIds = $this->buildDeletes($resolvedDtos, $existing);
+            if ($resolvedDtos !== []) {
+                $proposedNames = $this->buildProposedNames($resolvedDtos);
+                $inactiveNames = $this->loadInactiveAppOptionNames($appId, $context->context);
 
-        // Upsert and delete are one atomic unit: a partial failure must not leave the registered set
-        // half-synced (a stale-but-valid row alongside a committed new one).
-        $this->connection->transactional(function () use ($upserts, $deleteIds, $context): void {
-            if ($upserts !== []) {
-                try {
-                    $this->styleOptionRepository->upsert($upserts, $context->context);
-                } catch (UniqueConstraintViolationException $e) {
-                    throw AppException::contentSystemStyleOptionDuplicate(
-                        array_column($upserts, 'name'),
-                        'app:' . $context->app->getName(),
-                        $e,
-                    );
+                // Exclude own source to prevent self-collision when updating existing options
+                $this->collisionDetector->validate(
+                    $proposedNames,
+                    'app:' . $context->app->getName(),
+                    $inactiveNames,
+                );
+            }
+
+            $upserts = $this->buildUpserts($resolvedDtos, $existing, $context);
+            $deleteIds = $this->buildDeletes($resolvedDtos, $existing);
+
+            // Upsert and delete are one atomic unit: a partial failure must not leave the registered set
+            // half-synced (a stale-but-valid row alongside a committed new one).
+            $this->connection->transactional(function () use ($upserts, $deleteIds, $context): void {
+                if ($upserts !== []) {
+                    try {
+                        $this->styleOptionRepository->upsert($upserts, $context->context);
+                    } catch (UniqueConstraintViolationException $e) {
+                        throw AppException::contentSystemStyleOptionDuplicate(
+                            array_column($upserts, 'name'),
+                            'app:' . $context->app->getName(),
+                            $e,
+                        );
+                    }
                 }
-            }
 
-            if ($deleteIds !== []) {
-                $this->styleOptionRepository->delete($deleteIds, $context->context);
-            }
-        });
+                if ($deleteIds !== []) {
+                    $this->styleOptionRepository->delete($deleteIds, $context->context);
+                }
+            });
 
-        // Invalidate only after the transaction commits, so the cache is never refreshed from a write
-        // that rolled back.
-        if ($upserts !== [] || $deleteIds !== []) {
-            $this->registry->invalidate();
+            // Keep invalidation inside the lock and after commit so no concurrent persist can repopulate stale data.
+            if ($upserts !== [] || $deleteIds !== []) {
+                $this->registry->invalidate();
+            }
+        } finally {
+            $lock->release();
         }
     }
 

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -429,11 +429,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ElementTypeCollisionDetector::class),
             service(ContentSystemElementTypeRegistry::class),
             service(ElementTypeSpecificationSerializer::class),
+            service(Connection::class),
+            service('lock.factory'),
         ]);
 
     $services->set(ContentSystemElementTypeLifecycleHandler::class)
         ->args([
             service(ContentSystemElementTypePersister::class),
+            service(ContentSystemElementTypeRegistry::class),
         ])
         ->tag('shopware.app_lifecycle.handler', ['priority' => -1400]);
 
@@ -451,6 +454,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ContentSystemStyleOptionRegistry::class),
             service(StyleOptionSpecificationSerializer::class),
             service(Connection::class),
+            service('lock.factory'),
         ]);
 
     $services->set(ContentSystemStyleOptionLifecycleHandler::class)

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandlerTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Handler;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
+use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemElementTypeLifecycleHandler;
+use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\AbstractContentSystemElementTypeRegistry;
+use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\ContentSystemElementTypeRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Util\Filesystem;
+use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ContentSystemElementTypeLifecycleHandlerTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const FIXTURE = __DIR__ . '/_fixtures/element-type-lifecycle';
+
+    private const ELEMENT_TYPE = 'element-type-lifecycle:Hero';
+
+    #[TestDox('activating an app refreshes the cached registry and exposes its element types')]
+    public function testActivationRefreshesTheCachedRegistry(): void
+    {
+        [$appManager, $handler, $registry, $fixture] = $this->services();
+
+        $manifest = $fixture->loadManifest(self::FIXTURE . '/manifest.xml');
+        $app = $fixture->createApp($manifest);
+        $appManager->deactivate($app, Context::createDefaultContext());
+
+        $context = $fixture->createInstallContext($app, $manifest, new Filesystem($manifest->getPath()));
+        $handler->install($context);
+        static::assertArrayNotHasKey(self::ELEMENT_TYPE, $registry->all());
+
+        $appManager->activate($app, Context::createDefaultContext());
+
+        static::assertArrayHasKey(self::ELEMENT_TYPE, $registry->all());
+    }
+
+    #[TestDox('deactivating an app refreshes the cached registry and hides its element types')]
+    public function testDeactivationRefreshesTheCachedRegistry(): void
+    {
+        [$appManager, $handler, $registry, $fixture] = $this->services();
+
+        $manifest = $fixture->loadManifest(self::FIXTURE . '/manifest.xml');
+        $app = $fixture->createApp($manifest);
+        $context = $fixture->createInstallContext($app, $manifest, new Filesystem($manifest->getPath()));
+        $handler->install($context);
+        static::assertArrayHasKey(self::ELEMENT_TYPE, $registry->all());
+
+        $appManager->deactivate($app, Context::createDefaultContext());
+
+        static::assertArrayNotHasKey(self::ELEMENT_TYPE, $registry->all());
+    }
+
+    /**
+     * @return array{AppManager, ContentSystemElementTypeLifecycleHandler, AbstractContentSystemElementTypeRegistry, AppFixture}
+     */
+    private function services(): array
+    {
+        $appManager = static::getContainer()->get(AppManager::class);
+        static::assertInstanceOf(AppManager::class, $appManager);
+
+        $handler = static::getContainer()->get(ContentSystemElementTypeLifecycleHandler::class);
+        static::assertInstanceOf(ContentSystemElementTypeLifecycleHandler::class, $handler);
+
+        $registry = static::getContainer()->get(ContentSystemElementTypeRegistry::class);
+        static::assertInstanceOf(AbstractContentSystemElementTypeRegistry::class, $registry);
+
+        $fixture = static::getContainer()->get(AppFixture::class);
+        static::assertInstanceOf(AppFixture::class, $fixture);
+
+        return [$appManager, $handler, $registry, $fixture];
+    }
+}

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/element-type-lifecycle/Resources/content-system/types/hero.yaml
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/element-type-lifecycle/Resources/content-system/types/hero.yaml
@@ -1,0 +1,3 @@
+meta:
+  label: "Hero"
+  description: "Lifecycle test element."

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/element-type-lifecycle/manifest.xml
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/element-type-lifecycle/manifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>element-type-lifecycle</name>
+        <label>Element Type Lifecycle Test</label>
+        <description>Fixture app shipping one content-system element type.</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+</manifest>

--- a/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandlerTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemElementTypeLifecycleHandlerTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Handler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppActivationContext;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppRemovalContext;
+use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemElementTypeLifecycleHandler;
+use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemElementTypePersister;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\AbstractContentSystemElementTypeRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ContentSystemElementTypeLifecycleHandler::class)]
+class ContentSystemElementTypeLifecycleHandlerTest extends TestCase
+{
+    #[TestDox('install persists the app element types')]
+    public function testInstallPersists(): void
+    {
+        $context = $this->buildPersistContext();
+        $persister = $this->createMock(ContentSystemElementTypePersister::class);
+        $persister->expects($this->once())->method('persist')->with($context);
+
+        $registry = static::createMock(AbstractContentSystemElementTypeRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        (new ContentSystemElementTypeLifecycleHandler($persister, $registry))->install($context);
+    }
+
+    #[TestDox('update persists the app element types')]
+    public function testUpdatePersists(): void
+    {
+        $context = $this->buildPersistContext();
+        $persister = $this->createMock(ContentSystemElementTypePersister::class);
+        $persister->expects($this->once())->method('persist')->with($context);
+
+        $registry = static::createMock(AbstractContentSystemElementTypeRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        (new ContentSystemElementTypeLifecycleHandler($persister, $registry))->update($context);
+    }
+
+    #[TestDox('activation invalidates the registry so the app element types become available')]
+    public function testActivateInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->activate($this->buildActivationContext());
+    }
+
+    #[TestDox('deactivation invalidates the registry so the app element types disappear')]
+    public function testDeactivateInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->deactivate($this->buildActivationContext());
+    }
+
+    #[TestDox('uninstall invalidates the registry')]
+    public function testUninstallInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->uninstall($this->buildRemovalContext());
+    }
+
+    #[TestDox('local deletion invalidates the registry')]
+    public function testDeleteInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->delete($this->buildRemovalContext());
+    }
+
+    #[TestDox('a persister failure is propagated')]
+    public function testPropagatesPersisterException(): void
+    {
+        $exception = new \RuntimeException('persist failed');
+        $persister = static::createStub(ContentSystemElementTypePersister::class);
+        $persister->method('persist')->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+        (new ContentSystemElementTypeLifecycleHandler($persister, static::createStub(AbstractContentSystemElementTypeRegistry::class)))
+            ->install($this->buildPersistContext());
+    }
+
+    #[TestDox('a registry invalidation failure is propagated')]
+    public function testPropagatesRegistryException(): void
+    {
+        $exception = new \RuntimeException('invalidate failed');
+        $registry = static::createStub(AbstractContentSystemElementTypeRegistry::class);
+        $registry->method('invalidate')->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+        (new ContentSystemElementTypeLifecycleHandler(static::createStub(ContentSystemElementTypePersister::class), $registry))
+            ->activate($this->buildActivationContext());
+    }
+
+    private function handlerExpectingInvalidation(): ContentSystemElementTypeLifecycleHandler
+    {
+        $persister = $this->createMock(ContentSystemElementTypePersister::class);
+        $persister->expects($this->never())->method('persist');
+
+        $registry = $this->createMock(AbstractContentSystemElementTypeRegistry::class);
+        $registry->expects($this->once())->method('invalidate');
+
+        return new ContentSystemElementTypeLifecycleHandler($persister, $registry);
+    }
+
+    private function buildApp(): AppEntity
+    {
+        $app = new AppEntity();
+        $app->setId('app-id');
+        $app->setName('DemoApp');
+
+        return $app;
+    }
+
+    private function buildActivationContext(): AppActivationContext
+    {
+        return new AppActivationContext($this->buildApp(), Context::createDefaultContext());
+    }
+
+    private function buildRemovalContext(): AppRemovalContext
+    {
+        return new AppRemovalContext($this->buildApp(), Context::createDefaultContext());
+    }
+
+    private function buildPersistContext(): AppPersistContext
+    {
+        return new AppPersistContext(
+            manifest: static::createStub(Manifest::class),
+            app: $this->buildApp(),
+            context: Context::createDefaultContext(),
+            appFilesystem: static::createStub(Filesystem::class),
+            defaultLocale: 'en-GB',
+        );
+    }
+}

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemBindingSpecificationPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemBindingSpecificationPersisterTest.php
@@ -222,8 +222,14 @@ class ContentSystemBindingSpecificationPersisterTest extends TestCase
         $connection = static::createMock(Connection::class);
         $connection->expects($this->once())
             ->method('transactional')
-            ->willReturnCallback(static function (\Closure $work) {
+            ->willReturnCallback(static function (\Closure $work) use ($repo) {
+                static::assertSame([], $repo->upserts);
+                static::assertSame([], $repo->deletes);
+
                 $work();
+
+                static::assertCount(1, $repo->upserts);
+                static::assertCount(1, $repo->deletes);
 
                 return null;
             });
@@ -235,25 +241,51 @@ class ContentSystemBindingSpecificationPersisterTest extends TestCase
         static::assertCount(1, $repo->deletes);
     }
 
-    #[TestDox('serializes the persist under a per-app lock, acquiring it blocking and releasing it')]
-    public function testAcquiresAndReleasesPerAppLockAroundPersist(): void
+    #[TestDox('holds the per-app lock from the existing-state read through cache invalidation')]
+    public function testHoldsLockAroundReconciliationAndInvalidation(): void
     {
+        $lockHeld = false;
+
         $lock = static::createMock(SharedLockInterface::class);
-        $lock->expects($this->once())->method('acquire')->with(true);
-        $lock->expects($this->once())->method('release');
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturnCallback(
+            static function () use (&$lockHeld): bool {
+                $lockHeld = true;
+
+                return true;
+            }
+        );
+        $lock->expects($this->once())->method('release')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+                $lockHeld = false;
+            }
+        );
 
         $lockFactory = static::createMock(LockFactory::class);
         $lockFactory->expects($this->once())
             ->method('createLock')
-            ->with(static::stringContains($this->ids->get('app')), static::anything())
+            ->with('content_system_binding_persist_' . $this->ids->get('app'), 15.0)
             ->willReturn($lock);
 
-        $repo = $this->createEmptyRepository();
-        $persister = $this->buildPersister($repo, lockFactory: $lockFactory);
+        $repo = new StaticEntityRepository([
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemBindingSpecificationCollection {
+                static::assertTrue($lockHeld);
 
-        $persister->persist($this->buildContext());
+                return new AppContentSystemBindingSpecificationCollection();
+            },
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemBindingSpecificationRegistry::class);
+        $registry->expects($this->once())->method('invalidate')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+            }
+        );
+
+        $this->buildPersister($repo, registry: $registry, lockFactory: $lockFactory)->persist($this->buildContext());
 
         static::assertCount(1, $repo->upserts);
+        static::assertFalse($lockHeld);
     }
 
     #[TestDox('returns early without writing when the app ships none and none are stored')]

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemElementTypePersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemElementTypePersisterTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -35,6 +36,9 @@ use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Validator\Validation;
 
 /**
@@ -263,6 +267,130 @@ class ContentSystemElementTypePersisterTest extends TestCase
         static::assertSame([['id' => $this->ids->get('type-orphan')]], $repo->deletes[0]);
     }
 
+    #[TestDox('routes the upsert and delete through a single transaction')]
+    public function testWritesGoThroughOneTransaction(): void
+    {
+        $obsolete = $this->buildExistingEntity('type-old', 'DemoApp:Legacy');
+
+        $repo = new StaticEntityRepository([
+            new AppContentSystemElementTypeCollection([$obsolete]),
+            new AppContentSystemElementTypeCollection(),
+        ]);
+
+        $connection = static::createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('transactional')
+            ->willReturnCallback(static function (\Closure $work) use ($repo) {
+                static::assertSame([], $repo->upserts);
+                static::assertSame([], $repo->deletes);
+
+                $work();
+
+                static::assertCount(1, $repo->upserts);
+                static::assertCount(1, $repo->deletes);
+
+                return null;
+            });
+
+        $this->buildPersister($repo, connection: $connection)
+            ->persist($this->buildContext($this->buildRealFilesystem()));
+
+        static::assertCount(1, $repo->upserts);
+        static::assertCount(1, $repo->deletes);
+    }
+
+    #[TestDox('holds the per-app lock from the existing-state read through cache invalidation')]
+    public function testHoldsLockAroundReconciliationAndInvalidation(): void
+    {
+        $lockHeld = false;
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturnCallback(
+            static function () use (&$lockHeld): bool {
+                $lockHeld = true;
+
+                return true;
+            }
+        );
+        $lock->expects($this->once())->method('release')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+                $lockHeld = false;
+            }
+        );
+
+        $lockFactory = static::createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('content_system_element_type_persist_' . $this->ids->get('app'), 15.0)
+            ->willReturn($lock);
+
+        $repo = new StaticEntityRepository([
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemElementTypeCollection {
+                static::assertTrue($lockHeld);
+
+                return new AppContentSystemElementTypeCollection();
+            },
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemElementTypeCollection {
+                static::assertTrue($lockHeld);
+
+                return new AppContentSystemElementTypeCollection();
+            },
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemElementTypeRegistry::class);
+        $registry->expects($this->once())->method('all')->willReturnCallback(
+            static function () use (&$lockHeld): array {
+                static::assertTrue($lockHeld);
+
+                return [];
+            }
+        );
+        $registry->expects($this->once())->method('invalidate')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+            }
+        );
+
+        $this->buildPersister($repo, registry: $registry, lockFactory: $lockFactory)
+            ->persist($this->buildContext($this->buildRealFilesystem()));
+
+        static::assertFalse($lockHeld);
+    }
+
+    #[TestDox('releases the lock and leaves the cache untouched when the transaction fails')]
+    public function testReleasesLockWhenTransactionFails(): void
+    {
+        $failure = new \RuntimeException('transaction failed');
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willThrowException($failure);
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturn(true);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $registry = static::createMock(AbstractContentSystemElementTypeRegistry::class);
+        $registry->method('all')->willReturn([]);
+        $registry->expects($this->never())->method('invalidate');
+
+        $repo = new StaticEntityRepository([
+            new AppContentSystemElementTypeCollection(),
+            new AppContentSystemElementTypeCollection(),
+        ]);
+
+        $this->expectExceptionObject($failure);
+        $this->buildPersister(
+            $repo,
+            registry: $registry,
+            connection: $connection,
+            lockFactory: $lockFactory,
+        )->persist($this->buildContext($this->buildRealFilesystem()));
+    }
+
     #[TestDox('returns early when loader returns empty and no existing types exist')]
     public function testEarlyReturnWhenBothEmpty(): void
     {
@@ -399,6 +527,8 @@ class ContentSystemElementTypePersisterTest extends TestCase
             new ElementTypeCollisionDetector($registry),
             $registry,
             $this->serializer,
+            $this->runTransactionStub(),
+            new LockFactory(new InMemoryStore()),
         );
 
         try {
@@ -463,6 +593,8 @@ class ContentSystemElementTypePersisterTest extends TestCase
         StaticEntityRepository $repo,
         ?YamlTypeLoader $loader = null,
         ?AbstractContentSystemElementTypeRegistry $registry = null,
+        ?Connection $connection = null,
+        ?LockFactory $lockFactory = null,
     ): ContentSystemElementTypePersister {
         if ($registry === null) {
             $registry = static::createStub(AbstractContentSystemElementTypeRegistry::class);
@@ -477,7 +609,21 @@ class ContentSystemElementTypePersisterTest extends TestCase
             $detector,
             $registry,
             $this->serializer,
+            $connection ?? $this->runTransactionStub(),
+            $lockFactory ?? new LockFactory(new InMemoryStore()),
         );
+    }
+
+    private function runTransactionStub(): Connection
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willReturnCallback(static function (\Closure $work) {
+            $work();
+
+            return null;
+        });
+
+        return $connection;
     }
 
     private function buildContext(Filesystem $filesystem): AppPersistContext

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemStyleOptionPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemStyleOptionPersisterTest.php
@@ -34,6 +34,9 @@ use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Validator\Validation;
 
 /**
@@ -266,8 +269,14 @@ class ContentSystemStyleOptionPersisterTest extends TestCase
         $connection = static::createMock(Connection::class);
         $connection->expects($this->once())
             ->method('transactional')
-            ->willReturnCallback(static function (\Closure $work) {
+            ->willReturnCallback(static function (\Closure $work) use ($repo) {
+                static::assertSame([], $repo->upserts);
+                static::assertSame([], $repo->deletes);
+
                 $work();
+
+                static::assertCount(1, $repo->upserts);
+                static::assertCount(1, $repo->deletes);
 
                 return null;
             });
@@ -277,6 +286,98 @@ class ContentSystemStyleOptionPersisterTest extends TestCase
 
         static::assertCount(1, $repo->upserts);
         static::assertCount(1, $repo->deletes);
+    }
+
+    #[TestDox('holds the per-app lock from the existing-state read through cache invalidation')]
+    public function testHoldsLockAroundReconciliationAndInvalidation(): void
+    {
+        $lockHeld = false;
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturnCallback(
+            static function () use (&$lockHeld): bool {
+                $lockHeld = true;
+
+                return true;
+            }
+        );
+        $lock->expects($this->once())->method('release')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+                $lockHeld = false;
+            }
+        );
+
+        $lockFactory = static::createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('content_system_style_option_persist_' . $this->ids->get('app'), 15.0)
+            ->willReturn($lock);
+
+        $repo = new StaticEntityRepository([
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemStyleOptionCollection {
+                static::assertTrue($lockHeld);
+
+                return new AppContentSystemStyleOptionCollection();
+            },
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemStyleOptionCollection {
+                static::assertTrue($lockHeld);
+
+                return new AppContentSystemStyleOptionCollection();
+            },
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemStyleOptionRegistry::class);
+        $registry->expects($this->once())->method('all')->willReturnCallback(
+            static function () use (&$lockHeld): array {
+                static::assertTrue($lockHeld);
+
+                return [];
+            }
+        );
+        $registry->expects($this->once())->method('invalidate')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+            }
+        );
+
+        $this->buildPersister($repo, registry: $registry, lockFactory: $lockFactory)
+            ->persist($this->buildContext());
+
+        static::assertFalse($lockHeld);
+    }
+
+    #[TestDox('releases the lock and leaves the cache untouched when the transaction fails')]
+    public function testReleasesLockWhenTransactionFails(): void
+    {
+        $failure = new \RuntimeException('transaction failed');
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willThrowException($failure);
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturn(true);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $registry = static::createMock(AbstractContentSystemStyleOptionRegistry::class);
+        $registry->method('all')->willReturn([]);
+        $registry->expects($this->never())->method('invalidate');
+
+        $repo = new StaticEntityRepository([
+            new AppContentSystemStyleOptionCollection(),
+            new AppContentSystemStyleOptionCollection(),
+        ]);
+
+        $this->expectExceptionObject($failure);
+        $this->buildPersister(
+            $repo,
+            registry: $registry,
+            connection: $connection,
+            lockFactory: $lockFactory,
+        )->persist($this->buildContext());
     }
 
     #[TestDox('returns early without writing when the app ships none and none are stored')]
@@ -485,6 +586,7 @@ class ContentSystemStyleOptionPersisterTest extends TestCase
         ?YamlStyleOptionLoader $loader = null,
         ?AbstractContentSystemStyleOptionRegistry $registry = null,
         ?Connection $connection = null,
+        ?LockFactory $lockFactory = null,
     ): ContentSystemStyleOptionPersister {
         if ($registry === null) {
             $registry = static::createStub(AbstractContentSystemStyleOptionRegistry::class);
@@ -498,6 +600,7 @@ class ContentSystemStyleOptionPersisterTest extends TestCase
             $registry,
             $this->serializer,
             $connection ?? $this->runTransactionStub(),
+            $lockFactory ?? new LockFactory(new InMemoryStore()),
         );
     }
 
@@ -519,6 +622,7 @@ class ContentSystemStyleOptionPersisterTest extends TestCase
             $registry,
             $this->serializer,
             $this->runTransactionStub(),
+            new LockFactory(new InMemoryStore()),
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Content-system app persisters used inconsistent locking, transaction, and cache invalidation guarantees. This could leave partially synchronized or stale registry data.

### 2. What does this change do, exactly?

It aligns the three content-system persisters by serializing same-app writes, making element type reconciliation transactional, and invalidating caches only after successful writes. Element type caches are also invalidated for all relevant app lifecycle operations.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install an app providing content-system element types.
2. Warm the element type registry cache.
3. Deactivate or uninstall the app.
4. Observe that its element types can remain available from the stale cache.

  Concurrent app updates could additionally calculate and persist conflicting registry changes.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #19953

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
