### PR TITLE
fix(system-number-range): reject colliding number range patterns for document types

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -123,6 +123,10 @@ Customer import records whose `customerNumber` does not match the configured cus
 
 Custom number range increment storages can implement `AbstractIncrementStorage::increaseToAtLeast()` to raise an existing increment state without lowering higher values.
 
+### Document number ranges reject colliding patterns
+
+Saving a number range whose pattern matches another number range of the same document type (for example two `document_invoice` ranges assigned to different sales channels) is now rejected with a validation error naming the collision, instead of silently allowing it and failing later at document generation with a generic "number already allocated" error. If a collision is still hit at generation time, for example on data that predates this change, the error message now names the affected document type.
+
 ### `JsonField::addPropertyMapping()` for entity extensions
 
 `Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField` now has `addPropertyMapping()`. Plugins can call it from `EntityExtension::modifyFields()` to extend an existing JSON schema, for example to add another entity key to a structured `hitCount` map. The field collection passed to `modifyFields()` is keyed by property name, so `$collection->get('hitCount')` returns the field.

--- a/src/Core/Checkout/Document/DocumentException.php
+++ b/src/Core/Checkout/Document/DocumentException.php
@@ -109,14 +109,17 @@ class DocumentException extends HttpException
         );
     }
 
-    public static function documentNumberAlreadyExistsException(string $number = ''): self
+    public static function documentNumberAlreadyExistsException(string $number = '', string $documentType = ''): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::DOCUMENT_NUMBER_ALREADY_EXISTS,
-            \sprintf('Document number %s has already been allocated.', $number),
+            $documentType !== ''
+                ? \sprintf('Document number %s has already been allocated for document type "%s".', $number, $documentType)
+                : \sprintf('Document number %s has already been allocated.', $number),
             [
                 '$number' => $number,
+                '$documentType' => $documentType,
             ],
         );
     }

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -327,7 +327,7 @@ class DocumentGenerator
         $result = (bool) $statement->fetchOne();
 
         if ($result) {
-            throw DocumentException::documentNumberAlreadyExistsException($documentNumber);
+            throw DocumentException::documentNumberAlreadyExistsException($documentNumber, $documentTypeName);
         }
     }
 

--- a/src/Core/Checkout/DocumentV2/DocumentV2Exception.php
+++ b/src/Core/Checkout/DocumentV2/DocumentV2Exception.php
@@ -321,13 +321,15 @@ class DocumentV2Exception extends HttpException
         );
     }
 
-    public static function documentNumberAlreadyExists(string $documentNumber): self
+    public static function documentNumberAlreadyExists(string $documentNumber, string $documentType = ''): self
     {
         return new self(
             Response::HTTP_CONFLICT,
             self::DOCUMENT_NUMBER_ALREADY_EXISTS,
-            'Document with number "{{ documentNumber }}" already exists.',
-            ['documentNumber' => $documentNumber],
+            $documentType !== ''
+                ? 'Document with number "{{ documentNumber }}" already exists for document type "{{ documentType }}".'
+                : 'Document with number "{{ documentNumber }}" already exists.',
+            ['documentNumber' => $documentNumber, 'documentType' => $documentType],
         );
     }
 

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
@@ -293,7 +293,7 @@ final readonly class DocumentPersister
         $exists = $this->documentRepository->searchIds($criteria, $context)->firstId() !== null;
 
         if ($exists) {
-            throw DocumentV2Exception::documentNumberAlreadyExists($documentNumber);
+            throw DocumentV2Exception::documentNumberAlreadyExists($documentNumber, $generationRequest->documentType);
         }
     }
 

--- a/src/Core/System/DependencyInjection/number_range.php
+++ b/src/Core/System/DependencyInjection/number_range.php
@@ -16,6 +16,7 @@ use Shopware\Core\System\NumberRange\Command\MigrateIncrementStorageCommand;
 use Shopware\Core\System\NumberRange\NumberRangeDefinition;
 use Shopware\Core\System\NumberRange\Telemetry\IncrementStorageMetricsDecorator;
 use Shopware\Core\System\NumberRange\Telemetry\NumberRangeTypeResolver;
+use Shopware\Core\System\NumberRange\Validation\NumberRangePatternCollisionValidator;
 use Shopware\Core\System\NumberRange\ValueGenerator\AbstractNumberRangeValueGenerator;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
@@ -135,4 +136,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('setContainer', [
             service('service_container'),
         ]);
+
+    $services->set(NumberRangePatternCollisionValidator::class)
+        ->args([
+            service(Connection::class),
+        ])
+        ->tag('kernel.event_subscriber');
 };

--- a/src/Core/System/NumberRange/Validation/NumberRangePatternCollisionValidator.php
+++ b/src/Core/System/NumberRange/Validation/NumberRangePatternCollisionValidator.php
@@ -1,0 +1,288 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\NumberRange\Validation;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\NumberRange\NumberRangeDefinition;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore Tested via integration tests.
+ *
+ * @see \Shopware\Tests\Integration\Core\System\NumberRange\Validation\NumberRangePatternCollisionValidatorTest
+ */
+#[Package('framework')]
+class NumberRangePatternCollisionValidator implements EventSubscriberInterface
+{
+    final public const NUMBER_RANGE_PATTERN_NOT_UNIQUE = 'NUMBER_RANGE_PATTERN_NOT_UNIQUE';
+
+    /**
+     * Document number range types are seeded with this technical name prefix, e.g. `document_invoice`.
+     *
+     * @see \Shopware\Core\Checkout\DocumentV2\Config\DocumentNumberGenerator::NUMBER_RANGE_DOCUMENT_TYPE_PREFIX
+     */
+    private const DOCUMENT_TYPE_PREFIX = 'document_';
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'validate',
+        ];
+    }
+
+    public function validate(PreWriteValidationEvent $event): void
+    {
+        $commands = $this->collectRelevantCommands($event);
+        if ($commands === []) {
+            return;
+        }
+
+        $states = $this->resolveStates($commands);
+        if ($states === []) {
+            return;
+        }
+
+        $documentTypeNames = $this->fetchDocumentTypeNames(\array_values(\array_unique(\array_column($states, 'typeId'))));
+        if ($documentTypeNames === []) {
+            return;
+        }
+
+        $states = \array_filter($states, static fn (array $state): bool => isset($documentTypeNames[$state['typeId']]));
+        if ($states === []) {
+            return;
+        }
+
+        $existingPatternsByType = $this->fetchExistingPatternsByType(
+            \array_values(\array_unique(\array_column($states, 'typeId'))),
+            \array_keys($states),
+        );
+
+        $violations = new ConstraintViolationList();
+
+        foreach ($states as $numberRangeId => $state) {
+            $otherPatterns = $existingPatternsByType[$state['typeId']] ?? [];
+
+            foreach ($states as $otherId => $otherState) {
+                if ($otherId === $numberRangeId || $otherState['typeId'] !== $state['typeId']) {
+                    continue;
+                }
+
+                $otherPatterns[] = $otherState['pattern'];
+            }
+
+            if (!\in_array($state['pattern'], $otherPatterns, true)) {
+                continue;
+            }
+
+            $this->addViolation($violations, $commands[$numberRangeId]->getPath(), $documentTypeNames[$state['typeId']], $state['pattern']);
+        }
+
+        if ($violations->count() > 0) {
+            $event->getExceptions()->add(new WriteConstraintViolationException($violations));
+        }
+    }
+
+    /**
+     * @return array<string, WriteCommand>
+     */
+    private function collectRelevantCommands(PreWriteValidationEvent $event): array
+    {
+        $commands = [];
+
+        foreach ($event->getCommandsForEntity(NumberRangeDefinition::ENTITY_NAME) as $command) {
+            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
+                continue;
+            }
+
+            if ($command instanceof UpdateCommand && !$command->hasAnyField('type_id', 'pattern')) {
+                continue;
+            }
+
+            $commands[$command->getDecodedPrimaryKey()['id']] = $command;
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @param array<string, WriteCommand> $commands
+     *
+     * @return array<string, array{typeId: string, pattern: string}>
+     */
+    private function resolveStates(array $commands): array
+    {
+        $currentStates = $this->fetchCurrentStates($commands);
+        $states = [];
+
+        foreach ($commands as $numberRangeId => $command) {
+            $payload = $command->getPayload();
+            $currentState = $currentStates[$numberRangeId] ?? null;
+
+            $typeId = \array_key_exists('type_id', $payload)
+                ? $this->normalizeId($payload['type_id'])
+                : ($currentState['typeId'] ?? null);
+
+            $pattern = $payload['pattern'] ?? $currentState['pattern'] ?? null;
+
+            if ($typeId === null || !\is_string($pattern) || $pattern === '') {
+                continue;
+            }
+
+            $states[$numberRangeId] = [
+                'typeId' => $typeId,
+                'pattern' => $pattern,
+            ];
+        }
+
+        return $states;
+    }
+
+    /**
+     * @param array<string, WriteCommand> $commands
+     *
+     * @return array<string, array{typeId: string, pattern: string}>
+     */
+    private function fetchCurrentStates(array $commands): array
+    {
+        $numberRangeIds = [];
+        foreach ($commands as $numberRangeId => $command) {
+            if ($command instanceof UpdateCommand) {
+                $numberRangeIds[] = $numberRangeId;
+            }
+        }
+
+        if ($numberRangeIds === []) {
+            return [];
+        }
+
+        /** @var list<array{id: string, type_id: string, pattern: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(`id`)) as `id`, LOWER(HEX(`type_id`)) as `type_id`, `pattern`
+             FROM `number_range`
+             WHERE `id` IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($numberRangeIds)],
+            ['ids' => ArrayParameterType::BINARY],
+        );
+
+        $states = [];
+        foreach ($rows as $row) {
+            $states[$row['id']] = [
+                'typeId' => $row['type_id'],
+                'pattern' => $row['pattern'],
+            ];
+        }
+
+        return $states;
+    }
+
+    /**
+     * @param list<string> $typeIds
+     *
+     * @return array<string, string> type id => document type name (e.g. "invoice")
+     */
+    private function fetchDocumentTypeNames(array $typeIds): array
+    {
+        if ($typeIds === []) {
+            return [];
+        }
+
+        /** @var list<array{id: string, technical_name: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(`id`)) as `id`, `technical_name`
+             FROM `number_range_type`
+             WHERE `id` IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($typeIds)],
+            ['ids' => ArrayParameterType::BINARY],
+        );
+
+        $names = [];
+        foreach ($rows as $row) {
+            if (!\str_starts_with($row['technical_name'], self::DOCUMENT_TYPE_PREFIX)) {
+                continue;
+            }
+
+            $names[$row['id']] = \substr($row['technical_name'], \strlen(self::DOCUMENT_TYPE_PREFIX));
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param list<string> $typeIds
+     * @param list<string> $excludeNumberRangeIds
+     *
+     * @return array<string, list<string>> type id => patterns of other number ranges of that type
+     */
+    private function fetchExistingPatternsByType(array $typeIds, array $excludeNumberRangeIds): array
+    {
+        if ($typeIds === []) {
+            return [];
+        }
+
+        /** @var list<array{id: string, type_id: string, pattern: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(`id`)) as `id`, LOWER(HEX(`type_id`)) as `type_id`, `pattern`
+             FROM `number_range`
+             WHERE `type_id` IN (:typeIds)',
+            ['typeIds' => Uuid::fromHexToBytesList($typeIds)],
+            ['typeIds' => ArrayParameterType::BINARY],
+        );
+
+        $patternsByType = [];
+        foreach ($rows as $row) {
+            if (\in_array($row['id'], $excludeNumberRangeIds, true)) {
+                continue;
+            }
+
+            $patternsByType[$row['type_id']][] = $row['pattern'];
+        }
+
+        return $patternsByType;
+    }
+
+    private function addViolation(ConstraintViolationList $violations, string $path, string $documentTypeName, string $pattern): void
+    {
+        $messageTemplate = 'Another {{ documentType }} number range already uses this pattern. Generated documents would collide.';
+        $parameters = ['{{ documentType }}' => $documentTypeName];
+
+        $violations->add(new ConstraintViolation(
+            message: \str_replace(\array_keys($parameters), \array_values($parameters), $messageTemplate),
+            messageTemplate: $messageTemplate,
+            parameters: $parameters,
+            root: null,
+            propertyPath: $path . '/pattern',
+            invalidValue: $pattern,
+            code: self::NUMBER_RANGE_PATTERN_NOT_UNIQUE,
+        ));
+    }
+
+    private function normalizeId(mixed $id): ?string
+    {
+        if (!\is_string($id)) {
+            return null;
+        }
+
+        if (Uuid::isValid($id)) {
+            return $id;
+        }
+
+        return Uuid::fromBytesToHex($id);
+    }
+}

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -689,7 +689,7 @@ class DocumentGeneratorTest extends TestCase
         static::assertEmpty($result->getSuccess()->getElements());
         static::assertNotEmpty($result->getErrors());
         static::assertArrayHasKey($this->orderId, $result->getErrors());
-        static::assertSame('Document number 1001 has already been allocated.', $result->getErrors()[$this->orderId]->getMessage());
+        static::assertSame('Document number 1001 has already been allocated for document type "invoice".', $result->getErrors()[$this->orderId]->getMessage());
     }
 
     public function testCreateInvoiceIsExistingNumberPdf(): void
@@ -726,7 +726,7 @@ class DocumentGeneratorTest extends TestCase
         $errors = $this->documentGenerator->generate(DeliveryNoteRenderer::TYPE, [$this->orderId => $operation], $this->context)->getErrors();
         static::assertNotEmpty($errors);
         static::assertArrayHasKey($this->orderId, $errors);
-        static::assertSame($errors[$this->orderId]->getMessage(), 'Document number 1002 has already been allocated.');
+        static::assertSame($errors[$this->orderId]->getMessage(), 'Document number 1002 has already been allocated for document type "delivery_note".');
     }
 
     public function testGenerateStaticDocument(): void

--- a/tests/integration/Core/System/NumberRange/Validation/NumberRangePatternCollisionValidatorTest.php
+++ b/tests/integration/Core/System/NumberRange/Validation/NumberRangePatternCollisionValidatorTest.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\System\NumberRange\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
+use Shopware\Core\System\NumberRange\NumberRangeCollection;
+use Shopware\Core\System\NumberRange\Validation\NumberRangePatternCollisionValidator;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class NumberRangePatternCollisionValidatorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var EntityRepository<NumberRangeTypeCollection>
+     */
+    private EntityRepository $numberRangeTypeRepository;
+
+    /**
+     * @var EntityRepository<NumberRangeCollection>
+     */
+    private EntityRepository $numberRangeRepository;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->numberRangeTypeRepository = static::getContainer()->get('number_range_type.repository');
+        $this->numberRangeRepository = static::getContainer()->get('number_range.repository');
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testRepositoryCreateRejectsCollidingPatternForSameDocumentType(): void
+    {
+        $typeId = $this->createDocumentNumberRangeType('document_test_invoice');
+        $this->createNumberRange($typeId, 'INV{n}');
+
+        $this->expectPatternCollisionViolation(fn () => $this->createNumberRange($typeId, 'INV{n}'));
+    }
+
+    public function testRepositoryCreateAllowsDistinctPatternForSameDocumentType(): void
+    {
+        $typeId = $this->createDocumentNumberRangeType('document_test_delivery_note');
+        $this->createNumberRange($typeId, 'DEL{n}');
+
+        $this->createNumberRange($typeId, 'DEL-B-{n}');
+
+        static::addToAssertionCount(1);
+    }
+
+    public function testRepositoryUpdateRejectsCollidingPattern(): void
+    {
+        $typeId = $this->createDocumentNumberRangeType('document_test_credit_note');
+        $this->createNumberRange($typeId, 'CN{n}');
+        $secondId = $this->createNumberRange($typeId, 'CN-B-{n}');
+
+        $this->expectPatternCollisionViolation(fn () => $this->numberRangeRepository->update([[
+            'id' => $secondId,
+            'pattern' => 'CN{n}',
+        ]], $this->context));
+    }
+
+    public function testRepositoryCreateRejectsCollidingPatternInSameWriteBatch(): void
+    {
+        $typeId = $this->createDocumentNumberRangeType('document_test_storno');
+
+        $this->expectPatternCollisionViolation(fn () => $this->numberRangeRepository->create([
+            $this->numberRangePayload($typeId, 'STO{n}'),
+            $this->numberRangePayload($typeId, 'STO{n}'),
+        ], $this->context));
+    }
+
+    public function testRepositoryCreateAllowsCollidingPatternForNonDocumentType(): void
+    {
+        $typeId = $this->createNumberRangeType('test_non_document_type');
+        $this->createNumberRange($typeId, 'X{n}');
+
+        $this->createNumberRange($typeId, 'X{n}');
+
+        static::addToAssertionCount(1);
+    }
+
+    private function createDocumentNumberRangeType(string $technicalName): string
+    {
+        return $this->createNumberRangeType($technicalName);
+    }
+
+    private function createNumberRangeType(string $technicalName): string
+    {
+        $id = Uuid::randomHex();
+
+        $this->numberRangeTypeRepository->create([[
+            'id' => $id,
+            'technicalName' => $technicalName,
+            'global' => false,
+            'typeName' => $technicalName,
+        ]], $this->context);
+
+        return $id;
+    }
+
+    private function createNumberRange(string $typeId, string $pattern): string
+    {
+        $payload = $this->numberRangePayload($typeId, $pattern);
+
+        $this->numberRangeRepository->create([$payload], $this->context);
+
+        return $payload['id'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function numberRangePayload(string $typeId, string $pattern): array
+    {
+        return [
+            'id' => Uuid::randomHex(),
+            'typeId' => $typeId,
+            'global' => false,
+            'pattern' => $pattern,
+            'start' => 1000,
+            'name' => 'Test number range',
+        ];
+    }
+
+    private function expectPatternCollisionViolation(\Closure $callback): void
+    {
+        try {
+            $callback();
+            static::fail('Expected a number range pattern collision violation.');
+        } catch (WriteException $exception) {
+            $writeException = $exception->getExceptions()[0] ?? null;
+
+            static::assertInstanceOf(WriteConstraintViolationException::class, $writeException);
+            static::assertSame(
+                NumberRangePatternCollisionValidator::NUMBER_RANGE_PATTERN_NOT_UNIQUE,
+                $writeException->getViolations()->get(0)->getCode(),
+            );
+        }
+    }
+}

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
@@ -498,7 +498,7 @@ class DocumentPersisterTest extends TestCase
 
         [$persister] = $this->createPersister($documentTypeId, existingDocumentIds: [$existingDocumentId]);
 
-        $this->expectExceptionObject(DocumentV2Exception::documentNumberAlreadyExists('12345'));
+        $this->expectExceptionObject(DocumentV2Exception::documentNumberAlreadyExists('12345', self::DOCUMENT_TYPE));
 
         $persister->persist(
             $this->generationRequest,


### PR DESCRIPTION
### 1. Why is this change necessary?

The admin lets you save two number ranges of the same document type (e.g. `document_invoice`) with an identical pattern, each assigned to a different sales channel. Nothing warns you at save time. The misconfiguration only surfaces later, when generating a document for an order in the second sales channel: generation fails with "Document number 1001 has already been allocated." That message doesn't name the document type or hint at the number-range-config root cause, and every failed attempt still burns a number from the colliding range before the uniqueness check runs.

### 2. What does this change do, exactly?

- Adds a `PreWriteValidationEvent` subscriber, `NumberRangePatternCollisionValidator`, that rejects saving a `number_range` whose pattern collides with another `number_range` of the same document-type `number_range_type` (technical name starting with `document_`, e.g. `document_invoice`), with a translated-ready inline violation naming the collision ("Another invoice number range already uses this pattern. Generated documents would collide."). It follows the same idiom as the existing `CustomerEmailUniqueSubscriber` and `DocumentBaseConfigValidator` validators. Non-document number range types (order, customer, product, ...) are unaffected — saving a distinct pattern, or colliding patterns on a non-document type, keeps working exactly as before.
- Improves the generation-time error (`DocumentException::documentNumberAlreadyExistsException` and its `DocumentV2Exception::documentNumberAlreadyExists` counterpart) to name the document type, as defense in depth for data that predates this validation.

Out of scope for this PR: the "burns a number before checking" ordering issue the linked issue also mentions. That's a separate, smaller concern in the increment-storage reservation order and isn't fixed here — flagging it as a follow-up rather than silently dropping it.

### 3. Describe each step to reproduce the issue or behaviour.

1. In Settings > Number ranges, create a number range for document type "Invoice" with pattern `INV{n}`, assigned to sales channel A.
2. Create a second number range for document type "Invoice" with the same pattern `INV{n}`, assigned to sales channel B.
3. Before this change: both save without warning; generating an invoice in each sales channel eventually collides and fails with a generic "already been allocated" error.
4. After this change: step 2 is rejected at save time with a validation error naming the collision.

### 4. Please link to the relevant issues (if any).

- closes #20115

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
