### PR TITLE
chore: update PHPStan to 2.2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,7 +202,7 @@
         "phpdocumentor/type-resolver": "^1.7.1",
         "phpstan/extension-installer": "^1.4.3",
         "phpstan/phpdoc-parser": "^2.0.0",
-        "phpstan/phpstan": "2.2.8",
+        "phpstan/phpstan": "2.2.13",
         "phpstan/phpstan-deprecation-rules": "2.0.5",
         "phpstan/phpstan-phpunit": "2.0.18",
         "phpstan/phpstan-strict-rules": "2.0.12",

--- a/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
@@ -256,6 +256,9 @@ class GoogleProductExportProviderTest extends TestCase
      */
     private function createSalesChannelRepository(array $searches = []): StaticEntityRepository
     {
+        /**
+         * @var StaticEntityRepository<SalesChannelCollection> $repository
+         */
         $repository = new StaticEntityRepository($searches);
 
         return $repository;

--- a/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
@@ -288,6 +288,9 @@ class OpenAiProductExportProviderTest extends TestCase
      */
     private function createSalesChannelRepository(array $searches = []): StaticEntityRepository
     {
+        /**
+         * @var StaticEntityRepository<SalesChannelCollection> $repository
+         */
         $repository = new StaticEntityRepository($searches);
 
         return $repository;


### PR DESCRIPTION
Use the latest PHPStan version to unlock latest speed improvements

before this PR (PHPStan 2.2.8)
```
➜  shopware git:(trunk) composer run phpstan -- --error-format=table --no-progress
> Composer\Config::disableProcessTimeout
> @php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php '--error-format=table' '--no-progress'
> phpstan analyze --memory-limit=4G -vv '--error-format=table' '--no-progress'
Note: Using configuration file /Users/staabm/workspace/shopware/phpstan.neon.dist.
Result cache not used because the metadata do not match: phpstanVersion, metaExtensions, phpVersion, projectConfig, analysedPaths, composerLocks, composerInstalled, executedFilesHashes
Result cache is saved.
                                                                                                                        
 [OK] No errors                                                                                                                                                                                                                                 

Elapsed time: 1 minute 28 seconds
Used memory: 8.07 GB
```

after this PR (PHPStan 2.2.13)
```
➜  shopware git:(trunk) ✗ composer run phpstan -- --error-format=table --no-progress
> Composer\Config::disableProcessTimeout
> @php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php '--error-format=table' '--no-progress'
> phpstan analyze --memory-limit=4G -vv '--error-format=table' '--no-progress'
Note: Using configuration file /Users/staabm/workspace/shopware/phpstan.neon.dist.
Result cache not used because the cache file is corrupted.
Result cache is saved.                                                                                                                                                                  

 [OK] No errors                                                                                                                                                                                                                                 

Elapsed time: 47.21 seconds
Peak memory: 513.09 MB (main process), 504 MB (largest of 14 forked workers)
```

=> 47% faster analysis on a macbook M4-pro using PHP 8.5.10 (cold result-cache)