### PR TITLE
fix(checkout): skip non-applicable fixed price delivery promotions

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -73,7 +73,7 @@ class PromotionDeliveryCalculator
 
         // reduce discount lineItems if fixed price discounts are in collection
         $this->restorePriceDefinitions($discountLineItems);
-        $checkedDiscountLineItems = $this->reduceDiscountLineItemsIfFixedPresent($discountLineItems);
+        $checkedDiscountLineItems = $this->reduceDiscountLineItemsIfFixedPresent($discountLineItems, $toCalculate, $context);
 
         foreach ($checkedDiscountLineItems as $discountItem) {
             if ($notDiscountedDeliveriesValue <= 0.0) {
@@ -214,7 +214,7 @@ class PromotionDeliveryCalculator
      * if there are more than one fixed price lineItems the lowest fixed price discount lineItem is returned
      * if no fixed price discount lineItems are in collection all discounts are returned
      */
-    private function reduceDiscountLineItemsIfFixedPresent(LineItemCollection $discountLineItems): LineItemCollection
+    private function reduceDiscountLineItemsIfFixedPresent(LineItemCollection $discountLineItems, Cart $toCalculate, SalesChannelContext $context): LineItemCollection
     {
         // filter all discountLineItems by scope delivery and type fixed price
         $fixedPricesDiscountLineItems = $discountLineItems->filter(static function (LineItem $discountLineItem) {
@@ -236,6 +236,16 @@ class PromotionDeliveryCalculator
         // if there are no fixed price lineItems we may return all discount line items and calculate them
         if ($fixedPricesDiscountLineItems->count() === 0) {
             return $discountLineItems;
+        }
+
+        $applicableDiscountLineItems = $fixedPricesDiscountLineItems->filter(
+            fn (LineItem $discountLineItem) => $this->isRequirementValid($discountLineItem, $toCalculate, $context)
+        );
+
+        // a fixed price discount that does not apply to the current cart must not shadow an applicable one.
+        // if none of them applies we keep the previous selection, so the customer still gets the not eligible notice
+        if ($applicableDiscountLineItems->count() > 0) {
+            $fixedPricesDiscountLineItems = $applicableDiscountLineItems;
         }
 
         // if there is one fixed price lineItem we return the filtered collection and calculate it

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionDeliveryCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionDeliveryCalculatorTest.php
@@ -369,6 +369,87 @@ class PromotionDeliveryCalculatorTest extends TestCase
         static::assertSame(20.0, $cart->getShippingCosts()->getTotalPrice(), 'Should set shipping to lowest fixed price of 20');
     }
 
+    public function testNotApplicableFixedDeliveryDiscountDoesNotSuppressApplicableOne(): void
+    {
+        $this->quantityPriceCalculator
+            ->method('calculate')
+            ->willReturnCallback(static function (QuantityPriceDefinition $definition, SalesChannelContext $context) {
+                return new CalculatedPrice($definition->getPrice(), $definition->getPrice(), new CalculatedTaxCollection(), new TaxRuleCollection());
+            });
+
+        $applicableDiscount = $this->getDiscountItem('applicable-fixed')
+            ->setPayloadValue('code', 'SHIP50')
+            ->setPayloadValue('discountType', PromotionDiscountEntity::TYPE_FIXED_UNIT)
+            ->setPayloadValue('value', 50)
+            ->setPayloadValue('priority', 1)
+            ->setPriceDefinition(new AbsolutePriceDefinition(50));
+
+        // cheaper, so it wins the reduction, but its requirement does not match the current cart
+        $notApplicableDiscount = $this->getDiscountItem('not-applicable-fixed')
+            ->setPayloadValue('code', 'SHIP20')
+            ->setPayloadValue('discountType', PromotionDiscountEntity::TYPE_FIXED_UNIT)
+            ->setPayloadValue('value', 20)
+            ->setPayloadValue('priority', 2)
+            ->setPriceDefinition(new AbsolutePriceDefinition(20));
+        $notApplicableDiscount->setRequirement(new FalseRule());
+
+        $delivery = new Delivery(
+            new DeliveryPositionCollection(),
+            new DeliveryDate(new \DateTimeImmutable(), new \DateTimeImmutable()),
+            new ShippingMethodEntity(),
+            new ShippingLocation(new CountryEntity(), null, null),
+            new CalculatedPrice(100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection())
+        );
+
+        $cart = new Cart('promotion-test');
+        $cart->setDeliveries(new DeliveryCollection([$delivery]));
+
+        $this->promotionDeliveryCalculator->calculate(
+            new LineItemCollection([$applicableDiscount, $notApplicableDiscount]),
+            $cart,
+            $cart,
+            static::createStub(SalesChannelContext::class)
+        );
+
+        static::assertSame(50.0, $cart->getShippingCosts()->getTotalPrice());
+    }
+
+    public function testAllFixedDeliveryDiscountsNotApplicableKeepsNotEligibleError(): void
+    {
+        $notApplicableDiscount = $this->getDiscountItem('not-applicable-fixed')
+            ->setPayloadValue('code', 'SHIP20')
+            ->setPayloadValue('discountType', PromotionDiscountEntity::TYPE_FIXED_UNIT)
+            ->setPayloadValue('value', 20)
+            ->setPayloadValue('priority', 1)
+            ->setPriceDefinition(new AbsolutePriceDefinition(20));
+        $notApplicableDiscount->setRequirement(new FalseRule());
+
+        $delivery = new Delivery(
+            new DeliveryPositionCollection(),
+            new DeliveryDate(new \DateTimeImmutable(), new \DateTimeImmutable()),
+            new ShippingMethodEntity(),
+            new ShippingLocation(new CountryEntity(), null, null),
+            new CalculatedPrice(100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection())
+        );
+
+        $cart = new Cart('promotion-test');
+        $cart->setDeliveries(new DeliveryCollection([$delivery]));
+
+        $context = static::createStub(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn(null);
+
+        $this->promotionDeliveryCalculator->calculate(
+            new LineItemCollection([$notApplicableDiscount]),
+            $cart,
+            $cart,
+            $context
+        );
+
+        static::assertSame(100.0, $cart->getShippingCosts()->getTotalPrice());
+        static::assertCount(1, $cart->getErrors());
+        static::assertInstanceOf(PromotionNotEligibleError::class, $cart->getErrors()->first());
+    }
+
     public function testNotLoggedInAddsSpecificErrorForDeliveryDiscount(): void
     {
         $discountItem = $this->getDiscountItem('delivery-promotion')


### PR DESCRIPTION
### 1. Why is this change necessary?

`PromotionDeliveryCalculator::reduceDiscountLineItemsIfFixedPresent()` collapses all fixed price delivery discounts down to the single cheapest one before any of them is checked against its requirement rules, because the rule check only happens afterwards in the calculation loop

A fixed price delivery discount that does not apply to the current cart can therefore win that selection, get dropped a few lines later by its own rule, and take every other applicable delivery discount down with it, so the customer ends up with no delivery discount at all even though one was applicable

### 2. What does this change do, exactly?

`reduceDiscountLineItemsIfFixedPresent()` now receives the calculated cart and the sales channel context, and ignores fixed price delivery discounts whose requirement rules do not match the current cart when picking the winner

Evaluating the requirement at that point is already established in this class, since `buildExclusions()` four lines earlier does exactly `$this->isRequirementValid($discountItem, $toCalculate, $context)` with the same two arguments. Because the fixed price path always reduces to exactly one line item, the loop runs a single iteration, so the cart the rule sees there is the same unmutated cart it would see at the later check

If none of the fixed price discounts is applicable, the previous selection is kept deliberately. That preserves both the "exactly one line item" invariant the method documents and the `PromotionNotEligibleError` the customer gets today, so the change stays limited to the case the issue describes

### 3. Describe each step to reproduce the issue or behaviour.

1. Create two delivery promotions, both assigned to the current sales channel, both of discount type "fixed price"
2. Give promotion A a fixed price of 50 and no requirement rule
3. Give promotion B a fixed price of 20 and a requirement rule that does not match the current cart
4. Put a product in the cart with shipping costs of 100

Before this change the shipping costs stay at 100, because B wins the reduction as the cheaper one, is then rejected by its rule, and A is never considered. After this change the shipping costs are 50, because B is disregarded and A is applied

Covered by `PromotionDeliveryCalculatorTest::testNotApplicableFixedDeliveryDiscountDoesNotSuppressApplicableOne`, which fails on trunk with `Failed asserting that 100.0 is identical to 50.0`. `testAllFixedDeliveryDiscountsNotApplicableKeepsNotEligibleError` guards the case where nothing is applicable and passes both before and after

### 4. Please link to the relevant issues (if any).

closes #12178

### 5. Checklist

* [x] I have written tests and verified that they fail without my change
* [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  * Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  * Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  * See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
* [ ] I have written or adjusted the documentation and agent skills according to my changes
* [x] This change has comments for package types, values, functions, and non-obvious lines of code
* [x] I have read the contribution requirements and fulfilled them
