### PR TITLE
fix(content): revoke newsletter opt-in when a customer changes the email address

### DIFF
--- a/src/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdater.php
+++ b/src/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdater.php
@@ -168,6 +168,18 @@ SQL;
 
         foreach ($parameters as $parameter) {
             RetryableQuery::retryable($this->connection, function () use ($parameter): void {
+                // a confirmed double opt-in was given for the old address, it must not carry over to the new one
+                $this->connection->executeStatement(
+                    'UPDATE newsletter_recipient SET status = (:notSet), confirmed_at = NULL WHERE id IN (:ids) AND email <> :email AND status = :optIn',
+                    [
+                        'ids' => Uuid::fromHexToBytesList($parameter['newsletter_ids']),
+                        'email' => $parameter['email'],
+                        'notSet' => NewsletterSubscribeRoute::STATUS_NOT_SET,
+                        'optIn' => NewsletterSubscribeRoute::STATUS_OPT_IN,
+                    ],
+                    ['ids' => ArrayParameterType::BINARY],
+                );
+
                 $this->connection->executeStatement(
                     'UPDATE newsletter_recipient SET email = (:email), first_name = (:firstName), last_name = (:lastName) WHERE id IN (:ids)',
                     [

--- a/tests/integration/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdaterTest.php
+++ b/tests/integration/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdaterTest.php
@@ -198,6 +198,68 @@ class CustomerNewsletterSalesChannelsUpdaterTest extends TestCase
         }
     }
 
+    public function testEmailChangeRevokesConfirmedNewsletterOptIn(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $email = Uuid::randomHex() . '@example.com';
+        $customerId = $this->createCustomer($email);
+
+        $recipientId = $this->createNewsletterRecipient(
+            $context,
+            $email,
+            TestDefaults::SALES_CHANNEL,
+            NewsletterSubscribeRoute::STATUS_OPT_IN,
+            '2025-01-01 10:00:00'
+        );
+
+        /** @var EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository */
+        $newsletterRecipientRepository = static::getContainer()->get('newsletter_recipient.repository');
+
+        $recipient = $newsletterRecipientRepository->search(new Criteria([$recipientId]), $context)->getEntities()->first();
+        static::assertNotNull($recipient);
+        static::assertSame(NewsletterSubscribeRoute::STATUS_OPT_IN, $recipient->getStatus());
+        static::assertNotNull($recipient->getConfirmedAt());
+
+        static::getContainer()->get('customer.repository')->upsert(
+            [['id' => $customerId, 'email' => 'someone-else@example.com']],
+            $context
+        );
+
+        $recipient = $newsletterRecipientRepository->search(new Criteria([$recipientId]), $context)->getEntities()->first();
+        static::assertNotNull($recipient);
+        static::assertSame('someone-else@example.com', $recipient->getEmail());
+        static::assertSame(NewsletterSubscribeRoute::STATUS_NOT_SET, $recipient->getStatus());
+        static::assertNull($recipient->getConfirmedAt());
+    }
+
+    public function testEmailChangeKeepsNewsletterStatusWithoutDoubleOptIn(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $email = Uuid::randomHex() . '@example.com';
+        $customerId = $this->createCustomer($email);
+
+        $recipientId = $this->createNewsletterRecipient(
+            $context,
+            $email,
+            TestDefaults::SALES_CHANNEL,
+            NewsletterSubscribeRoute::STATUS_DIRECT
+        );
+
+        static::getContainer()->get('customer.repository')->upsert(
+            [['id' => $customerId, 'email' => 'someone-else@example.com']],
+            $context
+        );
+
+        /** @var EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository */
+        $newsletterRecipientRepository = static::getContainer()->get('newsletter_recipient.repository');
+        $recipient = $newsletterRecipientRepository->search(new Criteria([$recipientId]), $context)->getEntities()->first();
+        static::assertNotNull($recipient);
+        static::assertSame('someone-else@example.com', $recipient->getEmail());
+        static::assertSame(NewsletterSubscribeRoute::STATUS_DIRECT, $recipient->getStatus());
+    }
+
     public static function createDataProvider(): \Generator
     {
         yield 'Email Newsletter Recipient Not Registered' => [
@@ -239,7 +301,8 @@ class CustomerNewsletterSalesChannelsUpdaterTest extends TestCase
         Context $context,
         string $email,
         string $salesChannelId,
-        string $status = NewsletterSubscribeRoute::STATUS_OPT_IN
+        string $status = NewsletterSubscribeRoute::STATUS_OPT_IN,
+        ?string $confirmedAt = null
     ): string {
         $id = Uuid::randomHex();
 
@@ -250,6 +313,7 @@ class CustomerNewsletterSalesChannelsUpdaterTest extends TestCase
             'hash' => Uuid::randomHex(),
             'salesChannelId' => $salesChannelId,
             'languageId' => Defaults::LANGUAGE_SYSTEM,
+            'confirmedAt' => $confirmedAt,
         ];
 
         static::getContainer()

--- a/tests/unit/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdaterTest.php
+++ b/tests/unit/Core/Content/Newsletter/DataAbstractionLayer/Indexing/CustomerNewsletterSalesChannelsUpdaterTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Newsletter\DataAbstractionLayer\Indexing\CustomerNewsletterSalesChannelsUpdater;
+use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -57,7 +58,23 @@ class CustomerNewsletterSalesChannelsUpdaterTest extends TestCase
 
         $ids = $this->getNewsLetterIds($newsletterIds);
 
-        $this->connection->expects($this->once())->method('executeStatement')->willReturnCallback(static function ($sql, $params) use ($ids): int {
+        $consentReset = false;
+        $this->connection->expects($this->exactly(2))->method('executeStatement')->willReturnCallback(static function ($sql, $params) use ($ids, &$consentReset): int {
+            if (!$consentReset) {
+                $consentReset = true;
+
+                static::assertSame('UPDATE newsletter_recipient SET status = (:notSet), confirmed_at = NULL WHERE id IN (:ids) AND email <> :email AND status = :optIn', $sql);
+
+                static::assertSame([
+                    'ids' => Uuid::fromHexToBytesList($ids),
+                    'email' => 'y.tran@shopware.com',
+                    'notSet' => NewsletterSubscribeRoute::STATUS_NOT_SET,
+                    'optIn' => NewsletterSubscribeRoute::STATUS_OPT_IN,
+                ], $params);
+
+                return 1;
+            }
+
             static::assertSame('UPDATE newsletter_recipient SET email = (:email), first_name = (:firstName), last_name = (:lastName) WHERE id IN (:ids)', $sql);
 
             static::assertSame([
@@ -88,7 +105,23 @@ class CustomerNewsletterSalesChannelsUpdaterTest extends TestCase
         ]);
 
         $ids = $this->getNewsLetterIds($newsletterIds);
-        $this->connection->expects($this->once())->method('executeStatement')->willReturnCallback(static function ($sql, $params) use ($ids): int {
+        $consentReset = false;
+        $this->connection->expects($this->exactly(2))->method('executeStatement')->willReturnCallback(static function ($sql, $params) use ($ids, &$consentReset): int {
+            if (!$consentReset) {
+                $consentReset = true;
+
+                static::assertSame('UPDATE newsletter_recipient SET status = (:notSet), confirmed_at = NULL WHERE id IN (:ids) AND email <> :email AND status = :optIn', $sql);
+
+                static::assertSame([
+                    'ids' => Uuid::fromHexToBytesList($ids),
+                    'email' => 'y.tran@shopware.com',
+                    'notSet' => NewsletterSubscribeRoute::STATUS_NOT_SET,
+                    'optIn' => NewsletterSubscribeRoute::STATUS_OPT_IN,
+                ], $params);
+
+                return 1;
+            }
+
             static::assertSame('UPDATE newsletter_recipient SET email = (:email), first_name = (:firstName), last_name = (:lastName) WHERE id IN (:ids)', $sql);
 
             static::assertSame([


### PR DESCRIPTION
### 1. Why is this change necessary?

With both "Double opt-in on sign-up" and "Double opt-in for registered customers" enabled, a customer can bind an active, confirmed newsletter subscription to somebody else's e-mail address without that address ever confirming anything

`CustomerNewsletterSalesChannelsUpdater::updateCustomersRecipient()` rewrites `newsletter_recipient.email` when a customer's e-mail address changes, but leaves `status` and `confirmed_at` untouched. A recipient that reached `optIn` by confirming for address A therefore stays `optIn` under address B and shows up as "Active" in the administration. Both double opt-ins are defeated, because the consent record is silently re-pointed at an address that never gave consent

Because the propagation sits in the customer indexer rather than in `ChangeEmailRoute`, this affects every write path, including the store-api route, the Admin API, sync, import and CLI

### 2. What does this change do, exactly?

Before the e-mail is rewritten, `updateCustomersRecipient()` now resets affected recipients to `notSet` and clears `confirmedAt`

The reset is scoped twice, on purpose:

* `AND email <> :email` so only rows whose address actually changes are touched, which leaves the subscription alone on unrelated re-indexing of a customer
* `AND status = :optIn` because `optIn` is the only status that can represent a completed double opt-in

Why `direct` is not reset: `direct` counts as subscribed, since the sibling `update()` lists it in its `states` filter, and it is only ever written when double opt-in was disabled at subscribe time. Resetting it would silently unsubscribe customers of every double-opt-in-disabled shop on each e-mail change, which `ChangeEmailRouteTest::testChangeSuccessWithNewsletterRecipient` codifies as the intended behaviour

That leaves one residual case this PR does not close: a shop that ran with double opt-in disabled, accumulated `direct` recipients, and enabled double opt-in afterwards. Nothing re-evaluates or migrates those legacy rows on the config change, so they stay `direct` and would still follow an e-mail change. Closing that would have to key off the current double opt-in setting per sales channel rather than off the status alone, which is a larger change than the reported issue needs, so I am happy to follow up separately if you want it in here

Affected customers become unsubscribed and have to opt in again from the new address, which sends a fresh confirmation mail there

This PR deliberately covers only the newsletter half of the report. Re-triggering the *account* double opt-in on an e-mail change would need a new system config key and is a separate, backwards-compatibility sensitive decision

### 3. Describe each step to reproduce the issue or behaviour.

On a shop with "Double opt-in on sign-up" and "Double opt-in for registered customers" enabled:

1. Register as user A and confirm the account via the mail link
2. Subscribe to the newsletter as user A and confirm it via the mail link, so the recipient is "Active" in the administration
3. Change the account e-mail address to user B's address

Before this change the newsletter recipient shows up under user B's address, still "Active", although user B never received or confirmed anything. After this change the recipient is reset to `notSet` with `confirmedAt` cleared, and the customer is unsubscribed

Covered by `CustomerNewsletterSalesChannelsUpdaterTest::testEmailChangeRevokesConfirmedNewsletterOptIn`, which fails on trunk with `Failed asserting that two strings are identical. -'notSet' +'optIn'`. `testEmailChangeKeepsNewsletterStatusWithoutDoubleOptIn` guards the `direct` case and passes both before and after, as does the existing `ChangeEmailRouteTest::testChangeSuccessWithNewsletterRecipient`

### 4. Please link to the relevant issues (if any).

closes #7893

### 5. Checklist

* [x] I have written tests and verified that they fail without my change
* [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  * Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  * Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  * See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
* [ ] I have written or adjusted the documentation and agent skills according to my changes
* [x] This change has comments for package types, values, functions, and non-obvious lines of code
* [x] I have read the contribution requirements and fulfilled them
