### PR TITLE
fix(checkout): release promotion redemptions when an order is cancelled

### DIFF
--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -193,7 +193,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             $parameters['cancelledStateId'] = $cancelledStateId;
         }
 
-        $sql = <<<SQL
+        $sql = <<<'SQL'
             SELECT LOWER(HEX(order_line_item.promotion_id)) as promotion_id,
                    COUNT(DISTINCT order_line_item.order_id) as total,
                    LOWER(HEX(order_customer.customer_id)) as customer_id
@@ -201,13 +201,15 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
                      INNER JOIN `order`
                                ON (`order`.id = order_line_item.order_id
                                    AND `order`.version_id = order_line_item.order_version_id
-                                   {$cancelledStateFilter})
+                                   #cancelledStateFilter#)
                      LEFT JOIN order_customer
                                ON (order_customer.order_id = order_line_item.order_id
                                    AND order_customer.order_version_id = order_line_item.order_version_id)
             WHERE order_line_item.promotion_id IN (:ids) AND order_line_item.version_id = :versionId AND order_line_item.type = :type
             GROUP BY order_line_item.promotion_id, order_customer.customer_id
         SQL;
+
+        $sql = str_replace('#cancelledStateFilter#', $cancelledStateFilter, $sql);
 
         /** @var list<array{promotion_id: string, total: numeric-string, customer_id: ?string}> $promotions */
         $promotions = $this->connection->fetchAllAssociative(

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Checkout\Promotion\DataAbstractionLayer;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEvents;
+use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -16,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -48,6 +51,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             EntityWriteEvent::class => 'beforeDelete',
             OrderEvents::ORDER_LINE_ITEM_DELETED_EVENT => 'lineItemDeleted',
             OrderEvents::ORDER_LINE_ITEM_WRITTEN_EVENT => 'lineItemCreated',
+            StateMachineTransitionEvent::class => 'orderStateChanged',
         ];
     }
 
@@ -131,6 +135,40 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
     }
 
     /**
+     * Cancelling an order neither writes nor deletes its line items, so the redemption counts would
+     * otherwise keep the promotion claimed forever. Both directions are handled so that reopening a
+     * cancelled order claims the promotion again.
+     */
+    public function orderStateChanged(StateMachineTransitionEvent $event): void
+    {
+        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
+            return;
+        }
+
+        if ($event->getEntityName() !== OrderDefinition::ENTITY_NAME) {
+            return;
+        }
+
+        if ($event->getToPlace()->getTechnicalName() !== OrderStates::STATE_CANCELLED
+            && $event->getFromPlace()->getTechnicalName() !== OrderStates::STATE_CANCELLED
+        ) {
+            return;
+        }
+
+        $promotionIds = $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT LOWER(HEX(promotion_id)) FROM order_line_item
+             WHERE order_id = :orderId AND version_id = :versionId AND type = :type AND promotion_id IS NOT NULL',
+            [
+                'orderId' => Uuid::fromHexToBytes($event->getEntityId()),
+                'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'type' => PromotionProcessor::LINE_ITEM_TYPE,
+            ]
+        );
+
+        $this->update($promotionIds, $event->getContext());
+    }
+
+    /**
      * @param array<string> $ids
      */
     public function update(array $ids, Context $context): void
@@ -141,11 +179,29 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             return;
         }
 
-        $sql = <<<'SQL'
+        $parameters = [
+            'type' => PromotionProcessor::LINE_ITEM_TYPE,
+            'ids' => Uuid::fromHexToBytesList($ids),
+            'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+        ];
+
+        // a cancelled order no longer claims its promotions, so it must not count towards the redemptions
+        $cancelledStateFilter = '';
+        $cancelledStateId = $this->fetchCancelledOrderStateId();
+        if ($cancelledStateId !== null) {
+            $cancelledStateFilter = 'AND `order`.state_id != :cancelledStateId';
+            $parameters['cancelledStateId'] = $cancelledStateId;
+        }
+
+        $sql = <<<SQL
             SELECT LOWER(HEX(order_line_item.promotion_id)) as promotion_id,
                    COUNT(DISTINCT order_line_item.order_id) as total,
                    LOWER(HEX(order_customer.customer_id)) as customer_id
             FROM order_line_item
+                     INNER JOIN `order`
+                               ON (`order`.id = order_line_item.order_id
+                                   AND `order`.version_id = order_line_item.order_version_id
+                                   {$cancelledStateFilter})
                      LEFT JOIN order_customer
                                ON (order_customer.order_id = order_line_item.order_id
                                    AND order_customer.order_version_id = order_line_item.order_version_id)
@@ -156,7 +212,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
         /** @var list<array{promotion_id: string, total: numeric-string, customer_id: ?string}> $promotions */
         $promotions = $this->connection->fetchAllAssociative(
             $sql,
-            ['type' => PromotionProcessor::LINE_ITEM_TYPE, 'ids' => Uuid::fromHexToBytesList($ids), 'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
+            $parameters,
             ['ids' => ArrayParameterType::BINARY]
         );
 
@@ -175,6 +231,23 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
                 'customerCount' => $totals !== [] ? json_encode($totals, \JSON_THROW_ON_ERROR) : null,
             ]);
         }
+    }
+
+    /**
+     * Resolved per call rather than memoised, so the class keeps no state that would need resetting
+     * between requests or test cases.
+     */
+    private function fetchCancelledOrderStateId(): ?string
+    {
+        $id = $this->connection->fetchOne(
+            'SELECT state_machine_state.id
+             FROM state_machine_state
+                 INNER JOIN state_machine ON state_machine.id = state_machine_state.state_machine_id
+             WHERE state_machine.technical_name = :stateMachine AND state_machine_state.technical_name = :state',
+            ['stateMachine' => OrderStates::STATE_MACHINE, 'state' => OrderStates::STATE_CANCELLED]
+        );
+
+        return $id === false ? null : $id;
     }
 
     /**

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
@@ -139,7 +139,7 @@ class PromotionRedemptionOnOrderCancelTest extends TestCase
     public function testReopeningAnOrderClaimedElsewhereExceedsTheGlobalLimit(): void
     {
         $promotionId = Uuid::randomHex();
-        $this->createPromotion($promotionId, maxRedemptionsGlobal: 1);
+        $this->createLimitedPromotion($promotionId, maxRedemptionsGlobal: 1);
 
         $firstOrderId = $this->placeOrder($this->createCustomer());
         $this->transition($firstOrderId, StateMachineTransitionActions::ACTION_CANCEL);
@@ -163,12 +163,12 @@ class PromotionRedemptionOnOrderCancelTest extends TestCase
 
     private function placeOrderWithPromotion(string $promotionId, string $customerId, ?string $productId = null): string
     {
-        $this->createPromotion($promotionId, maxRedemptionsPerCustomer: 1);
+        $this->createLimitedPromotion($promotionId, maxRedemptionsPerCustomer: 1);
 
         return $this->placeOrder($customerId, $productId);
     }
 
-    private function createPromotion(string $promotionId, ?int $maxRedemptionsGlobal = null, ?int $maxRedemptionsPerCustomer = null): void
+    private function createLimitedPromotion(string $promotionId, ?int $maxRedemptionsGlobal = null, ?int $maxRedemptionsPerCustomer = null): void
     {
         $this->promotionRepository->create([[
             'id' => $promotionId,

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
@@ -1,0 +1,268 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart\Promotion\Integration;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
+use Shopware\Core\System\StateMachine\StateMachineRegistry;
+use Shopware\Core\System\StateMachine\Transition;
+use Shopware\Core\Test\Integration\Traits\Promotion\PromotionIntegrationTestBehaviour;
+use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PromotionRedemptionOnOrderCancelTest extends TestCase
+{
+    use CountryAddToSalesChannelTestBehaviour;
+    use IntegrationTestBehaviour;
+    use PromotionIntegrationTestBehaviour;
+    use PromotionTestFixtureBehaviour;
+
+    /**
+     * @var EntityRepository<PromotionCollection>
+     */
+    private EntityRepository $promotionRepository;
+
+    private CartService $cartService;
+
+    private Connection $connection;
+
+    private StateMachineRegistry $stateMachineRegistry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->promotionRepository = static::getContainer()->get('promotion.repository');
+        $this->cartService = static::getContainer()->get(CartService::class);
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->stateMachineRegistry = static::getContainer()->get(StateMachineRegistry::class);
+        $this->addCountriesToSalesChannel();
+    }
+
+    #[Group('promotions')]
+    public function testCancellingAnOrderReleasesThePromotionForTheCustomer(): void
+    {
+        $promotionId = Uuid::randomHex();
+        $customerId = $this->createCustomer();
+        $orderId = $this->placeOrderWithPromotion($promotionId, $customerId);
+
+        static::assertSame(
+            [$customerId => 1],
+            $this->fetchPerCustomerCount($promotionId),
+            'the placed order must claim the promotion for the customer'
+        );
+        static::assertSame(1, $this->fetchOrderCount($promotionId));
+
+        $this->transition($orderId, StateMachineTransitionActions::ACTION_CANCEL);
+
+        static::assertNull(
+            $this->fetchPerCustomerCount($promotionId),
+            'cancelling the order must release the promotion for the customer'
+        );
+        static::assertSame(0, $this->fetchOrderCount($promotionId));
+    }
+
+    #[Group('promotions')]
+    public function testTheReleasedCodeCanBeRedeemedAgain(): void
+    {
+        $promotionId = Uuid::randomHex();
+        $productId = Uuid::randomHex();
+        $customerId = $this->createCustomer();
+        $orderId = $this->placeOrderWithPromotion($promotionId, $customerId, $productId);
+
+        $this->transition($orderId, StateMachineTransitionActions::ACTION_CANCEL);
+
+        $context = $this->createCustomerContext($customerId);
+        $cart = $this->cartService->getCart($context->getToken(), $context);
+        $cart = $this->addProduct($productId, 1, $cart, $this->cartService, $context);
+        $cart = $this->addPromotionCode('TESTCODE', $cart, $this->cartService, $context);
+
+        static::assertCount(
+            1,
+            $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE),
+            'the promotion of a cancelled order must be redeemable again'
+        );
+        static::assertNull($cart->getErrors()->get('promotion-not-eligible'));
+    }
+
+    #[Group('promotions')]
+    public function testCancelReopenCancelKeepsTheCountConsistent(): void
+    {
+        $promotionId = Uuid::randomHex();
+        $customerId = $this->createCustomer();
+        $orderId = $this->placeOrderWithPromotion($promotionId, $customerId);
+
+        $this->transition($orderId, StateMachineTransitionActions::ACTION_CANCEL);
+        static::assertNull($this->fetchPerCustomerCount($promotionId));
+        static::assertSame(0, $this->fetchOrderCount($promotionId));
+
+        $this->transition($orderId, StateMachineTransitionActions::ACTION_REOPEN);
+        static::assertSame(
+            [$customerId => 1],
+            $this->fetchPerCustomerCount($promotionId),
+            'reopening the order must claim the promotion again'
+        );
+        static::assertSame(1, $this->fetchOrderCount($promotionId));
+
+        $this->transition($orderId, StateMachineTransitionActions::ACTION_CANCEL);
+        static::assertNull($this->fetchPerCustomerCount($promotionId));
+        static::assertSame(0, $this->fetchOrderCount($promotionId), 'the count must not drift below zero');
+    }
+
+    private function placeOrderWithPromotion(string $promotionId, string $customerId, ?string $productId = null): string
+    {
+        $productId ??= Uuid::randomHex();
+
+        $this->promotionRepository->create([[
+            'id' => $promotionId,
+            'name' => 'Once per customer',
+            'active' => true,
+            'code' => 'TESTCODE',
+            'useCodes' => true,
+            'useIndividualCodes' => false,
+            'maxRedemptionsPerCustomer' => 1,
+            'salesChannels' => [
+                ['salesChannelId' => TestDefaults::SALES_CHANNEL, 'priority' => 1],
+            ],
+            'discounts' => [
+                [
+                    'scope' => PromotionDiscountEntity::SCOPE_CART,
+                    'type' => PromotionDiscountEntity::TYPE_ABSOLUTE,
+                    'value' => 10,
+                    'considerAdvancedRules' => false,
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        $context = $this->createCustomerContext($customerId);
+        $this->createTestFixtureProduct($productId, 119, 19, static::getContainer(), $context);
+
+        $cart = $this->cartService->getCart($context->getToken(), $context);
+        $cart = $this->addProduct($productId, 1, $cart, $this->cartService, $context);
+        $cart = $this->addPromotionCode('TESTCODE', $cart, $this->cartService, $context);
+
+        static::assertCount(1, $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE));
+
+        return $this->cartService->order($cart, $context, new RequestDataBag());
+    }
+
+    private function transition(string $orderId, string $action): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition('order', $orderId, $action, 'stateId'),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame(
+            $action === StateMachineTransitionActions::ACTION_CANCEL ? OrderStates::STATE_CANCELLED : OrderStates::STATE_OPEN,
+            $this->fetchOrderState($orderId)
+        );
+    }
+
+    /**
+     * @return array<string, int>|null
+     */
+    private function fetchPerCustomerCount(string $promotionId): ?array
+    {
+        $counts = $this->connection->fetchOne(
+            'SELECT orders_per_customer_count FROM promotion WHERE id = :id',
+            ['id' => Uuid::fromHexToBytes($promotionId)]
+        );
+
+        if (!\is_string($counts)) {
+            return null;
+        }
+
+        return json_decode($counts, true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    private function fetchOrderCount(string $promotionId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT order_count FROM promotion WHERE id = :id',
+            ['id' => Uuid::fromHexToBytes($promotionId)]
+        );
+    }
+
+    private function fetchOrderState(string $orderId): string
+    {
+        return (string) $this->connection->fetchOne(
+            'SELECT state_machine_state.technical_name
+             FROM `order`
+                 INNER JOIN state_machine_state ON state_machine_state.id = `order`.state_id
+             WHERE `order`.id = :id AND `order`.version_id = :version',
+            ['id' => Uuid::fromHexToBytes($orderId), 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)]
+        );
+    }
+
+    private function createCustomerContext(string $customerId): SalesChannelContext
+    {
+        return static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [SalesChannelContextService::CUSTOMER_ID => $customerId]
+        );
+    }
+
+    private function createCustomer(): string
+    {
+        $customerId = Uuid::randomHex();
+        $addressId = Uuid::randomHex();
+
+        $customer = [
+            'id' => $customerId,
+            'number' => '1337',
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'customerNumber' => '1337',
+            'email' => Uuid::randomHex() . '@example.com',
+            'password' => TestDefaults::HASHED_PASSWORD,
+            'groupId' => TestDefaults::FALLBACK_CUSTOMER_GROUP,
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'defaultBillingAddressId' => $addressId,
+            'defaultShippingAddressId' => $addressId,
+            'addresses' => [
+                [
+                    'id' => $addressId,
+                    'customerId' => $customerId,
+                    'countryId' => $this->getValidCountryId(),
+                    'salutationId' => $this->getValidSalutationId(),
+                    'firstName' => 'Max',
+                    'lastName' => 'Mustermann',
+                    'street' => 'Ebbinghoff 10',
+                    'zipcode' => '48624',
+                    'city' => 'Schöppingen',
+                ],
+            ],
+        ];
+
+        static::getContainer()
+            ->get('customer.repository')
+            ->upsert([$customer], Context::createDefaultContext());
+
+        return $customerId;
+    }
+}

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionRedemptionOnOrderCancelTest.php
@@ -131,18 +131,54 @@ class PromotionRedemptionOnOrderCancelTest extends TestCase
         static::assertSame(0, $this->fetchOrderCount($promotionId), 'the count must not drift below zero');
     }
 
+    /**
+     * Documents the accepted trade-off from the review: an order reopened after its promotion was
+     * claimed elsewhere over-redeems, until either of the two orders is cancelled again.
+     */
+    #[Group('promotions')]
+    public function testReopeningAnOrderClaimedElsewhereExceedsTheGlobalLimit(): void
+    {
+        $promotionId = Uuid::randomHex();
+        $this->createPromotion($promotionId, maxRedemptionsGlobal: 1);
+
+        $firstOrderId = $this->placeOrder($this->createCustomer());
+        $this->transition($firstOrderId, StateMachineTransitionActions::ACTION_CANCEL);
+
+        $secondOrderId = $this->placeOrder($this->createCustomer());
+        static::assertSame(1, $this->fetchOrderCount($promotionId));
+
+        $this->transition($firstOrderId, StateMachineTransitionActions::ACTION_REOPEN);
+
+        static::assertSame(
+            2,
+            $this->fetchOrderCount($promotionId),
+            'the reopened order claims the promotion again, exceeding the global limit by one'
+        );
+        static::assertSame(1, $this->countPromotionLineItems($firstOrderId), 'the reopened order keeps its discount');
+        static::assertSame(1, $this->countPromotionLineItems($secondOrderId), 'the second order keeps its discount');
+
+        $this->transition($firstOrderId, StateMachineTransitionActions::ACTION_CANCEL);
+        static::assertSame(1, $this->fetchOrderCount($promotionId), 'the absolute recount heals the excess again');
+    }
+
     private function placeOrderWithPromotion(string $promotionId, string $customerId, ?string $productId = null): string
     {
-        $productId ??= Uuid::randomHex();
+        $this->createPromotion($promotionId, maxRedemptionsPerCustomer: 1);
 
+        return $this->placeOrder($customerId, $productId);
+    }
+
+    private function createPromotion(string $promotionId, ?int $maxRedemptionsGlobal = null, ?int $maxRedemptionsPerCustomer = null): void
+    {
         $this->promotionRepository->create([[
             'id' => $promotionId,
-            'name' => 'Once per customer',
+            'name' => 'Test promotion',
             'active' => true,
             'code' => 'TESTCODE',
             'useCodes' => true,
             'useIndividualCodes' => false,
-            'maxRedemptionsPerCustomer' => 1,
+            'maxRedemptionsGlobal' => $maxRedemptionsGlobal,
+            'maxRedemptionsPerCustomer' => $maxRedemptionsPerCustomer,
             'salesChannels' => [
                 ['salesChannelId' => TestDefaults::SALES_CHANNEL, 'priority' => 1],
             ],
@@ -155,6 +191,11 @@ class PromotionRedemptionOnOrderCancelTest extends TestCase
                 ],
             ],
         ]], Context::createDefaultContext());
+    }
+
+    private function placeOrder(string $customerId, ?string $productId = null): string
+    {
+        $productId ??= Uuid::randomHex();
 
         $context = $this->createCustomerContext($customerId);
         $this->createTestFixtureProduct($productId, 119, 19, static::getContainer(), $context);
@@ -196,6 +237,19 @@ class PromotionRedemptionOnOrderCancelTest extends TestCase
         }
 
         return json_decode($counts, true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    private function countPromotionLineItems(string $orderId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM order_line_item
+             WHERE order_id = :orderId AND version_id = :version AND type = :type',
+            [
+                'orderId' => Uuid::fromHexToBytes($orderId),
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'type' => PromotionProcessor::LINE_ITEM_TYPE,
+            ]
+        );
     }
 
     private function fetchOrderCount(string $promotionId): int

--- a/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater;
 use Shopware\Core\Framework\Context;
@@ -23,6 +25,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterfa
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
+use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -312,6 +316,92 @@ class PromotionRedemptionUpdaterTest extends TestCase
             new EntityWriteResult('id', ['promotionId' => Uuid::randomHex()], 'order_line_item', EntityWriteResult::OPERATION_UPDATE),
             false,
         ];
+    }
+
+    public function testOrderStateChangedIgnoresNonLiveVersion(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchFirstColumn');
+
+        $this->getUpdater($connection)->orderStateChanged($this->stateTransition(
+            OrderDefinition::ENTITY_NAME,
+            OrderStates::STATE_OPEN,
+            OrderStates::STATE_CANCELLED,
+            Context::createDefaultContext()->createWithVersionId(Uuid::randomHex())
+        ));
+    }
+
+    public function testOrderStateChangedIgnoresOtherEntities(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchFirstColumn');
+
+        $this->getUpdater($connection)->orderStateChanged($this->stateTransition(
+            'order_transaction',
+            OrderStates::STATE_OPEN,
+            OrderStates::STATE_CANCELLED
+        ));
+    }
+
+    public function testOrderStateChangedIgnoresTransitionsNotTouchingCancelled(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchFirstColumn');
+
+        $this->getUpdater($connection)->orderStateChanged($this->stateTransition(
+            OrderDefinition::ENTITY_NAME,
+            OrderStates::STATE_OPEN,
+            OrderStates::STATE_IN_PROGRESS
+        ));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function cancelledTransitionProvider(): iterable
+    {
+        yield 'entering cancelled' => [OrderStates::STATE_OPEN, OrderStates::STATE_CANCELLED];
+        yield 'leaving cancelled' => [OrderStates::STATE_CANCELLED, OrderStates::STATE_OPEN];
+    }
+
+    #[DataProvider('cancelledTransitionProvider')]
+    public function testOrderStateChangedRecountsBothCancelDirections(string $from, string $to): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchFirstColumn')
+            ->willReturn([]);
+
+        // no promotion line items on the order, so the recount is skipped
+        $connection->expects($this->never())->method('fetchAllAssociative');
+
+        $this->getUpdater($connection)->orderStateChanged(
+            $this->stateTransition(OrderDefinition::ENTITY_NAME, $from, $to)
+        );
+    }
+
+    private function stateTransition(
+        string $entityName,
+        string $fromState,
+        string $toState,
+        ?Context $context = null
+    ): StateMachineTransitionEvent {
+        $from = new StateMachineStateEntity();
+        $from->setUniqueIdentifier(Uuid::randomHex());
+        $from->setTechnicalName($fromState);
+
+        $to = new StateMachineStateEntity();
+        $to->setUniqueIdentifier(Uuid::randomHex());
+        $to->setTechnicalName($toState);
+
+        return new StateMachineTransitionEvent(
+            $entityName,
+            Uuid::randomHex(),
+            $from,
+            $to,
+            $context ?? Context::createDefaultContext()
+        );
     }
 
     private function getUpdater(?Connection $connection = null): PromotionRedemptionUpdater


### PR DESCRIPTION
### 1. Why is this change necessary?

A promotion limited by `maxRedemptionsPerCustomer` stays consumed after the order that carried it is cancelled, so the customer permanently loses the benefit for an order that was never completed

`PromotionRedemptionUpdater` recomputes `promotion.order_count` and `promotion.orders_per_customer_count` from the promotion line items of an order, but it never looks at the owning order's state, and it subscribes only to `order_line_item` writes and deletes. Cancelling an order writes neither, so no recompute is triggered, and even if one were, the query would still count the cancelled order

This follows the solution @mstegmeyer outlined on the issue: add a cancelled-state filter to the updater, and trigger it on entering and leaving the cancelled state

### 2. What does this change do, exactly?

Two coupled edits, both inside `PromotionRedemptionUpdater`. No new class and no DI change, since the service is already tagged `kernel.event_subscriber`

* **Filter** so the recompute joins `order` and excludes orders in the cancelled state
* **Trigger** by adding `StateMachineTransitionEvent` to `getSubscribedEvents()`. The handler mirrors the existing `CustomerMetaFieldSubscriber::fillCustomerMetaDataFields()` guard triple, namely live version, entity is `order`, and the transition enters *or* leaves the relevant state, and then recomputes the promotions of that order. Handling both directions is what makes reopening a cancelled order claim the promotion again

**Why a filter and not a decrement.** `update()` already recomputes absolute values, using `COUNT(DISTINCT order_line_item.order_id)` written with a plain `SET`, so filtering its input is idempotent by construction: cancel, reopen and cancel again converge on the same counts and cannot drift below zero. This is also the direction trunk already moved in, because the delta-based `SET order_count = order_count - :orderCount` from `a6afc83ed15` was replaced by the recompute in #19211

**Scope.** Deliberately limited to `order.state`. Aborting a payment leaves the order `open` and only moves `order_transaction.state` to `failed` or `cancelled`, and those transactions are exactly the ones eligible for a payment retry, so releasing the code there would let it be spent elsewhere while the order still holds it

**Known limitation, not addressed here.** Individual promotion codes stay locked, because `PromotionIndividualCodeRedeemer` has no release path, and a re-claim on reopen would hit `PromotionIndividualCodeEntity::setRedeemed()`, which throws `codeAlreadyRedeemed` if another order took the code meanwhile, producing a 500 *after* the state write has already committed. That needs its own change, so this PR fixes fixed and global codes

The join is an `INNER JOIN` rather than a `LEFT JOIN` because `order_line_item.order_id` and `order_version_id` are `NOT NULL` and carry `fk.order_line_item.order_id ... ON DELETE CASCADE`, so an orphaned promotion line item cannot exist and the join cannot silently drop rows that used to count

Two things worth flagging for review:

* **An extra round trip per recompute**, because `fetchCancelledOrderStateId()` resolves the state id with its own small indexed lookup on each `update()` call, including the one triggered by `lineItemCreated()` on every order placement. I chose the round trip over memoising it so the subscriber keeps no state needing a reset between requests or test cases, and over joining `state_machine_state` into the recompute so the hot query does not grow another join. Happy to switch to either if you prefer
* **Performance**, because the added join is on the `order` primary key `(id, version_id)`, so it is roughly one clustered probe per matching row on the same query as #19536. I could not benchmark it here, having no dataset of that size, so it is worth measuring against a large promotion, ideally alongside the covering index in #20113. If the probe proves material, the alternative shape is `order_line_item.order_id NOT IN (SELECT id FROM \`order\` WHERE state_id = :cancelled AND version_id = :v)`, which scans the usually much smaller cancelled set via `idx.state_index`

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a promotion with a fixed code and `maxRedemptionsPerCustomer = 1`
2. As a customer, add a product, apply the code, and place the order
3. Cancel the order from the administration, or through an `order.state` to `cancelled` transition
4. Start a new checkout as the same customer and apply the same code

Before this change the code is rejected as not eligible and `promotion.orders_per_customer_count` still holds the customer. After it, the counter is released and the code applies again

Covered by the new `PromotionRedemptionOnOrderCancelTest`, where all three tests fail on trunk and pass with the change, and the redeem-again test fails with `Failed asserting that actual size 0 matches expected size 1`. The assertions reach the counter purely through `StateMachineRegistry::transition()` and `update()` is never called manually, so the test cannot pass on the SQL filter alone with the trigger unwired. `testCancelReopenCancelKeepsTheCountConsistent` pins the idempotency

Unit tests cover the guard conditions, so a non-live version, a non-`order` entity, and a transition that touches neither side of `cancelled` must not query

Note: `tests/integration/Core/Checkout/Promotion/` has 7 failures on my machine, but they are identical on a pristine `trunk` checkout with none of my changes applied, so they are pre-existing here and unrelated

### 4. Please link to the relevant issues (if any).

closes #8575
relates #19536

### 5. Checklist

* [x] I have written tests and verified that they fail without my change
* [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  * Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  * Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  * See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
* [ ] I have written or adjusted the documentation and agent skills according to my changes
* [x] This change has comments for package types, values, functions, and non-obvious lines of code
* [x] I have read the contribution requirements and fulfilled them
