### PR TITLE
fix(content-system): keep mirrored consumer wiring decode-legal

### DIFF
--- a/src/Core/Framework/ContentSystem/Mutation/ContextConsumerMirror.php
+++ b/src/Core/Framework/ContentSystem/Mutation/ContextConsumerMirror.php
@@ -169,6 +169,12 @@ class ContextConsumerMirror
             return null;
         }
 
+        // An integer-like key ("0", "42") is coerced to an int array key on write below, and the decode gate
+        // ({@see StoredElementWiringDecoder::decodeConsumers()}) rejects a non-string consumer key.
+        if ((string) (int) $key === $key) {
+            return null;
+        }
+
         // The written property must be the reference property whose resolution proved the consumer, or delivery
         // fills a foreign key while the declared property stays empty.
         $propertyAlias = $resolution->key !== $key ? $resolution->key : null;

--- a/src/Core/Framework/ContentSystem/Mutation/ContextConsumerMirror.php
+++ b/src/Core/Framework/ContentSystem/Mutation/ContextConsumerMirror.php
@@ -169,8 +169,7 @@ class ContextConsumerMirror
             return null;
         }
 
-        // An integer-like key ("0", "42") is coerced to an int array key on write below, and the decode gate
-        // ({@see StoredElementWiringDecoder::decodeConsumers()}) rejects a non-string consumer key.
+        // Integer-like keys ("0", "42") are coerced to int array keys on write below; {@see StoredElementWiringDecoder::decodeConsumers()} rejects a non-string consumer key.
         if ((string) (int) $key === $key) {
             return null;
         }

--- a/src/Core/Framework/ContentSystem/Mutation/Op/AttachElement.php
+++ b/src/Core/Framework/ContentSystem/Mutation/Op/AttachElement.php
@@ -37,7 +37,7 @@ final class AttachElement extends AbstractLayoutMutation
 
         $clone = $this->cloneWithNewIds($this->element);
         $this->affected = $this->subtreeIds($clone);
-        // Derived independently from affected: created must stay the fresh subtree even if affected later widens.
+        // created and affected are the same set here: every node of the fresh subtree.
         $this->created = $this->subtreeIds($clone);
 
         if ($this->parentElementId === null) {

--- a/src/Core/Framework/ContentSystem/Mutation/Op/AttachElement.php
+++ b/src/Core/Framework/ContentSystem/Mutation/Op/AttachElement.php
@@ -37,7 +37,8 @@ final class AttachElement extends AbstractLayoutMutation
 
         $clone = $this->cloneWithNewIds($this->element);
         $this->affected = $this->subtreeIds($clone);
-        $this->created = $this->affected;
+        // Derived independently from affected: created must stay the fresh subtree even if affected later widens.
+        $this->created = $this->subtreeIds($clone);
 
         if ($this->parentElementId === null) {
             return $tree->insertAtRoot($this->index, [$clone]);

--- a/src/Core/Framework/ContentSystem/Mutation/Op/DuplicateElement.php
+++ b/src/Core/Framework/ContentSystem/Mutation/Op/DuplicateElement.php
@@ -33,7 +33,7 @@ final class DuplicateElement extends AbstractLayoutMutation
 
         $clone = $this->cloneWithNewIds($location->node);
         $this->affected = $this->subtreeIds($clone);
-        // Derived independently from affected: created must stay the fresh subtree even if affected later widens.
+        // created and affected are the same set here: every node of the fresh subtree.
         $this->created = $this->subtreeIds($clone);
 
         $index = $this->index ?? $location->index + 1;

--- a/src/Core/Framework/ContentSystem/Mutation/Op/DuplicateElement.php
+++ b/src/Core/Framework/ContentSystem/Mutation/Op/DuplicateElement.php
@@ -33,7 +33,8 @@ final class DuplicateElement extends AbstractLayoutMutation
 
         $clone = $this->cloneWithNewIds($location->node);
         $this->affected = $this->subtreeIds($clone);
-        $this->created = $this->affected;
+        // Derived independently from affected: created must stay the fresh subtree even if affected later widens.
+        $this->created = $this->subtreeIds($clone);
 
         $index = $this->index ?? $location->index + 1;
 

--- a/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
+++ b/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
@@ -58,8 +58,8 @@ reads.
 
 Restricting mirroring to `created()` is what makes an explicit unwiring durable: the ambient offer that proved the
 reference does not go away, so mirroring on a non-creating mutation would write back in the same response the
-consumer that was just removed. That durability holds through every mutation that does not re-create the node.
-`ReplaceElement` is the one exception: it re-scaffolds the target element under the same id, which counts as
-`created()`, so mirroring re-applies to it and restores every consumer the node's own resolutions still prove,
-including one an explicit unwiring had just removed. That is wanted: a type swap is a fresh scaffold, and the
-removal applied to the old node, not the new one.
+consumer that was just removed. That durability holds through every mutation except one: `ReplaceElement`
+re-scaffolds the target element under the same id, which counts as `created()` (see
+[replace-element.md](replace-element.md)), so mirroring re-applies to it and restores every consumer the node's own
+resolutions still prove, including one an explicit unwiring had just removed. That is wanted: a type swap is a
+fresh scaffold, and the removal applied to the old node, not the new one.

--- a/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
+++ b/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
@@ -58,4 +58,8 @@ reads.
 
 Restricting mirroring to `created()` is what makes an explicit unwiring durable: the ambient offer that proved the
 reference does not go away, so mirroring on a non-creating mutation would write back in the same response the
-consumer that was just removed.
+consumer that was just removed. That durability holds through every mutation that does not re-create the node.
+`ReplaceElement` is the one exception: it re-scaffolds the target element under the same id, which counts as
+`created()`, so mirroring re-applies to it and restores every consumer the node's own resolutions still prove,
+including one an explicit unwiring had just removed. That is wanted: a type swap is a fresh scaffold, and the
+removal applied to the old node, not the new one.

--- a/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
+++ b/src/Core/Framework/ContentSystem/Mutation/docs/consumer-mirroring.md
@@ -10,9 +10,11 @@ public-surface allowlist. Only the draft pipeline calls it, so a persisted mutat
 ## What proves a consumer
 
 A resolution yields a consumer only when its `kind` is `Reference`, its `resolved` candidate is non-null with a
-non-empty `contextKey` and a non-null `contextType`, and that candidate's origin is `Parent` or `Root`
-(`scope: ConsumerScope::Root`). `Loader` and `Stored` origins fill themselves and are skipped, as is a `null`
-`resolved`.
+non-empty, non-integer-like `contextKey` and a non-null `contextType`, and that candidate's origin is `Parent` or
+`Root` (`scope: ConsumerScope::Root`). `Loader` and `Stored` origins fill themselves and are skipped, as is a `null`
+`resolved`. An integer-like `contextKey` (e.g. `"0"`, `"42"`) is skipped too: PHP coerces such a key to an int on
+the consumer-map write, and `StoredElementWiringDecoder::decodeConsumers()` rejects a non-string consumer key at
+decode time.
 
 The consumer is keyed by the resolved `contextKey`. It carries `propertyAlias: $resolution->key` whenever the
 resolution's own key differs from that `contextKey`, and `null` when they are equal, because the property key the

--- a/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
@@ -382,7 +382,8 @@ class ContextConsumerMirrorTest extends TestCase
     }
 
     /**
-     * One row per guard in ContextConsumerMirror::consumerFor().
+     * One row per guard in ContextConsumerMirror::consumerFor(), plus two extra rows for the integer-like
+     * context-key guard to cover both a zero and a negative integer-like string.
      *
      * @return iterable<string, array{0: PropertyResolution}>
      */
@@ -416,6 +417,26 @@ class ContextConsumerMirrorTest extends TestCase
             null,
             self::PRODUCT_FQCN,
             new ResolutionCandidate(CandidateOrigin::Parent, '', null, null, DistributionStrategy::Broadcast, ContextType::Single),
+        )];
+
+        yield 'proven candidate carrying an integer-like context key "0"' => [new PropertyResolution(
+            'product',
+            PropertyKind::Reference,
+            true,
+            null,
+            null,
+            self::PRODUCT_FQCN,
+            new ResolutionCandidate(CandidateOrigin::Parent, '0', null, null, DistributionStrategy::Broadcast, ContextType::Single),
+        )];
+
+        yield 'proven candidate carrying an integer-like context key "-7"' => [new PropertyResolution(
+            'product',
+            PropertyKind::Reference,
+            true,
+            null,
+            null,
+            self::PRODUCT_FQCN,
+            new ResolutionCandidate(CandidateOrigin::Parent, '-7', null, null, DistributionStrategy::Broadcast, ContextType::Single),
         )];
     }
 

--- a/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\ContentSystem\Api\DraftLayoutDecoder;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataContext\ContextType;
+use Shopware\Core\Framework\ContentSystem\Layout\Codec\StoredElementCodec;
 use Shopware\Core\Framework\ContentSystem\Layout\Codec\StoredElementWiringDecoder;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\ConsumerScope;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\ContextConsumer;
@@ -36,13 +36,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors a parent-origin resolved reference as a parent-scope consumer on a created element')]
     public function testMirrorsParentOriginAsParentScopeConsumer(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
+        [$tree, $resolutions, $created] = self::parentOriginReferenceScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertArrayHasKey('product', $consumers);
@@ -57,13 +53,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors a root-origin resolved reference as a root-scope consumer on a created element')]
     public function testMirrorsRootOriginAsRootScopeConsumer(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
+        [$tree, $resolutions, $created] = self::rootOriginReferenceScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Root, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertArrayHasKey('product', $consumers);
@@ -75,13 +67,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors one consumer per proven reference when an element consumes two context keys')]
     public function testMirrorsOneConsumerPerProvenReference(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $resolutions = ['p1' => [
-            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
-            self::reference('page', false, self::candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
-        ]];
+        [$tree, $resolutions, $created] = self::twoProvenReferencesScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['p1']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertSame(['product', 'page'], array_keys($consumers));
@@ -103,13 +91,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('keys a cross-key mirror by the resolved candidate context key and aliases it to the written property key')]
     public function testKeysTheConsumerByTheCandidateContextKey(CandidateOrigin $origin, bool $required, ConsumerScope $scope): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
+        [$tree, $resolutions, $created] = self::crossKeyReferenceScenario($origin, $required);
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('crossSellProduct', $required, self::candidate($origin, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertSame(['product'], array_keys($consumers));
@@ -120,15 +104,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors a cross-key reference even though the element provides the candidate context key, because the provider skip is matched against the written property key')]
     public function testMirrorsCrossKeyReferenceDespiteProvidingTheCandidateContextKey(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withProvider('product', BroadcastDistributionConfig::simple())
-            ->build();
+        [$tree, $resolutions, $created] = self::crossKeyReferenceOntoProvidingElementScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertSame(['product'], array_keys($consumers));
@@ -139,13 +117,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors an equal dotted key as a consumer with no propertyAlias, because a dotted consumer key without an alias is legal')]
     public function testMirrorsEqualDottedKeyWithoutAlias(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
+        [$tree, $resolutions, $created] = self::equalDottedKeyScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product.name'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertSame(['product.name'], array_keys($consumers));
@@ -155,15 +129,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors onto a created element nested in a slot, leaving its uncreated ancestors unwired')]
     public function testMirrorsOntoNestedCreatedElement(): void
     {
-        $price = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'price')->build();
-        $inner = StoredElementBuilder::create('Sw:Grid:Container', 'inner')->withSlot('content', [$price])->build();
-        $outer = StoredElementBuilder::create('Sw:Grid:Container', 'outer')->withSlot('content', [$inner])->build();
+        [$tree, $resolutions, $created] = self::nestedCreatedElementScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$outer]),
-            ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['price'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $wiredOuter = $wired->roots[0];
         $wiredInner = $wiredOuter->slots['content'][0];
@@ -176,29 +144,20 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('wires the created element under the second root, leaving the untouched first root the identical instance')]
     public function testWiresCreatedElementUnderSecondRoot(): void
     {
-        $untouched = StoredElementBuilder::create('Sw:Grid:Container', 'root0')->build();
-        $target = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'root1')->build();
+        [$tree, $resolutions, $created] = self::createdElementUnderSecondRootScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$untouched, $target]),
-            ['root1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['root1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
-        static::assertSame($untouched, $wired->roots[0]);
+        static::assertSame($tree->roots[0], $wired->roots[0]);
         static::assertArrayHasKey('product', $this->consumers($wired->roots[1]));
     }
 
     #[TestDox('mirrors only the first of two resolutions sharing a resolved context key, skipping the second')]
     public function testSameContextKeyResolutionsMirrorOnlyTheFirst(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $resolutions = ['p1' => [
-            self::reference('firstProperty', false, self::candidate(CandidateOrigin::Parent, 'product')),
-            self::reference('secondProperty', true, self::candidate(CandidateOrigin::Parent, 'product')),
-        ]];
+        [$tree, $resolutions, $created] = self::sharedContextKeyResolutionsScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['p1']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         $consumers = $this->consumers($wired->roots[0]);
         static::assertSame(['product'], array_keys($consumers));
@@ -208,15 +167,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors normally when the written property key does not collide with any existing consumer base key')]
     public function testMirrorsWhenNoBaseKeyCollides(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withConsumer('other', ContextType::Single)
-            ->build();
+        [$tree, $resolutions, $created] = self::noBaseKeyCollisionScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame(['other', 'product'], array_keys($this->consumers($wired->roots[0])));
     }
@@ -224,16 +177,10 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('never overwrites a consumer the element already carries under the same key')]
     public function testNeverOverwritesExistingConsumer(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withConsumer('product', ContextType::Collection, true, false, null, 'item')
-            ->build();
-        $authored = $this->consumers($element)['product'];
+        [$tree, $resolutions, $created] = self::existingConsumerSameKeyScenario();
+        $authored = $this->consumers($tree->roots[0])['product'];
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($authored, $this->consumers($wired->roots[0])['product']);
     }
@@ -276,9 +223,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('skips a base-key collision against an existing consumer')]
     public function testSkipsBaseKeyCollision(StoredElement $element, PropertyResolution $resolution, string $survivingKey): void
     {
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::baseKeyCollisionScenario($element, $resolution);
 
-        $wired = (new ContextConsumerMirror())->apply($tree, ['p1' => [$resolution]], ['p1']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([$survivingKey], array_keys($this->consumers($wired->roots[0])));
@@ -287,15 +234,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('skips a key the element already fills from a data requirement')]
     public function testSkipsKeyFilledByDataRequirement(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withDataRequirement('product', 'entity', new StubLoaderConfig())
-            ->build();
+        [$tree, $resolutions, $created] = self::dataRequirementFilledKeyScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertArrayNotHasKey('product', $this->consumers($wired->roots[0]));
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -304,15 +245,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('skips a key the element itself provides')]
     public function testSkipsSelfProvidedKey(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withProvider('product', BroadcastDistributionConfig::simple())
-            ->build();
+        [$tree, $resolutions, $created] = self::selfProvidedKeyScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            new StoredTree([$element]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertArrayNotHasKey('product', $this->consumers($wired->roots[0]));
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -321,31 +256,20 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('leaves an element outside the created set unwired even when its reference is proven')]
     public function testLeavesUncreatedElementUnwired(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-            ->withConsumer('authored', ContextType::Single)
-            ->build();
-        $resolutions = ['p1' => [
-            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
-            self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page')),
-        ]];
+        [$tree, $resolutions, $created] = self::uncreatedElementScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['other-id']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
-        static::assertSame($element->contextDefinitions->getAllConsumers(), $this->consumers($wired->roots[0]));
+        static::assertSame($tree->roots[0]->contextDefinitions->getAllConsumers(), $this->consumers($wired->roots[0]));
         static::assertSame(['authored'], array_keys($this->consumers($wired->roots[0])));
     }
 
     #[TestDox('mirrors nothing for a cross-key resolution whose written property key contains a dot, because the decoder rejects a dotted propertyAlias')]
     public function testMirrorsNothingForCrossKeyResolutionWithDottedWrittenKey(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::dottedWrittenKeyScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -354,14 +278,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors nothing for a reference the resolution did not prove')]
     public function testMirrorsNothingForUnprovenReference(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::unprovenReferenceScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [self::reference('product', true, null)]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -380,22 +299,48 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('mirrors nothing for a reference a loader or the element own wiring already fills')]
     public function testMirrorsNothingForSelfFillingOrigin(CandidateOrigin $origin): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::selfFillingOriginScenario($origin);
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [self::reference('product', true, self::candidate($origin, 'product'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([], $this->consumers($wired->roots[0]));
     }
 
     /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function integerLikeGuardBoundaryProvider(): iterable
+    {
+        yield 'zero-padded digits ("007")' => ['007'];
+        yield 'leading plus sign ("+1")' => ['+1'];
+        yield 'leading whitespace (" 1")' => [' 1'];
+        yield 'digit string past PHP_INT_MAX ("9223372036854775808")' => ['9223372036854775808'];
+    }
+
+    /**
+     * None of these context keys is integer-like under the guard ((string) (int) $key === $key): each fails the
+     * round trip through int, so the reference must still be mirrored. A guard reimplemented with ctype_digit()
+     * would wrongly treat "007" and the past-PHP_INT_MAX digit string as integer-like and skip them.
+     */
+    #[DataProvider('integerLikeGuardBoundaryProvider')]
+    #[TestDox('mirrors a cross-key reference whose candidate context key resembles an integer but fails the guard')]
+    public function testMirrorsCrossKeyReferenceWithNonIntegerLikeContextKey(string $contextKey): void
+    {
+        [$tree, $resolutions, $created] = self::integerLikeGuardBoundaryScenario($contextKey);
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        $consumers = $this->consumers($wired->roots[0]);
+        static::assertSame([$contextKey], array_keys($consumers));
+        static::assertSame('product', $consumers[$contextKey]->propertyAlias);
+    }
+
+    /**
      * One row per guard in ContextConsumerMirror::consumerFor(), plus two extra rows for the integer-like
-     * context-key guard to cover both a zero and a negative integer-like string.
+     * context-key guard to cover both a zero and a negative integer-like string, plus a row pinning that a
+     * non-integer-like but dotted written property key ("1.5") is rejected by the dotted-propertyAlias guard,
+     * never by the integer-like guard.
      *
      * @return iterable<string, array{0: PropertyResolution}>
      */
@@ -450,16 +395,25 @@ class ContextConsumerMirrorTest extends TestCase
             self::PRODUCT_FQCN,
             new ResolutionCandidate(CandidateOrigin::Parent, '-7', null, null, DistributionStrategy::Broadcast, ContextType::Single),
         )];
+
+        yield 'written property key "1.5" is not integer-like but is dotted, rejected by the dotted-propertyAlias guard' => [new PropertyResolution(
+            '1.5',
+            PropertyKind::Reference,
+            true,
+            null,
+            null,
+            self::PRODUCT_FQCN,
+            new ResolutionCandidate(CandidateOrigin::Parent, 'product', null, null, DistributionStrategy::Broadcast, ContextType::Single),
+        )];
     }
 
     #[DataProvider('unmirrorableResolutionProvider')]
     #[TestDox('mirrors nothing for a resolution a consumer guard rejects')]
     public function testMirrorsNothingForUnmirrorableResolution(PropertyResolution $resolution): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::unmirrorableResolutionScenario($resolution);
 
-        $wired = (new ContextConsumerMirror())->apply($tree, ['p1' => [$resolution]], ['p1']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -468,14 +422,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('returns the identical tree instance when the created set is empty')]
     public function testReturnsIdenticalTreeForEmptyCreatedSet(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::emptyCreatedSetScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            [],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
     }
@@ -483,14 +432,9 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('returns the identical tree instance when the created id names no element in the tree')]
     public function testReturnsIdenticalTreeForCreatedIdAbsentFromTree(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::createdIdAbsentFromTreeScenario();
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['ghost'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
         static::assertSame([], $this->consumers($wired->roots[0]));
@@ -499,211 +443,84 @@ class ContextConsumerMirrorTest extends TestCase
     #[TestDox('returns the identical tree instance when a created element has no resolutions at all')]
     public function testReturnsIdenticalTreeWhenCreatedElementHasNoResolutions(): void
     {
-        $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
-        $tree = new StoredTree([$element]);
+        [$tree, $resolutions, $created] = self::noResolutionsScenario();
 
-        $wired = (new ContextConsumerMirror())->apply($tree, [], ['p1']);
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
     }
 
     /**
      * Every mirroring scenario this class exercises, as the three arguments {@see ContextConsumerMirror::apply()}
-     * takes, so the decode-conformance test below runs over the same table the behavioural tests do. A scenario
-     * that mirrors nothing today rides along deliberately: three of those guards — the dotted `propertyAlias`,
-     * the base-key collision and the integer-like context key — exist because the consumer they would otherwise
-     * write is one the decode gate refuses, so the guard failing is the only way that consumer ever reaches this
-     * test. The remaining skip scenarios would write a legal consumer and are carried for completeness.
+     * takes, so the decode-conformance test below runs over the same table the behavioural tests do. Each row
+     * calls the same private static fixture method its originating test method uses, so the two cannot diverge. A
+     * scenario that mirrors nothing today rides along deliberately: three of those guards — the dotted
+     * `propertyAlias`, the base-key collision and the integer-like context key — exist because the consumer they
+     * would otherwise write is one the decode gate refuses, so the guard failing is the only way that consumer
+     * ever reaches this test. The remaining skip scenarios would write a legal consumer and are carried for
+     * completeness.
      *
      * @return iterable<string, array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}>
      */
     public static function mirroringScenarioProvider(): iterable
     {
-        $plain = static fn (): StoredTree => new StoredTree([StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build()]);
+        yield 'a parent-origin reference' => self::parentOriginReferenceScenario();
+        yield 'a root-origin reference' => self::rootOriginReferenceScenario();
+        yield 'two proven references on one element' => self::twoProvenReferencesScenario();
 
-        yield 'a parent-origin reference' => [
-            $plain(),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
+        $crossKeyScenarioNames = [
+            'parent origin' => 'a cross-key reference resolved off the parent chain',
+            'root origin' => 'a cross-key reference resolved off the root context',
         ];
 
-        yield 'a root-origin reference' => [
-            $plain(),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Root, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'two proven references on one element' => [
-            $plain(),
-            ['p1' => [
-                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
-                self::reference('page', false, self::candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
-            ]],
-            ['p1'],
-        ];
-
-        yield 'a cross-key reference resolved off the parent chain' => [
-            $plain(),
-            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'a cross-key reference resolved off the root context' => [
-            $plain(),
-            ['p1' => [self::reference('crossSellProduct', false, self::candidate(CandidateOrigin::Root, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'a cross-key reference onto an element providing the candidate context key' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withProvider('product', BroadcastDistributionConfig::simple())
-                    ->build(),
-            ]),
-            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'an equal dotted key' => [
-            $plain(),
-            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product.name'))]],
-            ['p1'],
-        ];
-
-        yield 'a created element nested in a slot' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Grid:Container', 'outer')->withSlot('content', [
-                    StoredElementBuilder::create('Sw:Grid:Container', 'inner')->withSlot('content', [
-                        StoredElementBuilder::create('Sw:Product:PriceDisplay', 'price')->build(),
-                    ])->build(),
-                ])->build(),
-            ]),
-            ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['price'],
-        ];
-
-        yield 'a created element under the second root' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Grid:Container', 'root0')->build(),
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'root1')->build(),
-            ]),
-            ['root1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['root1'],
-        ];
-
-        yield 'two resolutions sharing one resolved context key' => [
-            $plain(),
-            ['p1' => [
-                self::reference('firstProperty', false, self::candidate(CandidateOrigin::Parent, 'product')),
-                self::reference('secondProperty', true, self::candidate(CandidateOrigin::Parent, 'product')),
-            ]],
-            ['p1'],
-        ];
-
-        yield 'a written property key colliding with no existing consumer base key' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withConsumer('other', ContextType::Single)
-                    ->build(),
-            ]),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'a consumer the element already carries under the same key' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withConsumer('product', ContextType::Collection, true, false, null, 'item')
-                    ->build(),
-            ]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
-
-        foreach (self::baseKeyCollisionProvider() as $name => [$element, $resolution]) {
-            yield $name => [new StoredTree([$element]), ['p1' => [$resolution]], ['p1']];
+        foreach (self::crossKeyOriginProvider() as $name => [$origin, $required]) {
+            yield $crossKeyScenarioNames[$name] => self::crossKeyReferenceScenario($origin, $required);
         }
 
-        yield 'a key the element already fills from a data requirement' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withDataRequirement('product', 'entity', new StubLoaderConfig())
-                    ->build(),
-            ]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
+        yield 'a cross-key reference onto an element providing the candidate context key' => self::crossKeyReferenceOntoProvidingElementScenario();
+        yield 'an equal dotted key' => self::equalDottedKeyScenario();
+        yield 'a created element nested in a slot' => self::nestedCreatedElementScenario();
+        yield 'a created element under the second root' => self::createdElementUnderSecondRootScenario();
+        yield 'two resolutions sharing one resolved context key' => self::sharedContextKeyResolutionsScenario();
+        yield 'a written property key colliding with no existing consumer base key' => self::noBaseKeyCollisionScenario();
+        yield 'a consumer the element already carries under the same key' => self::existingConsumerSameKeyScenario();
 
-        yield 'a key the element itself provides' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withProvider('product', BroadcastDistributionConfig::simple())
-                    ->build(),
-            ]),
-            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
+        foreach (self::baseKeyCollisionProvider() as $name => [$element, $resolution]) {
+            yield $name => self::baseKeyCollisionScenario($element, $resolution);
+        }
 
-        yield 'an element outside the created set' => [
-            new StoredTree([
-                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
-                    ->withConsumer('authored', ContextType::Single)
-                    ->build(),
-            ]),
-            ['p1' => [
-                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
-                self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page')),
-            ]],
-            ['other-id'],
-        ];
-
-        yield 'a cross-key resolution whose written property key carries a dot' => [
-            $plain(),
-            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['p1'],
-        ];
-
-        yield 'a reference the resolution did not prove' => [
-            $plain(),
-            ['p1' => [self::reference('product', true, null)]],
-            ['p1'],
-        ];
+        yield 'a key the element already fills from a data requirement' => self::dataRequirementFilledKeyScenario();
+        yield 'a key the element itself provides' => self::selfProvidedKeyScenario();
+        yield 'an element outside the created set' => self::uncreatedElementScenario();
+        yield 'a cross-key resolution whose written property key carries a dot' => self::dottedWrittenKeyScenario();
+        yield 'a reference the resolution did not prove' => self::unprovenReferenceScenario();
 
         foreach (self::selfFillingOriginProvider() as $name => [$origin]) {
-            yield $name => [
-                $plain(),
-                ['p1' => [self::reference('product', true, self::candidate($origin, 'product'))]],
-                ['p1'],
-            ];
+            yield $name => self::selfFillingOriginScenario($origin);
         }
 
         foreach (self::unmirrorableResolutionProvider() as $name => [$resolution]) {
-            yield $name => [$plain(), ['p1' => [$resolution]], ['p1']];
+            yield $name => self::unmirrorableResolutionScenario($resolution);
         }
 
-        yield 'an empty created set' => [
-            $plain(),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            [],
-        ];
+        foreach (self::integerLikeGuardBoundaryProvider() as $name => [$contextKey]) {
+            yield $name => self::integerLikeGuardBoundaryScenario($contextKey);
+        }
 
-        yield 'a created id naming no element in the tree' => [
-            $plain(),
-            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
-            ['ghost'],
-        ];
-
-        yield 'a created element with no resolutions at all' => [$plain(), [], ['p1']];
+        yield 'an empty created set' => self::emptyCreatedSetScenario();
+        yield 'a created id naming no element in the tree' => self::createdIdAbsentFromTreeScenario();
+        yield 'a created element with no resolutions at all' => self::noResolutionsScenario();
     }
 
     /**
      * A mirrored consumer is written straight onto an in-memory tree, so nothing in the mirror itself proves the
-     * result survives the gate the client's next request puts it through: the element goes back out over HTTP,
-     * comes back in through {@see DraftLayoutDecoder}, and reaches {@see StoredElementWiringDecoder} — whose
-     * rules the mirror only hand-guards. This runs the encode shape the response carries, through the JSON round
-     * trip the wire performs, into that decoder. An integer-like consumer key is an integer array key before it
-     * is ever encoded, because PHP coerces it the moment the mirror assigns it; the round trip is here because it
-     * is what the HTTP boundary does, and it carries that key through as an integer for the decoder to refuse.
+     * result survives the gate the client's next request puts it through: the element goes back out over HTTP and
+     * comes back in through the same decode sequence {@see StoredElementCodec::decodeElement()} runs, reaching
+     * {@see StoredElementWiringDecoder} — whose rules the mirror only hand-guards. This runs the encode shape the
+     * response carries, through the JSON round trip the wire performs, into that decoder. An integer-like consumer
+     * key is an integer array key before it is ever encoded, because PHP coerces it the moment the mirror assigns
+     * it; the round trip is here because it is what the HTTP boundary does, and it carries that key through as an
+     * integer for the decoder to refuse.
      *
      * The pin is that no decode step throws. The equality below is the narrower claim that encode and decode
      * agree on the map, and it can only fail where a consumer decodes into something other than what was written.
@@ -721,8 +538,8 @@ class ContextConsumerMirrorTest extends TestCase
         foreach ($this->flatten($wired->roots) as $element) {
             $wireShape = $this->roundTrip($element);
 
-            $consumers = $decoder->decodeConsumers($wireShape['acceptsContext'] ?? []);
             $providers = $decoder->decodeProviders($wireShape['providesContext'] ?? []);
+            $consumers = $decoder->decodeConsumers($wireShape['acceptsContext'] ?? []);
             $decoder->rejectInvalidElementWiring($consumers, $providers);
 
             static::assertEquals(
@@ -731,6 +548,334 @@ class ContextConsumerMirrorTest extends TestCase
                 \sprintf('Element "%s" does not decode back to the consumer map the mirror left on it.', $element->id)
             );
         }
+    }
+
+    private static function plainTree(): StoredTree
+    {
+        return new StoredTree([StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build()]);
+    }
+
+    /**
+     * Shared by testSkipsBaseKeyCollision and mirroringScenarioProvider.
+     *
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function baseKeyCollisionScenario(StoredElement $element, PropertyResolution $resolution): array
+    {
+        return [new StoredTree([$element]), ['p1' => [$resolution]], ['p1']];
+    }
+
+    /**
+     * Shared by testMirrorsNothingForSelfFillingOrigin and mirroringScenarioProvider.
+     *
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function selfFillingOriginScenario(CandidateOrigin $origin): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, self::candidate($origin, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * Shared by testMirrorsNothingForUnmirrorableResolution and mirroringScenarioProvider.
+     *
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function unmirrorableResolutionScenario(PropertyResolution $resolution): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [$resolution]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function parentOriginReferenceScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function rootOriginReferenceScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Root, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function twoProvenReferencesScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('page', false, self::candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
+            ]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * Shared by {@see testKeysTheConsumerByTheCandidateContextKey} (via crossKeyOriginProvider) and
+     * mirroringScenarioProvider.
+     *
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function crossKeyReferenceScenario(CandidateOrigin $origin, bool $required): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('crossSellProduct', $required, self::candidate($origin, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function crossKeyReferenceOntoProvidingElementScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withProvider('product', BroadcastDistributionConfig::simple())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function equalDottedKeyScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product.name'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function nestedCreatedElementScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Grid:Container', 'outer')->withSlot('content', [
+                    StoredElementBuilder::create('Sw:Grid:Container', 'inner')->withSlot('content', [
+                        StoredElementBuilder::create('Sw:Product:PriceDisplay', 'price')->build(),
+                    ])->build(),
+                ])->build(),
+            ]),
+            ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['price'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function createdElementUnderSecondRootScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Grid:Container', 'root0')->build(),
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'root1')->build(),
+            ]),
+            ['root1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['root1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function sharedContextKeyResolutionsScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [
+                self::reference('firstProperty', false, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('secondProperty', true, self::candidate(CandidateOrigin::Parent, 'product')),
+            ]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function noBaseKeyCollisionScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('other', ContextType::Single)
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function existingConsumerSameKeyScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('product', ContextType::Collection, true, false, null, 'item')
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function dataRequirementFilledKeyScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withDataRequirement('product', 'entity', new StubLoaderConfig())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function selfProvidedKeyScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withProvider('product', BroadcastDistributionConfig::simple())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function uncreatedElementScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('authored', ContextType::Single)
+                    ->build(),
+            ]),
+            ['p1' => [
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page')),
+            ]],
+            ['other-id'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function dottedWrittenKeyScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function unprovenReferenceScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, null)]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function integerLikeGuardBoundaryScenario(string $contextKey): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, $contextKey))]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function emptyCreatedSetScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            [],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function createdIdAbsentFromTreeScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['ghost'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function noResolutionsScenario(): array
+    {
+        return [
+            self::plainTree(),
+            [],
+            ['p1'],
+        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
@@ -6,7 +6,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\ContentSystem\Api\DraftLayoutDecoder;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataContext\ContextType;
+use Shopware\Core\Framework\ContentSystem\Layout\Codec\StoredElementWiringDecoder;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\ConsumerScope;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\ContextConsumer;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\Distribution\BroadcastDistributionConfig;
@@ -38,7 +40,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -59,7 +61,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', false, $this->candidate(CandidateOrigin::Root, 'product'))]],
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Root, 'product'))]],
             ['p1'],
         );
 
@@ -75,8 +77,8 @@ class ContextConsumerMirrorTest extends TestCase
     {
         $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
         $resolutions = ['p1' => [
-            $this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product')),
-            $this->reference('page', false, $this->candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
+            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+            self::reference('page', false, self::candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
         ]];
 
         $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['p1']);
@@ -105,7 +107,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('crossSellProduct', $required, $this->candidate($origin, 'product'))]],
+            ['p1' => [self::reference('crossSellProduct', $required, self::candidate($origin, 'product'))]],
             ['p1'],
         );
 
@@ -124,7 +126,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('crossSellProduct', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -141,7 +143,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product.name', true, $this->candidate(CandidateOrigin::Parent, 'product.name'))]],
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product.name'))]],
             ['p1'],
         );
 
@@ -159,7 +161,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$outer]),
-            ['price' => [$this->reference('product', false, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['price'],
         );
 
@@ -179,7 +181,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$untouched, $target]),
-            ['root1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['root1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['root1'],
         );
 
@@ -192,8 +194,8 @@ class ContextConsumerMirrorTest extends TestCase
     {
         $element = StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build();
         $resolutions = ['p1' => [
-            $this->reference('firstProperty', false, $this->candidate(CandidateOrigin::Parent, 'product')),
-            $this->reference('secondProperty', true, $this->candidate(CandidateOrigin::Parent, 'product')),
+            self::reference('firstProperty', false, self::candidate(CandidateOrigin::Parent, 'product')),
+            self::reference('secondProperty', true, self::candidate(CandidateOrigin::Parent, 'product')),
         ]];
 
         $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['p1']);
@@ -212,7 +214,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -229,7 +231,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', false, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -237,7 +239,11 @@ class ContextConsumerMirrorTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{0: StoredElement, 1: string}>
+     * The written property key and the existing consumer's key each reduce to a base key, and either side may
+     * be the dotted one. The third row is the mirror image of the second: it dots the written key instead of
+     * the existing consumer's, so a comparison that reduced only the existing-consumer side fails it.
+     *
+     * @return iterable<string, array{0: StoredElement, 1: PropertyResolution, 2: string}>
      */
     public static function baseKeyCollisionProvider(): iterable
     {
@@ -245,6 +251,7 @@ class ContextConsumerMirrorTest extends TestCase
             StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
                 ->withConsumer('x', ContextType::Single, false, false, null, 'product')
                 ->build(),
+            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'y')),
             'x',
         ];
 
@@ -252,21 +259,26 @@ class ContextConsumerMirrorTest extends TestCase
             StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
                 ->withConsumer('product.name', ContextType::Single)
                 ->build(),
+            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'y')),
             'product.name',
+        ];
+
+        yield 'dotted written key against an undotted existing consumer key' => [
+            StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                ->withConsumer('product', ContextType::Single)
+                ->build(),
+            self::reference('product.sku', true, self::candidate(CandidateOrigin::Parent, 'product.sku')),
+            'product',
         ];
     }
 
     #[DataProvider('baseKeyCollisionProvider')]
     #[TestDox('skips a base-key collision against an existing consumer')]
-    public function testSkipsBaseKeyCollision(StoredElement $element, string $survivingKey): void
+    public function testSkipsBaseKeyCollision(StoredElement $element, PropertyResolution $resolution, string $survivingKey): void
     {
         $tree = new StoredTree([$element]);
 
-        $wired = (new ContextConsumerMirror())->apply(
-            $tree,
-            ['p1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'y'))]],
-            ['p1'],
-        );
+        $wired = (new ContextConsumerMirror())->apply($tree, ['p1' => [$resolution]], ['p1']);
 
         static::assertSame($tree, $wired);
         static::assertSame([$survivingKey], array_keys($this->consumers($wired->roots[0])));
@@ -281,7 +293,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', false, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -298,7 +310,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             new StoredTree([$element]),
-            ['p1' => [$this->reference('product', false, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -313,8 +325,8 @@ class ContextConsumerMirrorTest extends TestCase
             ->withConsumer('authored', ContextType::Single)
             ->build();
         $resolutions = ['p1' => [
-            $this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product')),
-            $this->reference('page', true, $this->candidate(CandidateOrigin::Root, 'page')),
+            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+            self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page')),
         ]];
 
         $wired = (new ContextConsumerMirror())->apply(new StoredTree([$element]), $resolutions, ['other-id']);
@@ -331,7 +343,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             $tree,
-            ['p1' => [$this->reference('product.name', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['p1'],
         );
 
@@ -347,7 +359,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             $tree,
-            ['p1' => [$this->reference('product', true, null)]],
+            ['p1' => [self::reference('product', true, null)]],
             ['p1'],
         );
 
@@ -373,7 +385,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             $tree,
-            ['p1' => [$this->reference('product', true, $this->candidate($origin, 'product'))]],
+            ['p1' => [self::reference('product', true, self::candidate($origin, 'product'))]],
             ['p1'],
         );
 
@@ -461,7 +473,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             $tree,
-            ['p1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             [],
         );
 
@@ -476,7 +488,7 @@ class ContextConsumerMirrorTest extends TestCase
 
         $wired = (new ContextConsumerMirror())->apply(
             $tree,
-            ['p1' => [$this->reference('product', true, $this->candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['ghost'],
         );
 
@@ -496,6 +508,265 @@ class ContextConsumerMirrorTest extends TestCase
     }
 
     /**
+     * Every mirroring scenario this class exercises, as the three arguments {@see ContextConsumerMirror::apply()}
+     * takes, so the decode-conformance test below runs over the same table the behavioural tests do. A scenario
+     * that mirrors nothing today rides along deliberately: three of those guards — the dotted `propertyAlias`,
+     * the base-key collision and the integer-like context key — exist because the consumer they would otherwise
+     * write is one the decode gate refuses, so the guard failing is the only way that consumer ever reaches this
+     * test. The remaining skip scenarios would write a legal consumer and are carried for completeness.
+     *
+     * @return iterable<string, array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}>
+     */
+    public static function mirroringScenarioProvider(): iterable
+    {
+        $plain = static fn (): StoredTree => new StoredTree([StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')->build()]);
+
+        yield 'a parent-origin reference' => [
+            $plain(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a root-origin reference' => [
+            $plain(),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Root, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'two proven references on one element' => [
+            $plain(),
+            ['p1' => [
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('page', false, self::candidate(CandidateOrigin::Root, 'page', ContextType::Collection)),
+            ]],
+            ['p1'],
+        ];
+
+        yield 'a cross-key reference resolved off the parent chain' => [
+            $plain(),
+            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a cross-key reference resolved off the root context' => [
+            $plain(),
+            ['p1' => [self::reference('crossSellProduct', false, self::candidate(CandidateOrigin::Root, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a cross-key reference onto an element providing the candidate context key' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withProvider('product', BroadcastDistributionConfig::simple())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'an equal dotted key' => [
+            $plain(),
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product.name'))]],
+            ['p1'],
+        ];
+
+        yield 'a created element nested in a slot' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Grid:Container', 'outer')->withSlot('content', [
+                    StoredElementBuilder::create('Sw:Grid:Container', 'inner')->withSlot('content', [
+                        StoredElementBuilder::create('Sw:Product:PriceDisplay', 'price')->build(),
+                    ])->build(),
+                ])->build(),
+            ]),
+            ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['price'],
+        ];
+
+        yield 'a created element under the second root' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Grid:Container', 'root0')->build(),
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'root1')->build(),
+            ]),
+            ['root1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['root1'],
+        ];
+
+        yield 'two resolutions sharing one resolved context key' => [
+            $plain(),
+            ['p1' => [
+                self::reference('firstProperty', false, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('secondProperty', true, self::candidate(CandidateOrigin::Parent, 'product')),
+            ]],
+            ['p1'],
+        ];
+
+        yield 'a written property key colliding with no existing consumer base key' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('other', ContextType::Single)
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a consumer the element already carries under the same key' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('product', ContextType::Collection, true, false, null, 'item')
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        foreach (self::baseKeyCollisionProvider() as $name => [$element, $resolution]) {
+            yield $name => [new StoredTree([$element]), ['p1' => [$resolution]], ['p1']];
+        }
+
+        yield 'a key the element already fills from a data requirement' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withDataRequirement('product', 'entity', new StubLoaderConfig())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a key the element itself provides' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withProvider('product', BroadcastDistributionConfig::simple())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'an element outside the created set' => [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withConsumer('authored', ContextType::Single)
+                    ->build(),
+            ]),
+            ['p1' => [
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product')),
+                self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page')),
+            ]],
+            ['other-id'],
+        ];
+
+        yield 'a cross-key resolution whose written property key carries a dot' => [
+            $plain(),
+            ['p1' => [self::reference('product.name', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
+        ];
+
+        yield 'a reference the resolution did not prove' => [
+            $plain(),
+            ['p1' => [self::reference('product', true, null)]],
+            ['p1'],
+        ];
+
+        foreach (self::selfFillingOriginProvider() as $name => [$origin]) {
+            yield $name => [
+                $plain(),
+                ['p1' => [self::reference('product', true, self::candidate($origin, 'product'))]],
+                ['p1'],
+            ];
+        }
+
+        foreach (self::unmirrorableResolutionProvider() as $name => [$resolution]) {
+            yield $name => [$plain(), ['p1' => [$resolution]], ['p1']];
+        }
+
+        yield 'an empty created set' => [
+            $plain(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            [],
+        ];
+
+        yield 'a created id naming no element in the tree' => [
+            $plain(),
+            ['p1' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['ghost'],
+        ];
+
+        yield 'a created element with no resolutions at all' => [$plain(), [], ['p1']];
+    }
+
+    /**
+     * A mirrored consumer is written straight onto an in-memory tree, so nothing in the mirror itself proves the
+     * result survives the gate the client's next request puts it through: the element goes back out over HTTP,
+     * comes back in through {@see DraftLayoutDecoder}, and reaches {@see StoredElementWiringDecoder} — whose
+     * rules the mirror only hand-guards. This runs the encode shape the response carries, through the JSON round
+     * trip the wire performs, into that decoder. An integer-like consumer key is an integer array key before it
+     * is ever encoded, because PHP coerces it the moment the mirror assigns it; the round trip is here because it
+     * is what the HTTP boundary does, and it carries that key through as an integer for the decoder to refuse.
+     *
+     * The pin is that no decode step throws. The equality below is the narrower claim that encode and decode
+     * agree on the map, and it can only fail where a consumer decodes into something other than what was written.
+     *
+     * @param array<string, list<PropertyResolution>> $resolutions
+     * @param list<string> $createdElementIds
+     */
+    #[DataProvider('mirroringScenarioProvider')]
+    #[TestDox('writes wiring the decode gate reads back for $_dataName')]
+    public function testMirroredWiringSurvivesTheDecodeGate(StoredTree $tree, array $resolutions, array $createdElementIds): void
+    {
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $createdElementIds);
+        $decoder = new StoredElementWiringDecoder();
+
+        foreach ($this->flatten($wired->roots) as $element) {
+            $wireShape = $this->roundTrip($element);
+
+            $consumers = $decoder->decodeConsumers($wireShape['acceptsContext'] ?? []);
+            $providers = $decoder->decodeProviders($wireShape['providesContext'] ?? []);
+            $decoder->rejectInvalidElementWiring($consumers, $providers);
+
+            static::assertEquals(
+                $element->contextDefinitions->getAllConsumers(),
+                $consumers,
+                \sprintf('Element "%s" does not decode back to the consumer map the mirror left on it.', $element->id)
+            );
+        }
+    }
+
+    /**
+     * The encoded element put through the JSON round trip the HTTP boundary performs, so PHP's array-key
+     * coercion applies to every wiring key exactly as it does on a real request body.
+     *
+     * @return array<array-key, mixed>
+     */
+    private function roundTrip(StoredElement $element): array
+    {
+        return (array) json_decode(json_encode($element->jsonSerialize(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param list<StoredElement> $elements
+     *
+     * @return list<StoredElement>
+     */
+    private function flatten(array $elements): array
+    {
+        $flat = [];
+
+        foreach ($elements as $element) {
+            $flat[] = $element;
+
+            foreach ($element->slots as $children) {
+                foreach ($this->flatten($children) as $descendant) {
+                    $flat[] = $descendant;
+                }
+            }
+        }
+
+        return $flat;
+    }
+
+    /**
      * @return array<string, ContextConsumer>
      */
     private function consumers(StoredElement $element): array
@@ -503,12 +774,12 @@ class ContextConsumerMirrorTest extends TestCase
         return $element->contextDefinitions->getAllConsumers();
     }
 
-    private function reference(string $key, bool $required, ?ResolutionCandidate $resolved): PropertyResolution
+    private static function reference(string $key, bool $required, ?ResolutionCandidate $resolved): PropertyResolution
     {
         return new PropertyResolution($key, PropertyKind::Reference, $required, null, null, self::PRODUCT_FQCN, $resolved);
     }
 
-    private function candidate(CandidateOrigin $origin, string $contextKey, ContextType $type = ContextType::Single): ResolutionCandidate
+    private static function candidate(CandidateOrigin $origin, string $contextKey, ContextType $type = ContextType::Single): ResolutionCandidate
     {
         return new ResolutionCandidate($origin, $contextKey, null, null, DistributionStrategy::Broadcast, $type);
     }

--- a/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Mutation/ContextConsumerMirrorTest.php
@@ -114,6 +114,24 @@ class ContextConsumerMirrorTest extends TestCase
         static::assertSame(ConsumerScope::Parent, $consumers['product']->scope);
     }
 
+    /**
+     * Mirroring rebuilds the element's whole {@see ContextDefinitions}, carrying the providers over unchanged.
+     * Nothing else on the element reads them back, so a rebuild that dropped them is only observable here.
+     */
+    #[TestDox('preserves the providers an element already declares when mirroring writes a consumer onto it')]
+    public function testPreservesExistingProvidersOnARewiredElement(): void
+    {
+        [$tree, $resolutions, $created] = self::crossKeyReferenceOntoProvidingElementScenario();
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        static::assertArrayHasKey('product', $this->consumers($wired->roots[0]));
+        static::assertSame(
+            $tree->roots[0]->contextDefinitions->getAllProviders(),
+            $wired->roots[0]->contextDefinitions->getAllProviders()
+        );
+    }
+
     #[TestDox('mirrors an equal dotted key as a consumer with no propertyAlias, because a dotted consumer key without an alias is legal')]
     public function testMirrorsEqualDottedKeyWithoutAlias(): void
     {
@@ -139,6 +157,24 @@ class ContextConsumerMirrorTest extends TestCase
         static::assertArrayHasKey('product', $this->consumers($wiredInner->slots['content'][0]));
         static::assertSame([], $this->consumers($wiredInner));
         static::assertSame([], $this->consumers($wiredOuter));
+    }
+
+    /**
+     * The one input where both rebuild steps fire on the same element: it gains its own mirrored consumer
+     * through {@see StoredElement::withContextDefinitions()} and a rewired child through
+     * {@see StoredElement::withSlots()}. A rebuild that applied the second step to the pre-rebuild element
+     * would drop the consumer the first step wrote.
+     */
+    #[TestDox('mirrors onto a created container and the created child it holds in one pass')]
+    public function testMirrorsOntoCreatedContainerAndItsCreatedChild(): void
+    {
+        [$tree, $resolutions, $created] = self::createdContainerWithCreatedChildScenario();
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        $wiredOuter = $wired->roots[0];
+        static::assertSame(['page'], array_keys($this->consumers($wiredOuter)));
+        static::assertSame(['product'], array_keys($this->consumers($wiredOuter->slots['content'][0])));
     }
 
     #[TestDox('wires the created element under the second root, leaving the untouched first root the identical instance')]
@@ -188,9 +224,11 @@ class ContextConsumerMirrorTest extends TestCase
     /**
      * The written property key and the existing consumer's key each reduce to a base key, and either side may
      * be the dotted one. The third row is the mirror image of the second: it dots the written key instead of
-     * the existing consumer's, so a comparison that reduced only the existing-consumer side fails it.
+     * the existing consumer's, so a comparison that reduced only the existing-consumer side fails it. The
+     * fourth row puts the colliding consumer second, so a comparison that inspected only the first entry of
+     * the existing consumer map instead of looping it mirrors the reference and fails the row.
      *
-     * @return iterable<string, array{0: StoredElement, 1: PropertyResolution, 2: string}>
+     * @return iterable<string, array{0: StoredElement, 1: PropertyResolution, 2: list<string>}>
      */
     public static function baseKeyCollisionProvider(): iterable
     {
@@ -199,7 +237,7 @@ class ContextConsumerMirrorTest extends TestCase
                 ->withConsumer('x', ContextType::Single, false, false, null, 'product')
                 ->build(),
             self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'y')),
-            'x',
+            ['x'],
         ];
 
         yield 'existing dotted consumer key sharing the first segment' => [
@@ -207,7 +245,7 @@ class ContextConsumerMirrorTest extends TestCase
                 ->withConsumer('product.name', ContextType::Single)
                 ->build(),
             self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'y')),
-            'product.name',
+            ['product.name'],
         ];
 
         yield 'dotted written key against an undotted existing consumer key' => [
@@ -215,20 +253,42 @@ class ContextConsumerMirrorTest extends TestCase
                 ->withConsumer('product', ContextType::Single)
                 ->build(),
             self::reference('product.sku', true, self::candidate(CandidateOrigin::Parent, 'product.sku')),
-            'product',
+            ['product'],
+        ];
+
+        yield 'collision against the second of two existing consumers' => [
+            StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                ->withConsumer('unrelated', ContextType::Single)
+                ->withConsumer('product.name', ContextType::Single)
+                ->build(),
+            self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'y')),
+            ['unrelated', 'product.name'],
         ];
     }
 
+    /**
+     * @param list<string> $survivingKeys
+     */
     #[DataProvider('baseKeyCollisionProvider')]
     #[TestDox('skips a base-key collision against an existing consumer')]
-    public function testSkipsBaseKeyCollision(StoredElement $element, PropertyResolution $resolution, string $survivingKey): void
+    public function testSkipsBaseKeyCollision(StoredElement $element, PropertyResolution $resolution, array $survivingKeys): void
     {
         [$tree, $resolutions, $created] = self::baseKeyCollisionScenario($element, $resolution);
 
         $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
 
         static::assertSame($tree, $wired);
-        static::assertSame([$survivingKey], array_keys($this->consumers($wired->roots[0])));
+        static::assertSame($survivingKeys, array_keys($this->consumers($wired->roots[0])));
+    }
+
+    #[TestDox('skips a second resolution whose written key base-collides with the consumer the first resolution wrote')]
+    public function testSkipsBaseKeyCollisionAgainstAConsumerWrittenInTheSameApply(): void
+    {
+        [$tree, $resolutions, $created] = self::accumulatedBaseKeyCollisionScenario();
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        static::assertSame(['productA'], array_keys($this->consumers($wired->roots[0])));
     }
 
     #[TestDox('skips a key the element already fills from a data requirement')]
@@ -240,6 +300,24 @@ class ContextConsumerMirrorTest extends TestCase
 
         static::assertArrayNotHasKey('product', $this->consumers($wired->roots[0]));
         static::assertSame([], $this->consumers($wired->roots[0]));
+    }
+
+    /**
+     * The data-requirement skip is matched against the written property key, so a requirement keyed on the
+     * resolved candidate context key does not suppress the mirror. This is the counterpart of
+     * {@see testMirrorsCrossKeyReferenceDespiteProvidingTheCandidateContextKey} for the requirement half of
+     * the same guard.
+     */
+    #[TestDox('mirrors a cross-key reference whose candidate context key, not its written property key, names a data requirement the element fills')]
+    public function testMirrorsCrossKeyReferenceDespiteADataRequirementOnTheCandidateContextKey(): void
+    {
+        [$tree, $resolutions, $created] = self::dataRequirementOnTheCandidateContextKeyScenario();
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        $consumers = $this->consumers($wired->roots[0]);
+        static::assertSame(['product'], array_keys($consumers));
+        static::assertSame('crossSellProduct', $consumers['product']->propertyAlias);
     }
 
     #[TestDox('skips a key the element itself provides')]
@@ -419,16 +497,6 @@ class ContextConsumerMirrorTest extends TestCase
         static::assertSame([], $this->consumers($wired->roots[0]));
     }
 
-    #[TestDox('returns the identical tree instance when the created set is empty')]
-    public function testReturnsIdenticalTreeForEmptyCreatedSet(): void
-    {
-        [$tree, $resolutions, $created] = self::emptyCreatedSetScenario();
-
-        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
-
-        static::assertSame($tree, $wired);
-    }
-
     #[TestDox('returns the identical tree instance when the created id names no element in the tree')]
     public function testReturnsIdenticalTreeForCreatedIdAbsentFromTree(): void
     {
@@ -480,8 +548,10 @@ class ContextConsumerMirrorTest extends TestCase
         yield 'a cross-key reference onto an element providing the candidate context key' => self::crossKeyReferenceOntoProvidingElementScenario();
         yield 'an equal dotted key' => self::equalDottedKeyScenario();
         yield 'a created element nested in a slot' => self::nestedCreatedElementScenario();
+        yield 'a created container holding a created child' => self::createdContainerWithCreatedChildScenario();
         yield 'a created element under the second root' => self::createdElementUnderSecondRootScenario();
         yield 'two resolutions sharing one resolved context key' => self::sharedContextKeyResolutionsScenario();
+        yield 'a second resolution base-colliding with the consumer the first wrote' => self::accumulatedBaseKeyCollisionScenario();
         yield 'a written property key colliding with no existing consumer base key' => self::noBaseKeyCollisionScenario();
         yield 'a consumer the element already carries under the same key' => self::existingConsumerSameKeyScenario();
 
@@ -490,6 +560,7 @@ class ContextConsumerMirrorTest extends TestCase
         }
 
         yield 'a key the element already fills from a data requirement' => self::dataRequirementFilledKeyScenario();
+        yield 'a data requirement on the candidate context key rather than the written property key' => self::dataRequirementOnTheCandidateContextKeyScenario();
         yield 'a key the element itself provides' => self::selfProvidedKeyScenario();
         yield 'an element outside the created set' => self::uncreatedElementScenario();
         yield 'a cross-key resolution whose written property key carries a dot' => self::dottedWrittenKeyScenario();
@@ -548,6 +619,16 @@ class ContextConsumerMirrorTest extends TestCase
                 \sprintf('Element "%s" does not decode back to the consumer map the mirror left on it.', $element->id)
             );
         }
+    }
+
+    #[TestDox('returns the identical tree instance when the created set is empty')]
+    public function testReturnsIdenticalTreeForEmptyCreatedSet(): void
+    {
+        [$tree, $resolutions, $created] = self::emptyCreatedSetScenario();
+
+        $wired = (new ContextConsumerMirror())->apply($tree, $resolutions, $created);
+
+        static::assertSame($tree, $wired);
     }
 
     private static function plainTree(): StoredTree
@@ -690,6 +771,56 @@ class ContextConsumerMirrorTest extends TestCase
             ]),
             ['price' => [self::reference('product', false, self::candidate(CandidateOrigin::Parent, 'product'))]],
             ['price'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function createdContainerWithCreatedChildScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Grid:Container', 'outer')->withSlot('content', [
+                    StoredElementBuilder::create('Sw:Product:PriceDisplay', 'price')->build(),
+                ])->build(),
+            ]),
+            [
+                'outer' => [self::reference('page', true, self::candidate(CandidateOrigin::Root, 'page'))],
+                'price' => [self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'product'))],
+            ],
+            ['outer', 'price'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function accumulatedBaseKeyCollisionScenario(): array
+    {
+        return [
+            self::plainTree(),
+            ['p1' => [
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'productA')),
+                self::reference('product', true, self::candidate(CandidateOrigin::Parent, 'productB')),
+            ]],
+            ['p1'],
+        ];
+    }
+
+    /**
+     * @return array{0: StoredTree, 1: array<string, list<PropertyResolution>>, 2: list<string>}
+     */
+    private static function dataRequirementOnTheCandidateContextKeyScenario(): array
+    {
+        return [
+            new StoredTree([
+                StoredElementBuilder::create('Sw:Product:PriceDisplay', 'p1')
+                    ->withDataRequirement('product', 'entity', new StubLoaderConfig())
+                    ->build(),
+            ]),
+            ['p1' => [self::reference('crossSellProduct', true, self::candidate(CandidateOrigin::Parent, 'product'))]],
+            ['p1'],
         ];
     }
 


### PR DESCRIPTION
`Mutation/ContextConsumerMirror` writes `acceptsContext` consumers onto the elements a mutation created, and the response tree re-enters the decode gate on the client's next request. One legal input broke that round trip: a provider `consumerAlias` of an integer-like string (`"0"`) flows verbatim into the resolved context key, PHP coerces it to an `int` array key on the consumer map, and `StoredElementWiringDecoder` rejects non-string consumer keys, so the mirrored response failed its next decode with `invalidMapKey`. This PR closes that path, tightens the `created()` contract the mirror reads, and pins the mirror's decode guarantees with a conformance test.

### Integer-like context keys are skipped

`consumerFor()` gains a guard beside its null/empty checks: a resolved context key in PHP's array-key coercion domain (`(string) (int) $key === $key`, so `"0"`, `"42"`, `"-7"`; not `"01"`, `"1.5"`, `" 1"`) is never mirrored. A skip rather than a throw, deliberately: the input tree is legal wiring, a consumer under such a key is unrepresentable in a PHP-keyed map at all, and the un-mirrored reference stays visible as unresolved in the same response's diagnostics, consistent with the mirror's existing skips.

### created() derived independently of affected()

`AttachElement` and `DuplicateElement` assigned `$this->created = $this->affected;`. The two sets are identical for these ops today, but `affected()` is a widenable response-highlight hint while `created()` is the exact fresh-node set the mirror wires, so the aliasing let a future widening of `affected` silently re-mirror consumers onto carried-over elements and undo an explicit unwiring. Both ops now derive `created` from the clone subtree directly, matching how `InsertElement`, `ReplaceElement`, and `WrapElements` already do it.

### Decode-conformance pin

A new test in `ContextConsumerMirrorTest` runs every mirroring scenario of the class through `StoredElement::jsonSerialize()`, a JSON round trip, and the wiring decoder in the codec's order (`decodeProviders()`, `decodeConsumers()`, `rejectInvalidElementWiring()`). Every scenario lives in one static fixture method shared by the originating test and the conformance provider, so the two cannot diverge and future rows are covered automatically. A mirror emitting a dotted `propertyAlias`, a base-key collision, or a non-string key now fails this test instead of surfacing as a 400 on the client's next request. The base-key skip fixtures gain the dotted-written-key case they lacked, and boundary rows pin the coercion domain's edges: `"007"`, `"+1"`, `" 1"`, and a past-`PHP_INT_MAX` digit string stay mirrorable string keys, so a reimplementation of the skip via `ctype_digit()` fails the suite.

### Guard-branch discrimination

Five guard-branch combinations in the mirror had no fixture that would fail if the branch broke: providers dropped from the rebuilt `ContextDefinitions`, an element rebuilt on both the consumer and the slot axis, a base-key collision against the second of several existing consumers, a collision against a consumer an earlier resolution wrote in the same apply, and a data requirement keyed on the candidate context key rather than the written property key. Each now has a fixture confirmed to fail when the matching mutation is applied.

### Durability exception documented

`docs/consumer-mirroring.md`'s durability paragraph now states the one exception to "an unwired consumer stays removed": `ReplaceElement` re-creates the node under the same id, counts as `created()`, and restores every consumer the node's resolutions still prove, by design.

## References

Ref #20178
Ref #19823
Ref #20124