### PR TITLE
fix(administration): use surface and border tokens in CMS editor

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
@@ -112,7 +112,7 @@
 
     .sw-cms-section__actions {
         width: 60px;
-        background: var(--color-background-secondary-default);
+        background: var(--color-elevation-surface-default);
         height: 100%;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-add-section/sw-cms-stage-add-section.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-add-section/sw-cms-stage-add-section.scss
@@ -3,7 +3,7 @@
     padding: 19px 0;
     text-align: center;
     z-index: 200;
-    background: var(--color-background-secondary-default);
+    background: var(--color-elevation-surface-sunken);
     display: grid;
 
     &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-section-selection/sw-cms-stage-section-selection.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-section-selection/sw-cms-stage-section-selection.scss
@@ -24,7 +24,7 @@
         height: 112px;
         background: var(--color-elevation-surface-raised);
         padding: 12px 16px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-default;
         margin-bottom: 8px;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.scss
@@ -137,12 +137,12 @@
             overflow-y: auto;
             overflow-x: hidden;
             position: relative;
-            background: var(--color-background-secondary-default);
+            background: var(--color-elevation-surface-sunken);
         }
 
         .sw-cms-detail__empty-stage {
             height: 100%;
-            background: var(--color-background-secondary-default);
+            background: var(--color-elevation-surface-sunken);
             display: grid;
             align-items: center;
             align-content: center;


### PR DESCRIPTION
### 1. Why is this change necessary?

The CMS editor stage, section actions and section selection cards still use `--color-background-secondary-default` and `--color-border-primary-default`, which don't match the intended surface hierarchy.

### 2. What does this change do, exactly?

Swaps the CMS editor SCSS to the correct Meteor tokens: `--color-elevation-surface-sunken` for the stage background, `--color-elevation-surface-default` for section actions, and `--color-border-secondary-default` for the section selection cards.

### 3. Describe each step to reproduce the issue or behaviour.

Open any layout in Content > Shopping Experiences and inspect the stage, section actions and "add section" panel.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
