### PR TITLE
feat(storefront): align theme list actions with cms list page

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
@@ -42,8 +42,12 @@
                     {% endblock %}
 
                     {% block sw_theme_list_listing_actions_mode %}
-                    <div
+                    <mt-button
                         class="sw-theme-list__actions-mode"
+                        variant="secondary"
+                        size="small"
+                        square
+                        :aria-label="$t('sw-theme-manager.general.switchThemeListMode')"
                         @click="onListModeChange"
                     >
                         <mt-icon
@@ -56,7 +60,7 @@
                             name="regular-view-grid"
                             size="16"
                         />
-                    </div>
+                    </mt-button>
                     {% endblock %}
                 </div>
                 {% endblock %}

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.scss
@@ -13,19 +13,19 @@
 
     .sw-theme-list__actions {
         display: grid;
-        grid-template-columns: auto 380px 36px;
-        grid-column-gap: 20px;
+        grid-template-columns: auto 380px max-content;
+        grid-column-gap: var(--scale-size-8);
         align-items: center;
         align-content: center;
-        margin-bottom: 28px;
+        margin-bottom: var(--scale-size-32);
 
         @media screen and (max-width: 700px) {
-            grid-template-columns: auto 36px;
+            grid-template-columns: auto max-content;
         }
 
         h3 {
-            font-size: 28px;
-            font-weight: normal;
+            font-size: var(--font-size-xl);
+            font-weight: var(--font-weight-semibold);
             margin: 0;
         }
     }
@@ -35,42 +35,6 @@
 
         @media screen and (max-width: 700px) {
             display: none;
-        }
-
-        .sw-field.sw-field--select {
-            margin-bottom: 0;
-
-            select {
-                padding: 6px 12px;
-            }
-
-            &.sw-field--select-aside {
-                grid-column-gap: 10px;
-            }
-
-            .sw-field--select__options {
-                top: calc(50% - 12px);
-
-                .sw-icon {
-                    margin-bottom: 0;
-                }
-            }
-        }
-    }
-
-    .sw-theme-list__actions-mode {
-        height: 36px;
-        line-height: 33px;
-        text-align: center;
-        color: $color-darkgray-200;
-        border: 1px solid $color-gray-300;
-        border-radius: 4px;
-        background: $color-white;
-        cursor: pointer;
-
-        &:hover {
-            color: $color-shopware-brand-500;
-            border-color: $color-shopware-brand-500;
         }
     }
 

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de.json
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de.json
@@ -102,7 +102,8 @@
       "captionMediaUpload": "Lade ein Bild hoch",
       "lockedToolTip": "Themes die von einem Plugin installiert wurden sind gesperrt und können nicht gelöscht werden.",
       "messageSaveError": "Theme konnte dem Verkaufskanal nicht zugewiesen werden",
-      "defaultTab": "Allgemein"
+      "defaultTab": "Allgemein",
+      "switchThemeListMode": "Zwischen Raster- und Listenansicht wechseln"
     },
     "sorting": {
       "labelSort": "Sortieren nach:",

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/en.json
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/en.json
@@ -102,7 +102,8 @@
       "captionMediaUpload": "Upload an image",
       "lockedToolTip": "Themes installed via plugin are locked and cannot be deleted",
       "messageSaveError": "Theme could not be assigned to Sales Channel.",
-      "defaultTab": "General"
+      "defaultTab": "General",
+      "switchThemeListMode": "Switch between grid and list view"
     },
     "sorting": {
       "labelSort": "Sort by:",


### PR DESCRIPTION
### 1. Why is this change necessary?

The theme list and the CMS list page show the same kind of listing header (headline, sorting select, grid/list toggle), but the theme list still used its own legacy styling: a larger, lighter headline, wider spacing between the sorting select and the toggle, and a hand-rolled `div` styled to look like a button. Both pages should look identical.

### 2. What does this change do, exactly?

- Headline: `28px` / `font-weight: normal` → `--font-size-xl` / `--font-weight-semibold`.
- Action row: column gap `20px` → `--scale-size-8`, bottom margin `28px` → `--scale-size-32`, and the toggle column `36px` → `max-content` so the button sizes itself.
- Replaces the clickable `div.sw-theme-list__actions-mode` with `mt-button` (`variant="secondary"`, `size="small"`, `square`) plus an `aria-label`, matching the CMS list toggle.
- Removes the now obsolete `.sw-theme-list__actions-mode` box styling and the `.sw-field--select` overrides, which have been dead since `sw-sorting-select` renders `mt-select`.
- Adds the `sw-theme-manager.general.switchThemeListMode` snippet (en/de) for the button's `aria-label`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Administration → Content → Themes.
2. Open Administration → Content → Layouts (CMS list).
3. Compare the listing headline, the gap between the sorting select and the view toggle, and the toggle button itself — they now render identically.

### 4. Screenshots

#### Before
<img width="1113" height="254" alt="Bildschirmfoto 2026-09-07 um 14 25 17" src="https://github.com/user-attachments/assets/5858ec8a-2693-4b1b-aedc-c302c1aa4768" />

#### After
<img width="1067" height="297" alt="Bildschirmfoto 2026-09-07 um 14 26 38" src="https://github.com/user-attachments/assets/beb60dfa-9674-4294-94df-ed9ef58831fc" />

#### Matches with CMS
<img width="1069" height="260" alt="Bildschirmfoto 2026-09-07 um 14 26 44" src="https://github.com/user-attachments/assets/47a4c0bb-3f70-486b-bcc8-5ab8832c829a" />


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
