### PR TITLE
fix: add missing flow trigger snippets

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de.json
@@ -365,7 +365,11 @@
       "pending": "Ausstehend",
       "changed": "Geändert",
       "update": "Aktualisierung",
-      "password": "Passwort"
+      "password": "Passwort",
+      "confirm": "Bestätigung",
+      "document": "Dokument",
+      "generation": "Erzeugung",
+      "revocationRequest": "Widerrufsantrag"
     }
   },
   "sw-privileges": {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en.json
@@ -365,7 +365,11 @@
       "pending": "Pending",
       "changed": "Changed",
       "update": "Update",
-      "password": "Password"
+      "password": "Password",
+      "confirm": "Confirmation",
+      "document": "Document",
+      "generation": "Generation",
+      "revocationRequest": "Revocation request"
     }
   },
   "sw-privileges": {


### PR DESCRIPTION
follow-up to #19026
follow-up to #14362

Some trigger snippet keys were missing, leading to untranslated segments in the picker:

<img width="357" height="618" alt="Auslöser" src="https://github.com/user-attachments/assets/45f249f0-f925-4bf0-88aa-2f17b4321507" />
