### PR TITLE
fix(administration): read slot-text labels for v-for sw-tabs items

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
@@ -75,11 +75,28 @@ export default Shopware.Component.wrapComponentConfig({
                                 ?.filter((child) => child.type?.name === 'sw-tabs-item')
                                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
                                 .map((child: any) => {
+                                    /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
+                                    let label = child.props?.title;
+                                    let name = child.props?.name ?? child.props?.title;
+
+                                    if (label === undefined) {
+                                        // Label given as slot text is stored as the default slot text vnode.
+                                        const defaultSlot = child.children?.default?.()?.[0];
+                                        if (defaultSlot?.type?.toString() === 'Symbol(v-txt)') {
+                                            label = defaultSlot.children;
+                                        }
+                                    }
+
+                                    if (name === undefined) {
+                                        name = label;
+                                    }
+                                    /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
+
                                     return {
-                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-                                        label: child.props?.title ?? child.props?.name,
-                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-                                        name: child.props?.name ?? child.props?.title,
+                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                                        label,
+                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                                        name,
                                         onClick: () => {
                                             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                                             if (child.props?.route) {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
@@ -27,6 +27,16 @@ function isFragmentVNode(vnode: VNode): boolean {
 }
 
 /**
+ * Returns the text of a `sw-tabs-item`'s default slot, or `undefined` when it has none.
+ * Used as the label fallback for items that provide their label as slot text.
+ */
+function getTabItemSlotText(vnode: VNode): string | undefined {
+    const slotChild = (vnode.children as VNodeChildrenWithDefaultSlot | null)?.default?.()?.[0];
+
+    return slotChild?.type === Text ? (slotChild.children as string) : undefined;
+}
+
+/**
  * Maps a legacy `sw-tabs-item` vnode to the `mt-tabs` item format.
  *
  * The label is resolved from the `title` prop, then the default slot text, so an item whose label is
@@ -35,19 +45,12 @@ function isFragmentVNode(vnode: VNode): boolean {
 function resolveTabItem(vnode: VNode, router: Router): TabItem {
     const props = (vnode.props ?? {}) as SwTabsItemProps;
 
-    let label = props.title;
-    if (label === undefined) {
-        const slotChild = (vnode.children as VNodeChildrenWithDefaultSlot | null)?.default?.()?.[0];
-        if (slotChild?.type === Text) {
-            label = slotChild.children as string;
-        }
-    }
-
+    const label = props.title ?? getTabItemSlotText(vnode) ?? '';
     const name = props.name ?? props.title ?? label;
 
     const tabItem: TabItem = {
-        label: label as string,
-        name: name as string,
+        label,
+        name,
     };
 
     if (props.route) {
@@ -111,12 +114,14 @@ export default Shopware.Component.wrapComponentConfig({
             // Convert the slotted `sw-tabs-item` vnodes into `mt-tabs` items. A `v-for` of items is
             // wrapped in a fragment vnode, so its children are unwrapped and mapped individually.
             return defaultSlotContent.flatMap((item) => {
+                // v-for
                 if (isFragmentVNode(item)) {
                     const children = Array.isArray(item.children) ? (item.children as VNode[]) : [];
 
                     return children.filter(isTabItemVNode).map((child) => resolveTabItem(child, this.$router));
                 }
 
+                // normal cases
                 if (isTabItemVNode(item)) {
                     return [resolveTabItem(item, this.$router)];
                 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
@@ -1,5 +1,65 @@
+import { Text, type VNode } from 'vue';
+import type { RouteLocationRaw, Router } from 'vue-router';
 import type { TabItem } from '@shopware-ag/meteor-component-library/dist/esm/MtTabs';
 import template from './sw-tabs.html.twig';
+
+type SwTabsItemProps = {
+    name?: string;
+    route?: RouteLocationRaw;
+    title?: string;
+};
+
+type VNodeTypeWithName = {
+    name?: string;
+};
+
+type VNodeChildrenWithDefaultSlot = {
+    default?: () => VNode[];
+};
+
+function isTabItemVNode(vnode: VNode): boolean {
+    return (vnode.type as VNodeTypeWithName | undefined)?.name === 'sw-tabs-item';
+}
+
+function isFragmentVNode(vnode: VNode): boolean {
+    // A `v-for` of `sw-tabs-item` is wrapped in a fragment vnode.
+    return typeof vnode.type === 'symbol' && vnode.type.toString() === 'Symbol(v-fgt)';
+}
+
+/**
+ * Maps a legacy `sw-tabs-item` vnode to the `mt-tabs` item format.
+ *
+ * The label is resolved from the `title` prop, then the default slot text, so an item whose label is
+ * only provided as slot text (`<sw-tabs-item :name="id">{{ label }}</sw-tabs-item>`) still renders it.
+ */
+function resolveTabItem(vnode: VNode, router: Router): TabItem {
+    const props = (vnode.props ?? {}) as SwTabsItemProps;
+
+    let label = props.title;
+    if (label === undefined) {
+        const slotChild = (vnode.children as VNodeChildrenWithDefaultSlot | null)?.default?.()?.[0];
+        if (slotChild?.type === Text) {
+            label = slotChild.children as string;
+        }
+    }
+
+    const name = props.name ?? props.title ?? label;
+
+    const tabItem: TabItem = {
+        label: label as string,
+        name: name as string,
+    };
+
+    if (props.route) {
+        tabItem.onClick = () => {
+            if (props.route) {
+                void router.push(props.route);
+            }
+        };
+    }
+
+    return tabItem;
+}
 
 /**
  * @sw-package framework
@@ -48,107 +108,21 @@ export default Shopware.Component.wrapComponentConfig({
                 return [];
             }
 
-            /**
-             * Iterate over the default slot content and extract the tab items
-             * and convert them to the new format
-             */
-            let items = defaultSlotContent
-                .filter((item) => {
-                    return (
-                        // @ts-expect-error
-                        item.type?.name === 'sw-tabs-item' ||
-                        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-                        item.type?.toString() === 'Symbol(v-fgt)'
-                    );
-                })
-                .map((item) => {
-                    // Handle fragments
+            // Convert the slotted `sw-tabs-item` vnodes into `mt-tabs` items. A `v-for` of items is
+            // wrapped in a fragment vnode, so its children are unwrapped and mapped individually.
+            return defaultSlotContent.flatMap((item) => {
+                if (isFragmentVNode(item)) {
+                    const children = Array.isArray(item.children) ? (item.children as VNode[]) : [];
 
-                    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-                    if (item.type?.toString() === 'Symbol(v-fgt)') {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                        return (
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                            (item.children ?? [])
-                                // @ts-expect-error
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                                ?.filter((child) => child.type?.name === 'sw-tabs-item')
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
-                                .map((child: any) => {
-                                    /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
-                                    let label = child.props?.title;
-                                    let name = child.props?.name ?? child.props?.title;
+                    return children.filter(isTabItemVNode).map((child) => resolveTabItem(child, this.$router));
+                }
 
-                                    if (label === undefined) {
-                                        // Label given as slot text is stored as the default slot text vnode.
-                                        const defaultSlot = child.children?.default?.()?.[0];
-                                        if (defaultSlot?.type?.toString() === 'Symbol(v-txt)') {
-                                            label = defaultSlot.children;
-                                        }
-                                    }
+                if (isTabItemVNode(item)) {
+                    return [resolveTabItem(item, this.$router)];
+                }
 
-                                    if (name === undefined) {
-                                        name = label;
-                                    }
-                                    /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
-
-                                    return {
-                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                                        label,
-                                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                                        name,
-                                        onClick: () => {
-                                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                                            if (child.props?.route) {
-                                                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-                                                void this.$router.push(child.props.route);
-                                            }
-                                        },
-                                    };
-                                })
-                        );
-                    }
-
-                    /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
-                    let label = item.props?.title;
-                    let name = item.props?.name ?? item.props?.title;
-
-                    if (label === undefined) {
-                        // @ts-expect-error
-                        // Get label from default slot content of item
-                        const defaultSlot = item.children?.default?.()?.[0];
-                        // Check if default slot is Symbol(v-txt)
-                        if (defaultSlot?.type?.toString() === 'Symbol(v-txt)') {
-                            label = defaultSlot.children;
-                        }
-                    }
-
-                    if (name === undefined) {
-                        // Use label as name if name is not set
-                        name = label;
-                    }
-
-                    /* eslint-enable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access */
-
-                    return {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        label,
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        name,
-                        onClick: () => {
-                            if (item.props?.route) {
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                                void this.$router.push(item.props.route);
-                            }
-                        },
-                    };
-                });
-
-            // Flat map items
-            items = items.flat();
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return items;
+                return [];
+            });
         },
     },
 
@@ -174,18 +148,14 @@ export default Shopware.Component.wrapComponentConfig({
 
         mountedComponent() {
             // Fallback for $refs access in some modules
-            if (this.$refs.tabComponent) {
-                // @ts-expect-error
-                this.$refs.tabComponent.mountedComponent();
-            }
+            const tabComponent = this.$refs.tabComponent as { mountedComponent?: () => void } | undefined;
+            tabComponent?.mountedComponent?.();
         },
 
         setActiveItem(item: unknown) {
             // Fallback for $refs access in some modules
-            if (this.$refs.tabComponent) {
-                // @ts-expect-error
-                this.$refs.tabComponent.setActiveItem(item);
-            }
+            const tabComponent = this.$refs.tabComponent as { setActiveItem?: (item: unknown) => void } | undefined;
+            tabComponent?.setActiveItem?.(item);
         },
 
         onNewItemActive(item: unknown) {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
@@ -31,4 +31,40 @@ describe('src/app/component/base/sw-tabs', () => {
 
         expect(wrapper.html()).toContain('mt-tabs');
     });
+
+    // Regression test for https://github.com/shopware/shopware/issues/18863
+    it.activeFeatureFlags(['v6.8.0.0'])(
+        'should resolve labels from slot text for v-for / fragment tab items',
+        async () => {
+            const wrapper = await createWrapper({
+                global: {
+                    stubs: {
+                        'sw-tabs-deprecated': true,
+                        'mt-tabs': true,
+                        // Keep the real component name so the fragment branch recognizes the items.
+                        'sw-tabs-item': {
+                            name: 'sw-tabs-item',
+                            props: ['name', 'title', 'route'],
+                            template: '<div class="sw-tabs-item"><slot /></div>',
+                        },
+                    },
+                },
+                slots: {
+                    default: `
+                        <sw-tabs-item
+                            v-for="locale in ['en-GB', 'de-DE']"
+                            :key="locale"
+                            :name="locale"
+                        >Label {{ locale }}</sw-tabs-item>
+                    `,
+                },
+            });
+
+            // Label comes from the slot text, name from the :name prop - not name for both.
+            expect(wrapper.vm.itemsBackwardCompatible).toEqual([
+                expect.objectContaining({ name: 'en-GB', label: 'Label en-GB' }),
+                expect.objectContaining({ name: 'de-DE', label: 'Label de-DE' }),
+            ]);
+        },
+    );
 });

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
@@ -33,38 +33,39 @@ describe('src/app/component/base/sw-tabs', () => {
     });
 
     // Regression test for https://github.com/shopware/shopware/issues/18863
-    it.activeFeatureFlags(['v6.8.0.0'])(
-        'should resolve labels from slot text for v-for / fragment tab items',
-        async () => {
-            const wrapper = await createWrapper({
-                global: {
-                    stubs: {
-                        'sw-tabs-deprecated': true,
-                        'mt-tabs': true,
-                        // Keep the real component name so the fragment branch recognizes the items.
-                        'sw-tabs-item': {
-                            name: 'sw-tabs-item',
-                            props: ['name', 'title', 'route'],
-                            template: '<div class="sw-tabs-item"><slot /></div>',
-                        },
+    it.activeFeatureFlags(['v6.8.0.0'])('should resolve labels from slot text for v-for / fragment tab items', async () => {
+        const wrapper = await createWrapper({
+            global: {
+                stubs: {
+                    'sw-tabs-deprecated': true,
+                    'mt-tabs': true,
+                    // Keep the real component name so the fragment branch recognizes the items.
+                    'sw-tabs-item': {
+                        name: 'sw-tabs-item',
+                        props: [
+                            'name',
+                            'title',
+                            'route',
+                        ],
+                        template: '<div class="sw-tabs-item"><slot /></div>',
                     },
                 },
-                slots: {
-                    default: `
+            },
+            slots: {
+                default: `
                         <sw-tabs-item
                             v-for="locale in ['en-GB', 'de-DE']"
                             :key="locale"
                             :name="locale"
                         >Label {{ locale }}</sw-tabs-item>
                     `,
-                },
-            });
+            },
+        });
 
-            // Label comes from the slot text, name from the :name prop - not name for both.
-            expect(wrapper.vm.itemsBackwardCompatible).toEqual([
-                expect.objectContaining({ name: 'en-GB', label: 'Label en-GB' }),
-                expect.objectContaining({ name: 'de-DE', label: 'Label de-DE' }),
-            ]);
-        },
-    );
+        // Label comes from the slot text, name from the :name prop - not name for both.
+        expect(wrapper.vm.itemsBackwardCompatible).toEqual([
+            expect.objectContaining({ name: 'en-GB', label: 'Label en-GB' }),
+            expect.objectContaining({ name: 'de-DE', label: 'Label de-DE' }),
+        ]);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
@@ -32,7 +32,6 @@ describe('src/app/component/base/sw-tabs', () => {
         expect(wrapper.html()).toContain('mt-tabs');
     });
 
-    // Regression test for https://github.com/shopware/shopware/issues/18863
     it.activeFeatureFlags(['v6.8.0.0'])('should resolve labels from slot text for v-for / fragment tab items', async () => {
         const wrapper = await createWrapper({
             global: {


### PR DESCRIPTION
### 1. Why is this change necessary?

`sw-tabs` is a deprecated wrapper that renders the new `mt-tabs` under the 6.8 feature flag
(and, after #19757, behind the `use-meteor-component` opt-in).

To do so it converts its legacy `<sw-tabs-item>` children into `mt-tabs` items, including each item's label.

Normally it can infer the label from the slot text (here `{{ label }}`):

```html
<sw-tabs-item :name="id">
    {{ label }}
</sw-tabs-item>
```

But currently that infer doesn't work if `sw-tabs-item` is nested in a `v-for`.

### 2. What does this change do, exactly?

- The `v-for` (fragment) branch now resolves the label the same way the static branch does: `title` prop, then default slot text, then `name` prop.
- Added helper functions and added a few abstractions

### 3. Describe each step to reproduce the issue or behaviour.

Render the wrapper on the `mt-tabs` path (feature flag `v6.8.0.0` active, or `<sw-tabs use-meteor-component>`):

```html
<sw-tabs>
    <template #default>
        <sw-tabs-item
            v-for="locale in ['en-GB', 'de-DE']"
            :key="locale"
            :name="locale"
        >{{ $t('locale.' + locale) }}</sw-tabs-item>
    </template>
</sw-tabs>
```

Before: the tabs show `en-GB` and `de-DE` (the names).
After: the tabs show the translated locale labels from the slot.

### 4. Please link to the relevant issues (if any).

- closes #18863
- relates #19752

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - Bugfix that restores intended label rendering. No API change and no documented behaviour to update.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
