### PR TITLE
fix(storefront): load snippets from every configInheritance parent

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -484,6 +484,11 @@ Dispatching a `removeLoader` event on the form removes the indicator and re-enab
 The new `shopware.app_system.enable_url_validation` option turns off app system and webhook target validation, including the HTTPS requirement, the private network checks and the DNS pinning. It defaults to `true` and is shipped as `false` for the `dev` environment, so local app and webhook endpoints work over HTTP and on private or unresolvable hosts without further configuration.
 
 While it is `false`, `shopware.app_system.allow_unencrypted_traffic` and `shopware.app_system.allowed_private_ip_addresses` have no effect. Keep the validation enabled in production.
+### Themes inherit snippets from every theme in `configInheritance`
+
+A theme that lists several ancestors in the `configInheritance` of its `theme.json` now receives the snippets of all of them. Storefront texts can change where an intermediate theme defines a snippet key that was dropped until now.
+
+`theme.parent_theme_id` now points to the nearest listed ancestor. Run `bin/console theme:refresh` to apply it outside a plugin or update cycle.
 
 # 6.7.14.0
 

--- a/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
+++ b/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
@@ -31,11 +31,7 @@ class DatabaseSalesChannelThemeLoader
      */
     public function load(string $salesChannelId): array
     {
-        if (($this->themes[$salesChannelId] ?? []) !== []) {
-            return $this->themes[$salesChannelId];
-        }
-
-        return $this->readFromDB($salesChannelId);
+        return $this->themes[$salesChannelId] ??= $this->readFromDB($salesChannelId);
     }
 
     public function reset(): void
@@ -48,56 +44,102 @@ class DatabaseSalesChannelThemeLoader
      */
     private function readFromDB(string $salesChannelId): array
     {
-        $themes = $this->connection->fetchAssociative('
-            SELECT LOWER(HEX(theme.id)) themeId, theme.technical_name as themeName, parentTheme.technical_name as parentThemeName, LOWER(HEX(parentTheme.parent_theme_id)) as grandParentThemeId
-            FROM sales_channel
-                LEFT JOIN theme_sales_channel ON sales_channel.id = theme_sales_channel.sales_channel_id
-                LEFT JOIN theme ON theme_sales_channel.theme_id = theme.id
-                LEFT JOIN theme AS parentTheme ON parentTheme.id = theme.parent_theme_id
-            WHERE sales_channel.id = :salesChannelId
-        ', [
-            'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
-        ]);
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(theme.id)) AS themeId,
+                    theme.technical_name AS technicalName,
+                    LOWER(HEX(theme.parent_theme_id)) AS parentThemeId,
+                    JSON_EXTRACT(theme.base_config, \'$.configInheritance\') AS configInheritance,
+                    theme_sales_channel.sales_channel_id IS NOT NULL AS assigned
+            FROM theme
+                LEFT JOIN theme_sales_channel
+                    ON theme_sales_channel.theme_id = theme.id
+                    AND theme_sales_channel.sales_channel_id = :salesChannelId',
+            [
+                'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
+            ]
+        );
 
-        if (\is_array($themes) && isset($themes['grandParentThemeId']) && \is_string($themes['grandParentThemeId'])) {
-            $themes['grandParentNames'] = $this->getGrantParents($themes['grandParentThemeId']);
+        $themesById = [];
+        $idsByTechnicalName = [];
+        $assignedThemeId = null;
+
+        foreach ($rows as $row) {
+            $themeId = (string) $row['themeId'];
+            $themesById[$themeId] = $row;
+
+            if (\is_string($row['technicalName'])) {
+                $idsByTechnicalName[$row['technicalName']] = $themeId;
+            }
+
+            if ($assignedThemeId === null && (int) $row['assigned'] === 1) {
+                $assignedThemeId = $themeId;
+            }
         }
 
-        $usedThemes = array_filter([
-            $themes['themeName'] ?? null,
-            $themes['parentThemeName'] ?? null,
-        ]);
-
-        if (isset($themes['grandParentNames'])) {
-            $usedThemes = array_merge($usedThemes, $themes['grandParentNames']);
+        if ($assignedThemeId === null) {
+            return [];
         }
 
-        return $this->themes[$salesChannelId] = array_values($usedThemes) ?: [];
+        $technicalNames = [];
+        $visited = [$assignedThemeId => true];
+        $queue = [$assignedThemeId];
+
+        while (($themeId = array_shift($queue)) !== null) {
+            $row = $themesById[$themeId];
+
+            if (\is_string($row['technicalName'])) {
+                $technicalNames[$row['technicalName']] = true;
+            }
+
+            foreach ($this->getAncestorIds($row, $idsByTechnicalName) as $ancestorId) {
+                if (isset($visited[$ancestorId]) || !isset($themesById[$ancestorId])) {
+                    continue;
+                }
+
+                $visited[$ancestorId] = true;
+                $queue[] = $ancestorId;
+            }
+        }
+
+        return array_keys($technicalNames);
     }
 
     /**
+     * `parent_theme_id` holds one ancestor, `configInheritance` may name several. Both are sources.
+     *
+     * @param array<string, mixed> $row
+     * @param array<string, string> $idsByTechnicalName
+     *
      * @return list<string>
      */
-    private function getGrantParents(mixed $grandParentThemeId): array
+    private function getAncestorIds(array $row, array $idsByTechnicalName): array
     {
-        $grandParents = $this->connection->fetchAssociative('
-            SELECT theme.technical_name as themeName, parentTheme.technical_name as parentThemeName, LOWER(HEX(parentTheme.parent_theme_id)) as grandParentThemeId
-            FROM theme
-                LEFT JOIN theme AS parentTheme ON parentTheme.id = theme.parent_theme_id
-            WHERE theme.id = :id
-        ', [
-            'id' => Uuid::fromHexToBytes($grandParentThemeId),
-        ]);
+        $ancestorIds = [];
 
-        $filtered = array_filter([
-            $grandParents['themeName'] ?? null,
-            $grandParents['parentThemeName'] ?? null,
-        ]);
-
-        if (\is_array($grandParents) && isset($grandParents['grandParentThemeId']) && \is_string($grandParents['grandParentThemeId'])) {
-            $filtered = array_merge($filtered, $this->getGrantParents($grandParents['grandParentThemeId']));
+        // Must stay first: theme copies have no technical name, index 0 comes from the database parent.
+        if (\is_string($row['parentThemeId'])) {
+            $ancestorIds[] = $row['parentThemeId'];
         }
 
-        return array_values($filtered);
+        $configInheritance = json_decode((string) $row['configInheritance'], true);
+
+        if (!\is_array($configInheritance)) {
+            return $ancestorIds;
+        }
+
+        // configInheritance is ordered from least to most specific
+        foreach (array_reverse($configInheritance) as $technicalName) {
+            if (!\is_string($technicalName)) {
+                continue;
+            }
+
+            $ancestorId = $idsByTechnicalName[ltrim($technicalName, '@')] ?? null;
+
+            if ($ancestorId !== null && $ancestorId !== $row['themeId']) {
+                $ancestorIds[] = $ancestorId;
+            }
+        }
+
+        return $ancestorIds;
     }
 }

--- a/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
+++ b/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
@@ -31,7 +31,11 @@ class DatabaseSalesChannelThemeLoader
      */
     public function load(string $salesChannelId): array
     {
-        return $this->themes[$salesChannelId] ??= $this->readFromDB($salesChannelId);
+        if (($this->themes[$salesChannelId] ?? []) !== []) {
+            return $this->themes[$salesChannelId];
+        }
+
+        return $this->themes[$salesChannelId] = $this->readFromDB($salesChannelId);
     }
 
     public function reset(): void

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -563,7 +563,8 @@ class ThemeLifecycleService
     private function addParentTheme(StorefrontPluginConfiguration $configuration, array $themeData, Context $context): array
     {
         $lastNotSameTheme = null;
-        foreach (array_reverse($configuration->getConfigInheritance()) as $themeName) {
+        // configInheritance is ordered from least to most specific, the last entry is the nearest ancestor.
+        foreach ($configuration->getConfigInheritance() as $themeName) {
             if (
                 $themeName === '@' . StorefrontPluginRegistry::BASE_THEME_NAME
                 || $themeName === '@' . $themeData['technicalName']

--- a/tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Theme;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class DatabaseSalesChannelThemeLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    private DatabaseSalesChannelThemeLoader $themeLoader;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->themeLoader = static::getContainer()->get(DatabaseSalesChannelThemeLoader::class);
+        $this->themeLoader->reset();
+    }
+
+    public function testUsedThemesContainEveryConfigInheritanceParent(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $this->createTheme('ParentTheme', ['@Storefront', '@BasicTheme'], $basicId);
+
+        // addParentTheme() stored BasicTheme, ParentTheme is only reachable through configInheritance.
+        $childId = $this->createTheme('ChildTheme', ['@Storefront', '@BasicTheme', '@ParentTheme'], $basicId);
+
+        $this->assignThemeToSalesChannel($childId, TestDefaults::SALES_CHANNEL);
+
+        static::assertSame(
+            ['ChildTheme', 'BasicTheme', 'ParentTheme', 'Storefront'],
+            $this->themeLoader->load(TestDefaults::SALES_CHANNEL)
+        );
+    }
+
+    public function testConfigInheritanceIsExpandedTransitively(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $this->createTheme('ParentTheme', ['@Storefront', '@BasicTheme'], $basicId);
+        $childId = $this->createTheme('ChildTheme', ['@ParentTheme']);
+
+        $this->assignThemeToSalesChannel($childId, TestDefaults::SALES_CHANNEL);
+
+        static::assertSame(
+            ['ChildTheme', 'ParentTheme', 'BasicTheme', 'Storefront'],
+            $this->themeLoader->load(TestDefaults::SALES_CHANNEL)
+        );
+    }
+
+    public function testThemeCopyWithoutTechnicalNameResolvesThroughItsParent(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $childId = $this->createTheme('ChildTheme', ['@Storefront', '@BasicTheme'], $basicId);
+        $copyId = $this->createTheme(null, null, $childId);
+
+        $this->assignThemeToSalesChannel($copyId, TestDefaults::SALES_CHANNEL);
+
+        $usedThemes = $this->themeLoader->load(TestDefaults::SALES_CHANNEL);
+
+        static::assertSame('ChildTheme', $usedThemes[0]);
+        static::assertSame(['ChildTheme', 'BasicTheme', 'Storefront'], $usedThemes);
+    }
+
+    /**
+     * @param list<string>|null $configInheritance
+     */
+    private function createTheme(?string $technicalName, ?array $configInheritance = null, ?string $parentThemeId = null): string
+    {
+        $id = Uuid::randomHex();
+
+        $this->connection->insert('theme', [
+            'id' => Uuid::fromHexToBytes($id),
+            'technical_name' => $technicalName,
+            'name' => $technicalName ?? 'Theme copy',
+            'author' => 'test',
+            'active' => 1,
+            'base_config' => $configInheritance === null
+                ? null
+                : json_encode(['configInheritance' => $configInheritance], \JSON_THROW_ON_ERROR),
+            'parent_theme_id' => $parentThemeId !== null ? Uuid::fromHexToBytes($parentThemeId) : null,
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s.v'),
+        ]);
+
+        return $id;
+    }
+
+    private function assignThemeToSalesChannel(string $themeId, string $salesChannelId): void
+    {
+        $this->connection->executeStatement(
+            'REPLACE INTO theme_sales_channel (theme_id, sales_channel_id) VALUES (:themeId, :salesChannelId)',
+            [
+                'themeId' => Uuid::fromHexToBytes($themeId),
+                'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
+            ]
+        );
+    }
+}

--- a/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
@@ -37,6 +37,7 @@ use Shopware\Storefront\Theme\ThemeEntity;
 use Shopware\Storefront\Theme\ThemeFilesystemResolver;
 use Shopware\Storefront\Theme\ThemeLifecycleService;
 use Shopware\Storefront\Theme\ThemeRuntimeConfigService;
+use Shopware\Tests\Integration\Storefront\Theme\fixtures\SimpleTheme\SimpleTheme;
 use Shopware\Tests\Integration\Storefront\Theme\fixtures\ThemeWithFileAssociations\ThemeWithFileAssociations;
 use Shopware\Tests\Integration\Storefront\Theme\fixtures\ThemeWithLabels\ThemeWithLabels;
 
@@ -79,11 +80,13 @@ class ThemeLifecycleServiceTest extends TestCase
         $kernel->method('getBundles')->willReturn([
             'ThemeWithFileAssociations' => new ThemeWithFileAssociations(),
             'ThemeWithLabels' => new ThemeWithLabels(),
+            'SimpleTheme' => new SimpleTheme(),
         ]);
 
         $kernel->method('getBundle')->willReturnMap([
             ['ThemeWithFileAssociations', new ThemeWithFileAssociations()],
             ['ThemeWithLabels', new ThemeWithLabels()],
+            ['SimpleTheme', new SimpleTheme()],
         ]);
 
         $this->themeFilesystemResolver = new ThemeFilesystemResolver(
@@ -163,6 +166,29 @@ class ThemeLifecycleServiceTest extends TestCase
         $themeEntity = $this->getTheme($bundle);
 
         static::assertSame($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
+    }
+
+    public function testThemeConfigInheritanceUsesNearestThemeAsParent(): void
+    {
+        $grandParentBundle = $this->getThemeConfigWithLabels();
+        $this->themeLifecycleService->refreshTheme($grandParentBundle, $this->context);
+
+        $parentBundle = $this->getSimpleThemeConfig();
+        $parentBundle->setConfigInheritance(['@Storefront', '@' . $grandParentBundle->getTechnicalName()]);
+        $this->themeLifecycleService->refreshTheme($parentBundle, $this->context);
+
+        $bundle = $this->getThemeConfig();
+        $bundle->setConfigInheritance([
+            '@Storefront',
+            '@' . $grandParentBundle->getTechnicalName(),
+            '@' . $parentBundle->getTechnicalName(),
+        ]);
+        $this->themeLifecycleService->refreshTheme($bundle, $this->context);
+
+        static::assertSame(
+            $this->getTheme($parentBundle)->getId(),
+            $this->getTheme($bundle)->getParentThemeId()
+        );
     }
 
     public function testThemeRefreshWithParentTheme(): void
@@ -462,6 +488,13 @@ class ThemeLifecycleServiceTest extends TestCase
         $factory = static::getContainer()->get(StorefrontPluginConfigurationFactory::class);
 
         return $factory->createFromBundle(new ThemeWithLabels());
+    }
+
+    private function getSimpleThemeConfig(): StorefrontPluginConfiguration
+    {
+        $factory = static::getContainer()->get(StorefrontPluginConfigurationFactory::class);
+
+        return $factory->createFromBundle(new SimpleTheme());
     }
 
     private function getTheme(StorefrontPluginConfiguration $bundle, bool $withChild = false): ThemeEntity

--- a/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -126,13 +126,24 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
 
     public function testResultIsMemoisedPerSalesChannel(): void
     {
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([
+            self::row('storefront', 'Storefront', assigned: true),
+        ]);
+
+        $salesChannelId = Uuid::randomHex();
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+
+        static::assertSame(['Storefront'], $this->themeLoader->load(Uuid::randomHex()));
+    }
+
+    public function testEmptyResultIsNotMemoised(): void
+    {
         $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
 
         $salesChannelId = Uuid::randomHex();
         static::assertSame([], $this->themeLoader->load($salesChannelId));
         static::assertSame([], $this->themeLoader->load($salesChannelId));
-
-        static::assertSame([], $this->themeLoader->load(Uuid::randomHex()));
     }
 
     public function testResetClearsTheMemoisedResult(): void

--- a/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Storefront\Theme;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
@@ -24,112 +25,148 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
-        $this->themeLoader = new DatabaseSalesChannelThemeLoader(
-            $this->connection,
-        );
+        $this->themeLoader = new DatabaseSalesChannelThemeLoader($this->connection);
     }
 
-    public function testLoadWithDifferentSalesChannel(): void
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param list<string> $expected
+     */
+    #[DataProvider('themeGraphProvider')]
+    public function testLoad(array $rows, array $expected): void
     {
-        $expectedDB = [
-            'themeName' => 'Storefront',
-            'parentThemeName' => null,
-            'themeId' => Uuid::randomHex(),
+        $this->connection->expects($this->once())->method('fetchAllAssociative')->willReturn($rows);
+
+        static::assertSame($expected, $this->themeLoader->load(Uuid::randomHex()));
+    }
+
+    public static function themeGraphProvider(): \Generator
+    {
+        yield 'no theme assigned to the sales channel' => [
+            [self::row('storefront', 'Storefront')],
+            [],
         ];
 
-        $expectedTheme = [
-            'Storefront',
+        yield 'only the base theme' => [
+            [self::row('storefront', 'Storefront', assigned: true)],
+            ['Storefront'],
         ];
 
-        $this->connection->expects($this->exactly(2))->method('fetchAssociative')->willReturnOnConsecutiveCalls($expectedDB, []);
+        yield 'linear parent_theme_id chain' => [
+            [
+                self::row('t1', 'Extended thrice', parentThemeId: 't2', assigned: true),
+                self::row('t2', 'Extended twice', parentThemeId: 't3'),
+                self::row('t3', 'Extended once', parentThemeId: 't4'),
+                self::row('t4', 'Extended', parentThemeId: 'storefront'),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['Extended thrice', 'Extended twice', 'Extended once', 'Extended', 'Storefront'],
+        ];
+
+        // addParentTheme() stored BasicTheme, ParentTheme is only reachable through configInheritance.
+        yield 'multiple configInheritance parents with a stale parent_theme_id' => [
+            [
+                self::row('child', 'ChildTheme', parentThemeId: 'basic', assigned: true, configInheritance: ['@Storefront', '@BasicTheme', '@ParentTheme']),
+                self::row('parent', 'ParentTheme', parentThemeId: 'basic', configInheritance: ['@Storefront', '@BasicTheme']),
+                self::row('basic', 'BasicTheme', configInheritance: ['@Storefront']),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['ChildTheme', 'BasicTheme', 'ParentTheme', 'Storefront'],
+        ];
+
+        yield 'configInheritance is expanded transitively' => [
+            [
+                self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@ParentTheme']),
+                self::row('parent', 'ParentTheme', configInheritance: ['@BasicTheme']),
+                self::row('basic', 'BasicTheme'),
+            ],
+            ['ChildTheme', 'ParentTheme', 'BasicTheme'],
+        ];
+
+        yield 'database copy without technical name uses its parent' => [
+            [
+                self::row('copy', null, parentThemeId: 'child', assigned: true),
+                self::row('child', 'ChildTheme', configInheritance: ['@Storefront', '@BasicTheme']),
+                self::row('basic', 'BasicTheme'),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['ChildTheme', 'BasicTheme', 'Storefront'],
+        ];
+
+        yield 'cyclic inheritance terminates' => [
+            [
+                self::row('a', 'A', parentThemeId: 'b', assigned: true, configInheritance: ['@B']),
+                self::row('b', 'B', parentThemeId: 'a', configInheritance: ['@A']),
+            ],
+            ['A', 'B'],
+        ];
+
+        yield 'configInheritance naming an uninstalled theme is ignored' => [
+            [self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@NotInstalled'])],
+            ['ChildTheme'],
+        ];
+
+        yield 'theme referencing itself is not duplicated' => [
+            [self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@ChildTheme'])],
+            ['ChildTheme'],
+        ];
+
+        yield 'missing base_config' => [
+            [self::row('child', 'ChildTheme', parentThemeId: 'storefront', assigned: true), self::row('storefront', 'Storefront')],
+            ['ChildTheme', 'Storefront'],
+        ];
+
+        yield 'malformed base_config' => [
+            [
+                ['themeId' => 'child', 'technicalName' => 'ChildTheme', 'parentThemeId' => null, 'configInheritance' => 'not json', 'assigned' => 1],
+            ],
+            ['ChildTheme'],
+        ];
+    }
+
+    public function testResultIsMemoisedPerSalesChannel(): void
+    {
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
 
         $salesChannelId = Uuid::randomHex();
+        static::assertSame([], $this->themeLoader->load($salesChannelId));
+        static::assertSame([], $this->themeLoader->load($salesChannelId));
 
-        $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertSame($expectedTheme, $actualTheme);
-
-        $otherSalesChannelId = Uuid::randomHex();
-        $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertSame([], $secondAttempt);
+        static::assertSame([], $this->themeLoader->load(Uuid::randomHex()));
     }
 
-    public function testLoadMultiple(): void
+    public function testResetClearsTheMemoisedResult(): void
     {
-        $expectedDB1 = [
-            'themeName' => 'Extended thrice',
-            'parentThemeName' => 'Extended twice',
-            'themeId' => Uuid::randomHex(),
-            'grandParentThemeId' => Uuid::randomHex(),
-        ];
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([
+            self::row('storefront', 'Storefront', assigned: true),
+        ]);
 
-        $expectedDB2 = [
-            'themeName' => 'Extended once',
-            'parentThemeName' => 'Extended',
-            'grandParentThemeId' => Uuid::randomHex(),
-        ];
-
-        $expectedDB3 = [
-            'themeName' => 'Storefront',
-            'parentThemeName' => null,
-            'grandParentThemeId' => null,
-        ];
-
-        $expectedTheme = [
-            'Extended thrice',
-            'Extended twice',
-            'Extended once',
-            'Extended',
-            'Storefront',
-        ];
-
-        $this->connection->expects($this->exactly(4))->method('fetchAssociative')->willReturnOnConsecutiveCalls($expectedDB1, $expectedDB2, $expectedDB3, []);
         $salesChannelId = Uuid::randomHex();
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
 
-        $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertSame($expectedTheme, $actualTheme);
+        $this->themeLoader->reset();
 
-        $otherSalesChannelId = Uuid::randomHex();
-        $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertSame([], $secondAttempt);
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
     }
 
-    public function testLoadWithMissingThemeNameUsesParentTheme(): void
-    {
-        $expectedDB = [
-            'themeName' => null,
-            'parentThemeName' => 'SwagTheme',
-            'themeId' => Uuid::randomHex(),
+    /**
+     * @param list<string>|null $configInheritance
+     *
+     * @return array<string, mixed>
+     */
+    private static function row(
+        string $themeId,
+        ?string $technicalName,
+        ?string $parentThemeId = null,
+        bool $assigned = false,
+        ?array $configInheritance = null,
+    ): array {
+        return [
+            'themeId' => $themeId,
+            'technicalName' => $technicalName,
+            'parentThemeId' => $parentThemeId,
+            'configInheritance' => $configInheritance === null ? null : json_encode($configInheritance, \JSON_THROW_ON_ERROR),
+            'assigned' => $assigned ? 1 : 0,
         ];
-
-        $this->connection->expects($this->once())->method('fetchAssociative')->willReturn($expectedDB);
-
-        $actualTheme = $this->themeLoader->load(Uuid::randomHex());
-        static::assertSame(['SwagTheme'], $actualTheme);
-    }
-
-    public function testGrandParentThemeWithMissingThemeNameIsReindexed(): void
-    {
-        // When the grandparent's themeName is null, array_filter leaves a gap at index 0.
-        // array_values ensures the result is contiguous so assertSame (key-strict) passes.
-        $salesChannelTheme = [
-            'themeName' => 'ChildTheme',
-            'parentThemeName' => 'ParentTheme',
-            'themeId' => Uuid::randomHex(),
-            'grandParentThemeId' => Uuid::randomHex(),
-        ];
-
-        $grandParentTheme = [
-            'themeName' => null,
-            'parentThemeName' => 'GrandParentTheme',
-            'grandParentThemeId' => null,
-        ];
-
-        $this->connection->expects($this->exactly(2))
-            ->method('fetchAssociative')
-            ->willReturnOnConsecutiveCalls($salesChannelTheme, $grandParentTheme);
-
-        $actualTheme = $this->themeLoader->load(Uuid::randomHex());
-
-        static::assertSame(['ChildTheme', 'ParentTheme', 'GrandParentTheme'], $actualTheme);
     }
 }

--- a/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
+++ b/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
@@ -82,14 +82,27 @@ class ThemeNamespaceHierarchyBuilderTest extends TestCase
         $request = Request::createFromGlobals();
         $event = new DocumentTemplateRendererParameterEvent($parameters);
 
-        $expectedDB = [
-            'themeName' => $usingTheme,
-            'parentThemeName' => $usingParentTheme,
-            'themeId' => Uuid::randomHex(),
-        ];
+        $expectedDB = [[
+            'themeId' => 'theme',
+            'technicalName' => $usingTheme,
+            'parentThemeId' => $usingParentTheme !== null ? 'parentTheme' : null,
+            'configInheritance' => null,
+            'assigned' => 1,
+        ]];
+
+        if ($usingParentTheme !== null) {
+            $expectedDB[] = [
+                'themeId' => 'parentTheme',
+                'technicalName' => $usingParentTheme,
+                'parentThemeId' => null,
+                'configInheritance' => null,
+                'assigned' => 0,
+            ];
+        }
+
         if (\array_key_exists('context', $parameters)) {
             $connectionMock = $this->createMock(Connection::class);
-            $connectionMock->expects($this->exactly(1))->method('fetchAssociative')->willReturn($expectedDB);
+            $connectionMock->expects($this->exactly(1))->method('fetchAllAssociative')->willReturn($expectedDB);
         } else {
             $connectionMock = static::createStub(Connection::class);
         }
@@ -126,12 +139,14 @@ class ThemeNamespaceHierarchyBuilderTest extends TestCase
         $connectionMock = $this->createMock(Connection::class);
         $connectionMock
             ->expects($this->once())
-            ->method('fetchAssociative')
-            ->willReturn([
-                'themeName' => 'SwagTheme',
-                'parentThemeName' => null,
-                'themeId' => Uuid::randomHex(),
-            ]);
+            ->method('fetchAllAssociative')
+            ->willReturn([[
+                'themeId' => 'theme',
+                'technicalName' => 'SwagTheme',
+                'parentThemeId' => null,
+                'configInheritance' => null,
+                'assigned' => 1,
+            ]]);
 
         $builder = new ThemeNamespaceHierarchyBuilder(new TestInheritanceBuilder(), new DatabaseSalesChannelThemeLoader($connectionMock));
         $builder->onSalesChannelFileTemplateResolve(new SalesChannelFileTemplateResolveEvent(Uuid::randomHex()));


### PR DESCRIPTION
### 1. Why is this change necessary?

A theme can declare several ancestors in the `configInheritance` of its `theme.json`, but snippet resolution only ever followed the single `theme.parent_theme_id` column. Ancestors that are not on that column's chain lose all their snippets. `ThemeLifecycleService::addParentTheme()` additionally stores the first non-Storefront entry of the list rather than the nearest ancestor, so for `["@Storefront", "@BasicTheme", "@ParentTheme"]` the column points at `BasicTheme` and `ParentTheme` is unreachable.

### 2. What does this change do, exactly?

`DatabaseSalesChannelThemeLoader` resolves the used themes of a sales channel from both `theme.parent_theme_id` and the `configInheritance` list in `theme.base_config`, expanding every discovered ancestor's own list transitively and guarding against cycles. The per-ancestor queries are replaced by a single projection of the `theme` table. The first entry of the result stays the theme of the sales channel, which `ThemeNamespaceHierarchyBuilder` and `StorybookService` rely on.

`ThemeLifecycleService::addParentTheme()` writes the last entry of `configInheritance` to `theme.parent_theme_id`. Existing rows are recalculated on the next theme refresh, which runs on plugin install, activation and update, and on update finish.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register a theme `BasicTheme` with `"configInheritance": ["@Storefront"]`.
2. Register a theme `ParentTheme` with `"configInheritance": ["@Storefront", "@BasicTheme"]` and a snippet key of its own.
3. Register a theme `ChildTheme` with `"configInheritance": ["@Storefront", "@BasicTheme", "@ParentTheme"]`.
4. Assign `ChildTheme` to a sales channel and open the storefront.
5. The snippet key defined by `ParentTheme` falls back to its Storefront default. With this change it resolves to the `ParentTheme` translation.

`tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php` covers the same setup, and `ThemeLifecycleServiceTest::testThemeConfigInheritanceUsesNearestThemeAsParent()` covers the stored parent.

### 4. Please link to the relevant issues (if any).

- closes #6331

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them