### PR TITLE
fix(storefront): load snippets from all parent themes (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-09-07-load-snippets-from-every-inherited-theme.md
+++ b/changelog/_unreleased/2026-09-07-load-snippets-from-every-inherited-theme.md
@@ -1,0 +1,8 @@
+---
+title: Load snippets from every inherited theme
+issue: 6331
+author: Dominik Grothaus
+author_email: d.grothaus@shopware.com
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader` to resolve the used themes of a sales channel from both `theme.parent_theme_id` and the `configInheritance` list stored in `theme.base_config`, walking the ancestors transitively. A theme naming several ancestors in its `theme.json` previously only received the snippets of the ancestors that happened to lie on the single `parent_theme_id` chain, so the snippets of the others were treated as unused and filtered out.

--- a/changelog/_unreleased/2026-09-07-load-snippets-from-every-inherited-theme.md
+++ b/changelog/_unreleased/2026-09-07-load-snippets-from-every-inherited-theme.md
@@ -5,4 +5,4 @@ author: Dominik Grothaus
 author_email: d.grothaus@shopware.com
 ---
 # Storefront
-* Changed `Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader` to resolve the used themes of a sales channel from both `theme.parent_theme_id` and the `configInheritance` list stored in `theme.base_config`, walking the ancestors transitively. A theme naming several ancestors in its `theme.json` previously only received the snippets of the ancestors that happened to lie on the single `parent_theme_id` chain, so the snippets of the others were treated as unused and filtered out.
+* Changed `Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader` to resolve the used themes of a sales channel from both `theme.parent_theme_id` and the `configInheritance` list in `theme.base_config`. A theme listing several ancestors in its `theme.json` now receives the snippets of all of them.

--- a/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
+++ b/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
@@ -34,11 +34,7 @@ final class DatabaseSalesChannelThemeLoader
      */
     public function load(string $salesChannelId): array
     {
-        if (!empty($this->themes[$salesChannelId])) {
-            return $this->themes[$salesChannelId];
-        }
-
-        return $this->readFromDB($salesChannelId);
+        return $this->themes[$salesChannelId] ??= $this->readFromDB($salesChannelId);
     }
 
     public function reset(): void
@@ -51,56 +47,101 @@ final class DatabaseSalesChannelThemeLoader
      */
     private function readFromDB(string $salesChannelId): array
     {
-        $themes = $this->connection->fetchAssociative('
-            SELECT LOWER(HEX(theme.id)) themeId, theme.technical_name as themeName, parentTheme.technical_name as parentThemeName, LOWER(HEX(parentTheme.parent_theme_id)) as grandParentThemeId
-            FROM sales_channel
-                LEFT JOIN theme_sales_channel ON sales_channel.id = theme_sales_channel.sales_channel_id
-                LEFT JOIN theme ON theme_sales_channel.theme_id = theme.id
-                LEFT JOIN theme AS parentTheme ON parentTheme.id = theme.parent_theme_id
-            WHERE sales_channel.id = :salesChannelId
+        $rows = $this->connection->fetchAllAssociative('
+            SELECT LOWER(HEX(theme.id)) AS themeId,
+                   theme.technical_name AS technicalName,
+                   LOWER(HEX(theme.parent_theme_id)) AS parentThemeId,
+                   JSON_EXTRACT(theme.base_config, \'$.configInheritance\') AS configInheritance,
+                   theme_sales_channel.sales_channel_id IS NOT NULL AS assigned
+            FROM theme
+                LEFT JOIN theme_sales_channel
+                    ON theme_sales_channel.theme_id = theme.id
+                    AND theme_sales_channel.sales_channel_id = :salesChannelId
         ', [
             'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
         ]);
 
-        if (\is_array($themes) && isset($themes['grandParentThemeId']) && \is_string($themes['grandParentThemeId'])) {
-            $themes['grandParentNames'] = $this->getGrantParents($themes['grandParentThemeId']);
+        $themesById = [];
+        $idsByTechnicalName = [];
+        $assignedThemeId = null;
+
+        foreach ($rows as $row) {
+            $themeId = (string) $row['themeId'];
+            $themesById[$themeId] = $row;
+
+            if (\is_string($row['technicalName'])) {
+                $idsByTechnicalName[$row['technicalName']] = $themeId;
+            }
+
+            if ($assignedThemeId === null && (int) $row['assigned'] === 1) {
+                $assignedThemeId = $themeId;
+            }
         }
 
-        $usedThemes = array_filter([
-            $themes['themeName'] ?? null,
-            $themes['parentThemeName'] ?? null,
-        ]);
-
-        if (isset($themes['grandParentNames'])) {
-            $usedThemes = array_merge($usedThemes, $themes['grandParentNames']);
+        if ($assignedThemeId === null) {
+            return [];
         }
 
-        return $this->themes[$salesChannelId] = $usedThemes ?: [];
+        $technicalNames = [];
+        $visited = [$assignedThemeId => true];
+        $queue = [$assignedThemeId];
+
+        while (($themeId = array_shift($queue)) !== null) {
+            $row = $themesById[$themeId];
+
+            if (\is_string($row['technicalName'])) {
+                $technicalNames[$row['technicalName']] = true;
+            }
+
+            foreach ($this->getAncestorIds($row, $idsByTechnicalName) as $ancestorId) {
+                if (isset($visited[$ancestorId]) || !isset($themesById[$ancestorId])) {
+                    continue;
+                }
+
+                $visited[$ancestorId] = true;
+                $queue[] = $ancestorId;
+            }
+        }
+
+        return array_keys($technicalNames);
     }
 
     /**
+     * `parent_theme_id` holds one ancestor, `configInheritance` may name several. Both are sources.
+     *
+     * @param array<string, mixed> $row
+     * @param array<string, string> $idsByTechnicalName
+     *
      * @return array<int, string>
      */
-    private function getGrantParents(mixed $grandParentThemeId): array
+    private function getAncestorIds(array $row, array $idsByTechnicalName): array
     {
-        $grandParents = $this->connection->fetchAssociative('
-            SELECT theme.technical_name as themeName, parentTheme.technical_name as parentThemeName, LOWER(HEX(parentTheme.parent_theme_id)) as grandParentThemeId
-            FROM theme
-                LEFT JOIN theme AS parentTheme ON parentTheme.id = theme.parent_theme_id
-            WHERE theme.id = :id
-        ', [
-            'id' => Uuid::fromHexToBytes($grandParentThemeId),
-        ]);
+        $ancestorIds = [];
 
-        $filtered = array_filter([
-            $grandParents['themeName'] ?? null,
-            $grandParents['parentThemeName'] ?? null,
-        ]);
-
-        if (\is_array($grandParents) && isset($grandParents['grandParentThemeId']) && \is_string($grandParents['grandParentThemeId'])) {
-            $filtered = array_merge($filtered, $this->getGrantParents($grandParents['grandParentThemeId']));
+        // Must stay first: theme copies have no technical name, index 0 comes from the database parent.
+        if (\is_string($row['parentThemeId'])) {
+            $ancestorIds[] = $row['parentThemeId'];
         }
 
-        return $filtered;
+        $configInheritance = json_decode((string) $row['configInheritance'], true);
+
+        if (!\is_array($configInheritance)) {
+            return $ancestorIds;
+        }
+
+        // configInheritance is ordered from least to most specific
+        foreach (array_reverse($configInheritance) as $technicalName) {
+            if (!\is_string($technicalName)) {
+                continue;
+            }
+
+            $ancestorId = $idsByTechnicalName[ltrim($technicalName, '@')] ?? null;
+
+            if ($ancestorId !== null && $ancestorId !== $row['themeId']) {
+                $ancestorIds[] = $ancestorId;
+            }
+        }
+
+        return $ancestorIds;
     }
 }

--- a/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
+++ b/src/Storefront/Theme/DatabaseSalesChannelThemeLoader.php
@@ -34,7 +34,11 @@ final class DatabaseSalesChannelThemeLoader
      */
     public function load(string $salesChannelId): array
     {
-        return $this->themes[$salesChannelId] ??= $this->readFromDB($salesChannelId);
+        if (($this->themes[$salesChannelId] ?? []) !== []) {
+            return $this->themes[$salesChannelId];
+        }
+
+        return $this->themes[$salesChannelId] = $this->readFromDB($salesChannelId);
     }
 
     public function reset(): void

--- a/tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Theme;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader;
+
+/**
+ * @internal
+ */
+class DatabaseSalesChannelThemeLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    private DatabaseSalesChannelThemeLoader $themeLoader;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->themeLoader = static::getContainer()->get(DatabaseSalesChannelThemeLoader::class);
+        $this->themeLoader->reset();
+    }
+
+    public function testUsedThemesContainEveryConfigInheritanceParent(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $this->createTheme('ParentTheme', ['@Storefront', '@BasicTheme'], $basicId);
+
+        // addParentTheme() stored BasicTheme, ParentTheme is only reachable through configInheritance.
+        $childId = $this->createTheme('ChildTheme', ['@Storefront', '@BasicTheme', '@ParentTheme'], $basicId);
+
+        $this->assignThemeToSalesChannel($childId, TestDefaults::SALES_CHANNEL);
+
+        static::assertSame(
+            ['ChildTheme', 'BasicTheme', 'ParentTheme', 'Storefront'],
+            $this->themeLoader->load(TestDefaults::SALES_CHANNEL)
+        );
+    }
+
+    public function testConfigInheritanceIsExpandedTransitively(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $this->createTheme('ParentTheme', ['@Storefront', '@BasicTheme'], $basicId);
+        $childId = $this->createTheme('ChildTheme', ['@ParentTheme']);
+
+        $this->assignThemeToSalesChannel($childId, TestDefaults::SALES_CHANNEL);
+
+        static::assertSame(
+            ['ChildTheme', 'ParentTheme', 'BasicTheme', 'Storefront'],
+            $this->themeLoader->load(TestDefaults::SALES_CHANNEL)
+        );
+    }
+
+    public function testThemeCopyWithoutTechnicalNameResolvesThroughItsParent(): void
+    {
+        $basicId = $this->createTheme('BasicTheme', ['@Storefront']);
+        $childId = $this->createTheme('ChildTheme', ['@Storefront', '@BasicTheme'], $basicId);
+        $copyId = $this->createTheme(null, null, $childId);
+
+        $this->assignThemeToSalesChannel($copyId, TestDefaults::SALES_CHANNEL);
+
+        $usedThemes = $this->themeLoader->load(TestDefaults::SALES_CHANNEL);
+
+        static::assertSame('ChildTheme', $usedThemes[0]);
+        static::assertSame(['ChildTheme', 'BasicTheme', 'Storefront'], $usedThemes);
+    }
+
+    /**
+     * @param list<string>|null $configInheritance
+     */
+    private function createTheme(?string $technicalName, ?array $configInheritance = null, ?string $parentThemeId = null): string
+    {
+        $id = Uuid::randomHex();
+
+        $this->connection->insert('theme', [
+            'id' => Uuid::fromHexToBytes($id),
+            'technical_name' => $technicalName,
+            'name' => $technicalName ?? 'Theme copy',
+            'author' => 'test',
+            'active' => 1,
+            'base_config' => $configInheritance === null
+                ? null
+                : json_encode(['configInheritance' => $configInheritance], \JSON_THROW_ON_ERROR),
+            'parent_theme_id' => $parentThemeId !== null ? Uuid::fromHexToBytes($parentThemeId) : null,
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s.v'),
+        ]);
+
+        return $id;
+    }
+
+    private function assignThemeToSalesChannel(string $themeId, string $salesChannelId): void
+    {
+        $this->connection->executeStatement(
+            'REPLACE INTO theme_sales_channel (theme_id, sales_channel_id) VALUES (:themeId, :salesChannelId)',
+            [
+                'themeId' => Uuid::fromHexToBytes($themeId),
+                'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
+            ]
+        );
+    }
+}

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -88,13 +88,15 @@ class SnippetServiceTest extends TestCase
 
         $cachedThemeLoader = null;
         if ($salesChannelId !== null) {
-            $expectedDB = [
-                'themeName' => $usedTheme ?? 'Storefront',
-                'parentThemeName' => null,
+            $expectedDB = [[
                 'themeId' => Uuid::randomHex(),
-            ];
+                'technicalName' => $usedTheme ?? 'Storefront',
+                'parentThemeId' => null,
+                'configInheritance' => null,
+                'assigned' => 1,
+            ]];
             $connectionMock = $this->createMock(Connection::class);
-            $connectionMock->expects($this->once())->method('fetchAssociative')->willReturn($expectedDB);
+            $connectionMock->expects($this->once())->method('fetchAllAssociative')->willReturn($expectedDB);
             $cachedThemeLoader = new DatabaseSalesChannelThemeLoader($connectionMock);
         }
 

--- a/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -124,13 +124,24 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
 
     public function testResultIsMemoisedPerSalesChannel(): void
     {
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([
+            self::row('storefront', 'Storefront', assigned: true),
+        ]);
+
+        $salesChannelId = Uuid::randomHex();
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+
+        static::assertSame(['Storefront'], $this->themeLoader->load(Uuid::randomHex()));
+    }
+
+    public function testEmptyResultIsNotMemoised(): void
+    {
         $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
 
         $salesChannelId = Uuid::randomHex();
         static::assertSame([], $this->themeLoader->load($salesChannelId));
         static::assertSame([], $this->themeLoader->load($salesChannelId));
-
-        static::assertSame([], $this->themeLoader->load(Uuid::randomHex()));
     }
 
     public function testResetClearsTheMemoisedResult(): void

--- a/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Storefront\Theme;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,72 +23,148 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
-        $this->themeLoader = new DatabaseSalesChannelThemeLoader(
-            $this->connection,
-        );
+        $this->themeLoader = new DatabaseSalesChannelThemeLoader($this->connection);
     }
 
-    public function testLoadWithDifferentSalesChannel(): void
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param list<string> $expected
+     */
+    #[DataProvider('themeGraphProvider')]
+    public function testLoad(array $rows, array $expected): void
     {
-        $expectedDB = [
-            'themeName' => 'Storefront',
-            'parentThemeName' => null,
-            'themeId' => Uuid::randomHex(),
-        ];
+        $this->connection->method('fetchAllAssociative')->willReturn($rows);
 
-        $expectedTheme = [
-            'Storefront',
-        ];
-
-        $this->connection->expects($this->exactly(2))->method('fetchAssociative')->willReturnOnConsecutiveCalls($expectedDB, []);
-
-        $salesChannelId = Uuid::randomHex();
-
-        $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertEquals($expectedTheme, $actualTheme);
-
-        $otherSalesChannelId = Uuid::randomHex();
-        $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertEquals([], $secondAttempt);
+        static::assertSame($expected, $this->themeLoader->load(Uuid::randomHex()));
     }
 
-    public function testLoadMultiple(): void
+    public static function themeGraphProvider(): \Generator
     {
-        $expectedDB1 = [
-            'themeName' => 'Extended thrice',
-            'parentThemeName' => 'Extended twice',
-            'themeId' => Uuid::randomHex(),
-            'grandParentThemeId' => Uuid::randomHex(),
+        yield 'no theme assigned to the sales channel' => [
+            [self::row('storefront', 'Storefront')],
+            [],
         ];
 
-        $expectedDB2 = [
-            'themeName' => 'Extended once',
-            'parentThemeName' => 'Extended',
-            'grandParentThemeId' => Uuid::randomHex(),
+        yield 'only the base theme' => [
+            [self::row('storefront', 'Storefront', assigned: true)],
+            ['Storefront'],
         ];
 
-        $expectedDB3 = [
-            'themeName' => 'Storefront',
-            'parentThemeName' => null,
-            'grandParentThemeId' => null,
+        yield 'linear parent_theme_id chain' => [
+            [
+                self::row('t1', 'Extended thrice', parentThemeId: 't2', assigned: true),
+                self::row('t2', 'Extended twice', parentThemeId: 't3'),
+                self::row('t3', 'Extended once', parentThemeId: 't4'),
+                self::row('t4', 'Extended', parentThemeId: 'storefront'),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['Extended thrice', 'Extended twice', 'Extended once', 'Extended', 'Storefront'],
         ];
 
-        $expectedTheme = [
-            'Extended thrice',
-            'Extended twice',
-            'Extended once',
-            'Extended',
-            'Storefront',
+        // addParentTheme() stored BasicTheme, ParentTheme is only reachable through configInheritance.
+        yield 'multiple configInheritance parents with a stale parent_theme_id' => [
+            [
+                self::row('child', 'ChildTheme', parentThemeId: 'basic', assigned: true, configInheritance: ['@Storefront', '@BasicTheme', '@ParentTheme']),
+                self::row('parent', 'ParentTheme', parentThemeId: 'basic', configInheritance: ['@Storefront', '@BasicTheme']),
+                self::row('basic', 'BasicTheme', configInheritance: ['@Storefront']),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['ChildTheme', 'BasicTheme', 'ParentTheme', 'Storefront'],
         ];
 
-        $this->connection->expects($this->exactly(4))->method('fetchAssociative')->willReturnOnConsecutiveCalls($expectedDB1, $expectedDB2, $expectedDB3, []);
+        yield 'configInheritance is expanded transitively' => [
+            [
+                self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@ParentTheme']),
+                self::row('parent', 'ParentTheme', configInheritance: ['@BasicTheme']),
+                self::row('basic', 'BasicTheme'),
+            ],
+            ['ChildTheme', 'ParentTheme', 'BasicTheme'],
+        ];
+
+        yield 'database copy without technical name uses its parent' => [
+            [
+                self::row('copy', null, parentThemeId: 'child', assigned: true),
+                self::row('child', 'ChildTheme', configInheritance: ['@Storefront', '@BasicTheme']),
+                self::row('basic', 'BasicTheme'),
+                self::row('storefront', 'Storefront'),
+            ],
+            ['ChildTheme', 'BasicTheme', 'Storefront'],
+        ];
+
+        yield 'cyclic inheritance terminates' => [
+            [
+                self::row('a', 'A', parentThemeId: 'b', assigned: true, configInheritance: ['@B']),
+                self::row('b', 'B', parentThemeId: 'a', configInheritance: ['@A']),
+            ],
+            ['A', 'B'],
+        ];
+
+        yield 'configInheritance naming an uninstalled theme is ignored' => [
+            [self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@NotInstalled'])],
+            ['ChildTheme'],
+        ];
+
+        yield 'theme referencing itself is not duplicated' => [
+            [self::row('child', 'ChildTheme', assigned: true, configInheritance: ['@ChildTheme'])],
+            ['ChildTheme'],
+        ];
+
+        yield 'missing base_config' => [
+            [self::row('child', 'ChildTheme', parentThemeId: 'storefront', assigned: true), self::row('storefront', 'Storefront')],
+            ['ChildTheme', 'Storefront'],
+        ];
+
+        yield 'malformed base_config' => [
+            [
+                ['themeId' => 'child', 'technicalName' => 'ChildTheme', 'parentThemeId' => null, 'configInheritance' => 'not json', 'assigned' => 1],
+            ],
+            ['ChildTheme'],
+        ];
+    }
+
+    public function testResultIsMemoisedPerSalesChannel(): void
+    {
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
+
         $salesChannelId = Uuid::randomHex();
+        static::assertSame([], $this->themeLoader->load($salesChannelId));
+        static::assertSame([], $this->themeLoader->load($salesChannelId));
 
-        $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertEquals($expectedTheme, $actualTheme);
+        static::assertSame([], $this->themeLoader->load(Uuid::randomHex()));
+    }
 
-        $otherSalesChannelId = Uuid::randomHex();
-        $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertEquals([], $secondAttempt);
+    public function testResetClearsTheMemoisedResult(): void
+    {
+        $this->connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([
+            self::row('storefront', 'Storefront', assigned: true),
+        ]);
+
+        $salesChannelId = Uuid::randomHex();
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+
+        $this->themeLoader->reset();
+
+        static::assertSame(['Storefront'], $this->themeLoader->load($salesChannelId));
+    }
+
+    /**
+     * @param list<string>|null $configInheritance
+     *
+     * @return array<string, mixed>
+     */
+    private static function row(
+        string $themeId,
+        ?string $technicalName,
+        ?string $parentThemeId = null,
+        bool $assigned = false,
+        ?array $configInheritance = null,
+    ): array {
+        return [
+            'themeId' => $themeId,
+            'technicalName' => $technicalName,
+            'parentThemeId' => $parentThemeId,
+            'configInheritance' => $configInheritance === null ? null : json_encode($configInheritance, \JSON_THROW_ON_ERROR),
+            'assigned' => $assigned ? 1 : 0,
+        ];
     }
 }

--- a/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
+++ b/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Event\DocumentTemplateRendererParameterEvent;
 use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader;
@@ -79,14 +78,16 @@ class ThemeNamespaceHierarchyBuilderTest extends TestCase
         $request = Request::createFromGlobals();
         $event = new DocumentTemplateRendererParameterEvent($parameters);
 
-        $expectedDB = [
-            'themeName' => $usingTheme,
-            'parentThemeName' => null,
-            'themeId' => Uuid::randomHex(),
-        ];
+        $expectedDB = [[
+            'themeId' => 'theme',
+            'technicalName' => $usingTheme,
+            'parentThemeId' => null,
+            'configInheritance' => null,
+            'assigned' => 1,
+        ]];
         $connectionMock = $this->createMock(Connection::class);
         if (\array_key_exists('context', $parameters)) {
-            $connectionMock->expects($this->exactly(1))->method('fetchAssociative')->willReturn($expectedDB);
+            $connectionMock->expects($this->exactly(1))->method('fetchAllAssociative')->willReturn($expectedDB);
         }
         $cachedThemeLoader = new DatabaseSalesChannelThemeLoader($connectionMock);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

A theme can declare several ancestors in the `configInheritance` of its `theme.json`, but snippet resolution only ever followed the single `theme.parent_theme_id` column. Ancestors that are not on that column's chain lose all their snippets, so a theme inheriting from `["@Storefront", "@BasicTheme", "@ParentTheme"]` never sees the snippets of `ParentTheme`.

Backport of #20208 

### 2. What does this change do, exactly?

`DatabaseSalesChannelThemeLoader` resolves the used themes of a sales channel from both `theme.parent_theme_id` and the `configInheritance` list in `theme.base_config`, expanding every discovered ancestor's own list transitively and guarding against cycles. The per-ancestor queries are replaced by a single projection of the `theme` table. The first entry of the result stays the theme of the sales channel, which `SnippetService` and `ThemeNamespaceHierarchyBuilder` rely on.

The `ThemeLifecycleService::addParentTheme()` half of the trunk fix is not part of this backport. It changes which theme cascades a recompile through `ThemeService::getThemeDependencyMapping()`, and it needs a theme refresh before it takes effect. The read path repairs affected shops on its own, including those whose stored parent is already wrong.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register a theme `BasicTheme` with `"configInheritance": ["@Storefront"]`.
2. Register a theme `ParentTheme` with `"configInheritance": ["@Storefront", "@BasicTheme"]` and a snippet key of its own.
3. Register a theme `ChildTheme` with `"configInheritance": ["@Storefront", "@BasicTheme", "@ParentTheme"]`.
4. Assign `ChildTheme` to a sales channel and open the storefront.
5. The snippet key defined by `ParentTheme` falls back to its Storefront default. With this change it resolves to the `ParentTheme` translation.

`tests/integration/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php` covers the same setup.

### 4. Please link to the relevant issues (if any).

- relates #6331

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them