### PR TITLE
fix(core): stop repeating the company name on invoice buyer names

### DIFF
--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -24,6 +24,7 @@ use Shopware\Core\Checkout\Document\DocumentConfiguration;
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerNameFormatter;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -130,10 +131,7 @@ class ZugferdDocument
 
     public function withBuyerInformation(OrderCustomerEntity $customer, OrderAddressEntity $billingAddress): self
     {
-        $customerName = $customer->getFirstName() . ' ' . $customer->getLastName();
-        if ($customer->getCompany()) {
-            $customerName .= ' - ' . $customer->getCompany();
-        }
+        $customerName = OrderCustomerNameFormatter::buyerName($customer);
 
         $replace = $billingAddress->getCountry()?->getIso() . '-';
         $countryStateCode = $billingAddress->getCountryState()?->getShortCode() ?? '';

--- a/src/Core/Checkout/DocumentV2/Template/View/TradePartyView.php
+++ b/src/Core/Checkout/DocumentV2/Template/View/TradePartyView.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\DocumentV2\Template\View;
 
 use Shopware\Core\Checkout\DocumentV2\Config\DocumentCompanyInfo;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerNameFormatter;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Log\Package;
 
@@ -37,11 +38,7 @@ final readonly class TradePartyView
         $billing = $order->getBillingAddress()
             ?? $order->getAddresses()?->get($order->getBillingAddressId());
 
-        $name = trim(($customer?->getFirstName() ?? '') . ' ' . ($customer?->getLastName() ?? ''));
-
-        if ($customer?->getCompany()) {
-            $name = trim($name . ' - ' . $customer->getCompany());
-        }
+        $name = OrderCustomerNameFormatter::buyerName($customer);
 
         if ($name === '') {
             throw DocumentV2Exception::invalidOrderData(

--- a/src/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerNameFormatter.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerNameFormatter.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderCustomer;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+final class OrderCustomerNameFormatter
+{
+    private function __construct()
+    {
+    }
+
+    public static function buyerName(?OrderCustomerEntity $customer): string
+    {
+        if ($customer === null) {
+            return '';
+        }
+
+        $personName = trim($customer->getFirstName() . ' ' . $customer->getLastName());
+        $company = trim($customer->getCompany() ?? '');
+
+        return match (true) {
+            $company === '' => $personName,
+            $personName === '' || $personName === $company => $company,
+            default => $personName . ' - ' . $company,
+        };
+    }
+}

--- a/tests/unit/Core/Checkout/DocumentV2/Template/View/TradePartyViewTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Template/View/TradePartyViewTest.php
@@ -63,6 +63,40 @@ class TradePartyViewTest extends TestCase
         static::assertSame('Jane Doe - Acme GmbH', $view->name);
     }
 
+    public function testBuyerNameDoesNotRepeatCompanyWhenItAlreadyIsThePersonName(): void
+    {
+        $order = $this->createOrderWithBillingAddress(
+            firstName: '',
+            lastName: 'Acme GmbH',
+            company: 'Acme GmbH',
+            street: '',
+            zipcode: '',
+            city: '',
+            countryIso: 'DE',
+        );
+
+        $view = TradePartyView::buyerFromOrder($order);
+
+        static::assertSame('Acme GmbH', $view->name);
+    }
+
+    public function testBuyerNameFallsBackToCompanyWhenPersonNameIsEmpty(): void
+    {
+        $order = $this->createOrderWithBillingAddress(
+            firstName: '',
+            lastName: '',
+            company: 'Acme GmbH',
+            street: '',
+            zipcode: '',
+            city: '',
+            countryIso: 'DE',
+        );
+
+        $view = TradePartyView::buyerFromOrder($order);
+
+        static::assertSame('Acme GmbH', $view->name);
+    }
+
     public function testBuyerCarriesAdditionalAddressLinesAndCountrySubdivision(): void
     {
         $state = new CountryStateEntity();

--- a/tests/unit/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerNameFormatterTest.php
+++ b/tests/unit/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerNameFormatterTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Order\Aggregate\OrderCustomer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerNameFormatter;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(OrderCustomerNameFormatter::class)]
+class OrderCustomerNameFormatterTest extends TestCase
+{
+    #[DataProvider('buyerNameProvider')]
+    public function testBuyerName(string $firstName, string $lastName, ?string $company, string $expected): void
+    {
+        $customer = new OrderCustomerEntity();
+        $customer->setUniqueIdentifier('order-customer-id');
+        $customer->setFirstName($firstName);
+        $customer->setLastName($lastName);
+
+        if ($company !== null) {
+            $customer->setCompany($company);
+        }
+
+        static::assertSame($expected, OrderCustomerNameFormatter::buyerName($customer));
+    }
+
+    public function testBuyerNameWithoutAnOrderCustomer(): void
+    {
+        static::assertSame('', OrderCustomerNameFormatter::buyerName(null));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string|null, string}>
+     */
+    public static function buyerNameProvider(): iterable
+    {
+        yield 'person name without a company' => ['Ada', 'Lovelace', null, 'Ada Lovelace'];
+        yield 'the company is appended to a person name' => ['Ada', 'Lovelace', 'Acme GmbH', 'Ada Lovelace - Acme GmbH'];
+        yield 'a company already carried by the name is not repeated' => ['', 'Acme GmbH', 'Acme GmbH', 'Acme GmbH'];
+        yield 'no contact person falls back to the company' => ['', '', 'Acme GmbH', 'Acme GmbH'];
+        yield 'a blank company is ignored' => ['Ada', 'Lovelace', '   ', 'Ada Lovelace'];
+        yield 'nothing at all stays empty' => ['', '', null, ''];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`ZugferdDocument::withBuyerInformation()` and `TradePartyView::buyerFromOrder()` each derive the invoice buyer name inline, the same way:

```php
$name = $customer->getFirstName() . ' ' . $customer->getLastName();
if ($customer->getCompany()) {
    $name .= ' - ' . $customer->getCompany();
}
```

Two defects follow from that.

`if ($customer->getCompany())` is a truthiness test, so a company whose name is the string `"0"` is silently dropped from the invoice.

Nothing compares the company against the person name, so an order customer whose last name equals their company renders the name twice: `Acme GmbH - Acme GmbH`. The Zugferd path also does not trim, so an empty name part leaves a stray space.

### 2. What does this change do, exactly?

Adds `OrderCustomerNameFormatter::buyerName()` and calls it from both places, so the two renderers can no longer drift apart. It trims both parts and then:

- no company: the person name
- no person name, or a company equal to the person name: the company alone
- otherwise: `person name - company`

The class is `@internal`, so there is no new public surface.

### 3. Describe each step to reproduce the issue or behaviour.

Repeated company name:

1. Place an order for a customer whose last name and company are both `Acme GmbH`.
2. Generate an invoice.
3. The buyer name reads `Acme GmbH - Acme GmbH`. It should read `Acme GmbH`.

Dropped company name:

1. Place an order for a customer with the company `0`.
2. Generate an invoice.
3. The company is missing from the buyer name entirely.

### 4. Please link to the relevant issues (if any).

relates #15321

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
