### PR TITLE
ci: auto-label major Administration tests

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -44,10 +44,10 @@ Three mechanisms decide how much runs:
   `nightly` widens the matrix. The matrix is generated at runtime and consumed as
   `matrix: ${{ fromJson(...) }}` — the expression must stay on `matrix:`, since
   zizmor cannot audit a file whose whole `strategy:` block is an expression.
-- **Major arms** — opt in on a PR with the `major-php` or `major-acceptance`
-  label, or the `major-tests` umbrella. `01-pr-issue-labeler.yml` applies
-  `major-php` automatically when the diff touches major feature flags. Nightly
-  and manual runs ignore the labels.
+- **Major arms** — opt in on a PR with the `major-php`, `major-js`, or
+  `major-acceptance` label, or the `major-tests` umbrella. `01-pr-issue-labeler.yml`
+  applies the relevant PHP and Administration JS labels automatically when the diff
+  touches major feature flags. Nightly and manual runs ignore the labels.
 - **`markdown-only-changes`** — a first job in each heavy workflow that
   short-circuits docs-only PRs.
 
@@ -128,7 +128,7 @@ grows a branch worth getting wrong, move it out:
 
 - **JavaScript/TypeScript** → `.github/bin/js/<name>.ts` with a sibling
   `<name>.test.ts`; `node --test` runs them from `lint-actions.yml`. See
-  `auto-label-major-php.ts` for the shape. Do not use Python.
+  `auto-label-major-tests.ts` for the shape. Do not use Python.
 - **PHP** → `.github/bin/<name>.php` with a PHPUnit test.
 - Logic repeated across workflows → a composite action under `.github/actions/`.
 - Start every non-trivial Bash `run:` block with `set -euo pipefail`.

--- a/.github/bin/js/auto-label-major-tests.test.ts
+++ b/.github/bin/js/auto-label-major-tests.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { FEATURE_REGISTRY_PATH, hasMajorMarkers, parseMajorFlags, shouldDetect } from './auto-label-major-php.ts';
+import {
+    FEATURE_REGISTRY_PATH,
+    hasMajorJsMarkers,
+    hasMajorMarkers,
+    labelsForMajorTestArms,
+    parseMajorFlags,
+    shouldDetect,
+} from './auto-label-major-tests.ts';
 
 
 type TestContext = {
@@ -68,6 +75,43 @@ test('deprecation tag annotation matches', () => {
 test('registry file edits match regardless of line content', () => {
     const diff = diffFor(FEATURE_REGISTRY_PATH, '+            - name: NEW_FLAG');
     assert.equal(hasMajorMarkers(diff, parseMajorFlags(REGISTRY)), true);
+});
+
+test('major markers in Administration source or tests enable the major-js arm', () => {
+    const sourceDiff = diffFor(
+        'src/Administration/Resources/app/administration/src/app/component/example/index.ts',
+        "+        return Shopware.Feature.isActive('v6.8.0.0');",
+    );
+    const testDiff = diffFor(
+        'src/Administration/Resources/app/administration/test/_setup/example.spec.ts',
+        "+        it.deprecated('v6.8.0.0')('keeps the legacy path', () => {});",
+    );
+
+    assert.equal(hasMajorJsMarkers(sourceDiff, parseMajorFlags(REGISTRY)), true);
+    assert.equal(hasMajorJsMarkers(testDiff, parseMajorFlags(REGISTRY)), true);
+});
+
+test('major markers outside Administration source and tests do not enable the major-js arm', () => {
+    const phpDiff = diffFor('src/Core/Framework/Feature.php', "+        Feature::isActive('v6.8.0.0');");
+    const documentationDiff = diffFor(
+        'src/Administration/Resources/app/administration/technical-docs/guide.md',
+        '+ v6.8.0.0',
+    );
+
+    assert.equal(hasMajorJsMarkers(phpDiff, parseMajorFlags(REGISTRY)), false);
+    assert.equal(hasMajorJsMarkers(documentationDiff, parseMajorFlags(REGISTRY)), false);
+});
+
+test('feature registry edits enable the major-js arm', () => {
+    const diff = diffFor(FEATURE_REGISTRY_PATH, '+            - name: NEW_FLAG');
+
+    assert.equal(hasMajorJsMarkers(diff, parseMajorFlags(REGISTRY)), true);
+});
+
+test('labelsForMajorTestArms adds only missing relevant labels', () => {
+    assert.deepEqual(labelsForMajorTestArms({ php: true, js: true }), ['major-php', 'major-js']);
+    assert.deepEqual(labelsForMajorTestArms({ php: true, js: true }, [{ name: 'major-php' }]), ['major-js']);
+    assert.deepEqual(labelsForMajorTestArms({ php: false, js: true }, [{ name: 'major-js' }]), []);
 });
 
 test('non-major flag usage does not match', () => {
@@ -157,10 +201,16 @@ test('shouldDetect rejects fork heads', async () => {
     assert.equal(shouldDetect(context), false);
 });
 
-test('shouldDetect rejects PRs already labeled major-php or major-tests', async () => {
-    for (const name of ['major-php', 'major-tests']) {
-        const context = baseContext();
-        context.payload.pull_request.labels = [{ name }];
-        assert.equal(shouldDetect(context), false);
-    }
+test('shouldDetect permits detection until both per-arm labels are present', () => {
+    const phpOnly = baseContext();
+    phpOnly.payload.pull_request.labels = [{ name: 'major-php' }];
+    assert.equal(shouldDetect(phpOnly), true);
+
+    const bothArms = baseContext();
+    bothArms.payload.pull_request.labels = [{ name: 'major-php' }, { name: 'major-js' }];
+    assert.equal(shouldDetect(bothArms), false);
+
+    const umbrella = baseContext();
+    umbrella.payload.pull_request.labels = [{ name: 'major-tests' }];
+    assert.equal(shouldDetect(umbrella), false);
 });

--- a/.github/bin/js/auto-label-major-tests.ts
+++ b/.github/bin/js/auto-label-major-tests.ts
@@ -1,5 +1,5 @@
 /**
- * Auto-apply the `major-php` label when a PR touches major feature flags.
+ * Auto-apply the relevant major-test labels when a PR touches major feature flags.
  *
  * Detection is registry-driven: every flag registered with `major: true` in
  * `src/Core/Framework/Resources/config/packages/feature.yaml` counts, read from the
@@ -15,9 +15,16 @@
  * signal. The imprecision is accepted: mentioning a version in changed code is a
  * good-enough reason to run the major matrix, and the known noise (e.g. changelog
  * release headings) is rare — see the discussion on the introducing PR.
+ *
+ * The PHP arm retains that repository-wide marker detection. The Administration
+ * Jest arm uses the same markers only in Administration source and test files;
+ * a feature-registry change enables both arms because it changes both baselines.
  */
 
 export const FEATURE_REGISTRY_PATH = 'src/Core/Framework/Resources/config/packages/feature.yaml';
+export const ADMINISTRATION_APP_PATH = 'src/Administration/Resources/app/administration/';
+export const ADMINISTRATION_SOURCE_PATH = `${ADMINISTRATION_APP_PATH}src/`;
+export const ADMINISTRATION_TEST_PATH = `${ADMINISTRATION_APP_PATH}test/`;
 
 type PullRequestLabel = {
     name: string;
@@ -108,6 +115,11 @@ type DiffFileSection = {
     section: string;
 };
 
+export type MajorTestArms = {
+    php: boolean;
+    js: boolean;
+};
+
 // All run conditions beyond the workflow-level `if: github.event_name == 'pull_request'`
 // live here so they are unit-testable instead of being an untestable YAML expression.
 export function shouldDetect(context: PullRequestDetectionContext): boolean {
@@ -127,7 +139,7 @@ export function shouldDetect(context: PullRequestDetectionContext): boolean {
 
     const labels = (pullRequest.labels ?? []).map((label) => label.name);
 
-    return !labels.includes('major-php') && !labels.includes('major-tests');
+    return !labels.includes('major-tests') && (!labels.includes('major-php') || !labels.includes('major-js'));
 }
 
 export function parseMajorFlags(registryYaml: string): string[] {
@@ -155,7 +167,7 @@ export function parseMajorFlags(registryYaml: string): string[] {
  */
 export const EXCLUDED_PATH_PREFIX = '.github/';
 
-function splitDiffByFile(diff: string): DiffFileSection[] {
+export function splitDiffByFile(diff: string): DiffFileSection[] {
     return diff
         .split(/^diff --git /m)
         .slice(1)
@@ -190,11 +202,47 @@ export function hasMajorMarkers(diff: string, majorFlags: string[]): boolean {
     return changedLines.some((line) => markers.some((marker) => marker.test(line)));
 }
 
-export async function detectMajorFlagUsage({ github, core, context }: DetectionToolkit): Promise<boolean> {
+export function hasMajorJsMarkers(diff: string, majorFlags: string[]): boolean {
+    const files = splitDiffByFile(diff);
+
+    if (files.some(({ path }) => path === FEATURE_REGISTRY_PATH)) {
+        return true;
+    }
+
+    const administrationFiles = files.filter(
+        ({ path }) => path.startsWith(ADMINISTRATION_SOURCE_PATH) || path.startsWith(ADMINISTRATION_TEST_PATH),
+    );
+    const changedLines = administrationFiles.flatMap(({ section }) =>
+        section.split('\n').filter((line) => /^[+-][^+-]/.test(line)),
+    );
+
+    if (changedLines.length === 0) {
+        return false;
+    }
+
+    const escaped = majorFlags.map((flag) => flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const markers = [
+        new RegExp(`['"](${escaped.join('|')})['"]`),
+        /6\.\d+\.\d/,
+    ];
+
+    return changedLines.some((line) => markers.some((marker) => marker.test(line)));
+}
+
+export function labelsForMajorTestArms(arms: MajorTestArms, existingLabels: PullRequestLabel[] = []): string[] {
+    const existing = new Set(existingLabels.map((label) => label.name));
+
+    return [
+        arms.php && !existing.has('major-php') ? 'major-php' : null,
+        arms.js && !existing.has('major-js') ? 'major-js' : null,
+    ].filter((label): label is string => label !== null);
+}
+
+export async function detectMajorTestArms({ github, core, context }: DetectionToolkit): Promise<MajorTestArms> {
     if (!shouldDetect(context)) {
         core.info('skipping major-flag detection: event, fork head, or existing label rules it out');
 
-        return false;
+        return { php: false, js: false };
     }
 
     const { data: registry } = await github.rest.repos.getContent({
@@ -214,22 +262,25 @@ export async function detectMajorFlagUsage({ github, core, context }: DetectionT
         mediaType: { format: 'diff' },
     });
 
-    const hit = hasMajorMarkers(String(diff), majorFlags);
+    const arms = {
+        php: hasMajorMarkers(String(diff), majorFlags),
+        js: hasMajorJsMarkers(String(diff), majorFlags),
+    };
     core.info(
-        hit
-            ? `major marker found in the diff (${majorFlags.length} registered major flags)`
+        arms.php || arms.js
+            ? `major marker found in the diff (${majorFlags.length} registered major flags; php=${arms.php}; js=${arms.js})`
             : 'no major markers in the diff',
     );
 
-    return hit;
+    return arms;
 }
 
 // Expects a token able to trigger the `labeled` workflow run.
-export async function addMajorPhpLabel({ github, context }: LabelToolkit): Promise<void> {
+export async function addMajorTestLabels({ github, context, labels }: LabelToolkit & { labels: string[] }): Promise<void> {
     await github.rest.issues.addLabels({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: context.payload.pull_request.number,
-        labels: ['major-php'],
+        labels,
     });
 }

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: srvaroa/labeler@bf262763a8a8e191f5847873aecc0f29df84f957 # v1.14.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      # auto-apply `major-php` when the diff touches major feature flags, so the integration-major
-      # matrix runs on the PRs where it matters without running it everywhere. Piggybacks on this
-      # job to avoid a runner spin-up of its own; costs one API call per PR event.
+      # Auto-apply the relevant major-test labels when the diff touches major feature flags, so the
+      # matching integration-major arm runs on the PRs where it matters without running it everywhere.
+      # Piggybacks on this job to avoid a runner spin-up of its own; costs one API call per PR event.
       # all further run conditions (action, fork head, existing labels) live in the
       # module's `shouldDetect` where they are unit-tested
       - id: detect-major
@@ -34,25 +34,31 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const { detectMajorFlagUsage } = await import('${{ github.workspace }}/.github/bin/js/auto-label-major-php.ts')
-            const hit = await detectMajorFlagUsage({ github, core, context })
-            core.setOutput('hit', hit ? 'yes' : 'no')
+            const { detectMajorTestArms, labelsForMajorTestArms } = await import(
+              '${{ github.workspace }}/.github/bin/js/auto-label-major-tests.ts'
+            )
+            const arms = await detectMajorTestArms({ github, core, context })
+            const labels = labelsForMajorTestArms(arms, context.payload.pull_request.labels)
+            core.setOutput('labels', labels.join(','))
       # an app token is required for the added label to trigger integration-major's `labeled` run;
       # if minting fails we fall back to GITHUB_TOKEN — the label still lands, the matrix starts on the next push
       - id: sts-major
-        if: steps.detect-major.outputs.hit == 'yes'
+        if: steps.detect-major.outputs.labels != ''
         continue-on-error: true
         uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: CreatePR
-      - if: steps.detect-major.outputs.hit == 'yes'
+      - if: steps.detect-major.outputs.labels != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.sts-major.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
-            const { addMajorPhpLabel } = await import('${{ github.workspace }}/.github/bin/js/auto-label-major-php.ts')
-            await addMajorPhpLabel({ github, context })
+            const { addMajorTestLabels } = await import(
+              '${{ github.workspace }}/.github/bin/js/auto-label-major-tests.ts'
+            )
+            const labels = '${{ steps.detect-major.outputs.labels }}'.split(',').filter(Boolean)
+            await addMajorTestLabels({ github, context, labels })
 
   cleanup-needs-triage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/integration-major.yml
+++ b/.github/workflows/integration-major.yml
@@ -106,6 +106,7 @@ jobs:
     env:
       NODE_VERSION: 'lts/*'
       JEST_MAX_WORKERS: 100%
+      FEATURE_ALL: major
 
     steps:
       - name: Setup Shopware


### PR DESCRIPTION
### 1. Why is this change necessary?

Major PHP test coverage is automatically enabled when a same-repository PR changes a major feature flag or major-version boundary. Administration major Jest coverage still requires the author to add `major-js` manually, so relevant changes can reach the nightly without a PR-time signal.

### 2. What does this change do, exactly?

- Generalises the major-test labeler so it adds only the missing relevant labels.
- Preserves the existing repository-wide PHP detection.
- Adds `major-js` when a registered major marker changes in Administration source or tests, or when the feature registry changes.
- Sets `FEATURE_ALL=major` on the major Jest job, matching the PHPUnit job environment.
- Keeps the existing hard-failing Jest step and `integration-major-check` aggregate; neither uses failure suppression.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a same-repository PR changing a major flag or `v6.x.0` deprecation in Administration source or tests.
2. The label workflow adds `major-js` with the existing app-token fallback.
3. The `labeled` event starts the major Jest job.
4. A Jest failure makes the job and `integration-major-check` fail.

Verified locally with `cd .github/bin/js && node --test` (165 passing tests). The pushed branch will run the repository Actions lint workflow.

### 4. Please link to the relevant issues (if any).

- Relates to #18585

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them