### PR TITLE
feat(content-system): layout presets from extensions

### DIFF
--- a/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetCollection.php
+++ b/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetCollection.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @extends EntityCollection<AppContentSystemLayoutPresetEntity>
+ */
+#[Package('framework')]
+class AppContentSystemLayoutPresetCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return AppContentSystemLayoutPresetEntity::class;
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetDefinition.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset;
+
+use Shopware\Core\Framework\App\AppDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class AppContentSystemLayoutPresetDefinition extends EntityDefinition
+{
+    final public const ENTITY_NAME = 'app_content_system_layout_preset';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return AppContentSystemLayoutPresetEntity::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return AppContentSystemLayoutPresetCollection::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.7.0.0';
+    }
+
+    protected function getParentDefinitionClass(): ?string
+    {
+        return AppDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new FkField('app_id', 'appId', AppDefinition::class))->addFlags(new Required()),
+            (new StringField('name', 'name'))->addFlags(new Required()),
+            (new JsonField('schema', 'schema'))->addFlags(new Required()),
+            (new StringField('hash', 'hash', 64))->addFlags(new Required()),
+            new ManyToOneAssociationField('app', 'app_id', AppDefinition::class),
+        ]);
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetEntity.php
+++ b/src/Core/Framework/App/Aggregate/AppContentSystemLayoutPreset/AppContentSystemLayoutPresetEntity.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset;
+
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class AppContentSystemLayoutPresetEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $appId;
+
+    protected string $name;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $schema;
+
+    protected string $hash;
+
+    protected ?AppEntity $app = null;
+
+    public function getAppId(): string
+    {
+        return $this->appId;
+    }
+
+    public function setAppId(string $appId): void
+    {
+        $this->appId = $appId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    public function setSchema(array $schema): void
+    {
+        $this->schema = $schema;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+
+    public function setHash(string $hash): void
+    {
+        $this->hash = $hash;
+    }
+
+    public function getApp(): ?AppEntity
+    {
+        return $this->app;
+    }
+
+    public function setApp(?AppEntity $app): void
+    {
+        $this->app = $app;
+    }
+}

--- a/src/Core/Framework/App/AppDefinition.php
+++ b/src/Core/Framework/App/AppDefinition.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemBindingSpecification\AppContentSystemBindingSpecificationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemElementType\AppContentSystemElementTypeDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemStyleOption\AppContentSystemStyleOptionDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceDefinition;
@@ -150,6 +151,7 @@ class AppDefinition extends EntityDefinition
             (new OneToManyAssociationField('contentElementTypes', AppContentSystemElementTypeDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('styleOptions', AppContentSystemStyleOptionDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('bindingSpecifications', AppContentSystemBindingSpecificationDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField('layoutPresets', AppContentSystemLayoutPresetDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('flowActions', AppFlowActionDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('flowEvents', AppFlowEventDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appShippingMethods', AppShippingMethodDefinition::class, 'app_id'))->addFlags(new SetNullOnDelete()),

--- a/src/Core/Framework/App/AppEntity.php
+++ b/src/Core/Framework/App/AppEntity.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Api\Acl\Role\AclRoleEntity;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonCollection;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemBindingSpecification\AppContentSystemBindingSpecificationCollection;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemElementType\AppContentSystemElementTypeCollection;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetCollection;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemStyleOption\AppContentSystemStyleOptionCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceCollection;
@@ -162,6 +163,8 @@ class AppEntity extends Entity
     protected ?AppContentSystemStyleOptionCollection $styleOptions = null;
 
     protected ?AppContentSystemBindingSpecificationCollection $bindingSpecifications = null;
+
+    protected ?AppContentSystemLayoutPresetCollection $layoutPresets = null;
 
     /**
      * @var EntityCollection<AppShippingMethodEntity>|null
@@ -695,6 +698,16 @@ class AppEntity extends Entity
     public function setBindingSpecifications(AppContentSystemBindingSpecificationCollection $bindingSpecifications): void
     {
         $this->bindingSpecifications = $bindingSpecifications;
+    }
+
+    public function getLayoutPresets(): ?AppContentSystemLayoutPresetCollection
+    {
+        return $this->layoutPresets;
+    }
+
+    public function setLayoutPresets(AppContentSystemLayoutPresetCollection $layoutPresets): void
+    {
+        $this->layoutPresets = $layoutPresets;
     }
 
     /**

--- a/src/Core/Framework/App/AppException.php
+++ b/src/Core/Framework/App/AppException.php
@@ -77,6 +77,8 @@ class AppException extends HttpException
     final public const MANIFEST_NOT_FOUND = 'FRAMEWORK__APP_MANIFEST_NOT_FOUND';
     final public const CONTENT_SYSTEM_ELEMENT_TYPE_LOAD_FAILED = 'FRAMEWORK__APP_ELEMENT_TYPE_LOAD_FAILED';
     final public const CONTENT_SYSTEM_ELEMENT_TYPE_DUPLICATE = 'FRAMEWORK__APP_ELEMENT_TYPE_DUPLICATE';
+    final public const CONTENT_SYSTEM_LAYOUT_PRESET_LOAD_FAILED = 'FRAMEWORK__APP_LAYOUT_PRESET_LOAD_FAILED';
+    final public const CONTENT_SYSTEM_LAYOUT_PRESET_DUPLICATE = 'FRAMEWORK__APP_LAYOUT_PRESET_DUPLICATE';
     final public const CONTENT_SYSTEM_STYLE_OPTION_LOAD_FAILED = 'FRAMEWORK__APP_STYLE_OPTION_LOAD_FAILED';
     final public const CONTENT_SYSTEM_STYLE_OPTION_DUPLICATE = 'FRAMEWORK__APP_STYLE_OPTION_DUPLICATE';
     final public const CONTENT_SYSTEM_BINDING_SPECIFICATION_LOAD_FAILED = 'FRAMEWORK__APP_BINDING_SPECIFICATION_LOAD_FAILED';
@@ -675,6 +677,31 @@ class AppException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::CONTENT_SYSTEM_ELEMENT_TYPE_LOAD_FAILED,
             'Failed to load element type from "{{ file }}": {{ reason }}',
+            ['file' => $file, 'reason' => $reason],
+            $previous
+        );
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    public static function contentSystemLayoutPresetDuplicate(array $ids, string $source, \Throwable $previous): self
+    {
+        return new self(
+            Response::HTTP_CONFLICT,
+            self::CONTENT_SYSTEM_LAYOUT_PRESET_DUPLICATE,
+            'Layout preset id collision while persisting presets for "{{ source }}" (ids: {{ ids }}). A concurrent registration claimed the same id.',
+            ['source' => $source, 'ids' => implode(', ', $ids)],
+            $previous
+        );
+    }
+
+    public static function contentSystemLayoutPresetLoadFailed(string $file, string $reason, ?\Throwable $previous = null): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::CONTENT_SYSTEM_LAYOUT_PRESET_LOAD_FAILED,
+            'Failed to load layout preset from "{{ file }}": {{ reason }}',
             ['file' => $file, 'reason' => $reason],
             $previous
         );

--- a/src/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandler.php
@@ -2,8 +2,11 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Handler;
 
+use Shopware\Core\Framework\App\Lifecycle\Context\AppActivationContext;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppRemovalContext;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -14,6 +17,7 @@ class ContentSystemLayoutPresetLifecycleHandler extends AbstractLifecycleHandler
 {
     public function __construct(
         private readonly ContentSystemLayoutPresetPersister $persister,
+        private readonly AbstractContentSystemLayoutPresetRegistry $registry,
     ) {
     }
 
@@ -25,5 +29,25 @@ class ContentSystemLayoutPresetLifecycleHandler extends AbstractLifecycleHandler
     public function update(AppPersistContext $context): void
     {
         $this->persister->persist($context);
+    }
+
+    public function activate(AppActivationContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function deactivate(AppActivationContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function uninstall(AppRemovalContext $context): void
+    {
+        $this->registry->invalidate();
+    }
+
+    public function delete(AppRemovalContext $context): void
+    {
+        $this->registry->invalidate();
     }
 }

--- a/src/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandler.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle\Handler;
+
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class ContentSystemLayoutPresetLifecycleHandler extends AbstractLifecycleHandler
+{
+    public function __construct(
+        private readonly ContentSystemLayoutPresetPersister $persister,
+    ) {
+    }
+
+    public function install(AppPersistContext $context): void
+    {
+        $this->persister->persist($context);
+    }
+
+    public function update(AppPersistContext $context): void
+    {
+        $this->persister->persist($context);
+    }
+}

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSpecificationSerializer;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\Dto\LayoutPresetSpecificationDto;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -31,6 +33,7 @@ class ContentSystemLayoutPresetPersister
     public function __construct(
         private readonly EntityRepository $presetRepository,
         private readonly YamlLayoutPresetLoader $loader,
+        private readonly LayoutPresetSpecificationSerializer $serializer,
         private readonly AbstractContentSystemLayoutPresetRegistry $registry,
     ) {
     }
@@ -39,22 +42,22 @@ class ContentSystemLayoutPresetPersister
     {
         $appId = $context->app->getId();
 
-        $raw = $this->loadRaw($context);
+        $dtos = $this->loadDtos($context);
         $existing = $this->getExistingPresets($appId, $context->context);
 
-        if ($raw === [] && $existing->count() === 0) {
+        if ($dtos === [] && $existing->count() === 0) {
             return;
         }
 
-        $upserts = $this->buildUpserts($raw, $existing, $appId);
-        $deleteIds = $this->buildDeletes($raw, $existing);
+        $upserts = $this->buildUpserts($dtos, $existing, $appId);
+        $deleteIds = $this->buildDeletes($dtos, $existing);
 
         if ($upserts !== []) {
             try {
                 $this->presetRepository->upsert($upserts, $context->context);
             } catch (UniqueConstraintViolationException $e) {
                 throw AppException::contentSystemLayoutPresetDuplicate(
-                    array_keys($raw),
+                    array_keys($dtos),
                     'app:' . $context->app->getName(),
                     $e,
                 );
@@ -71,14 +74,14 @@ class ContentSystemLayoutPresetPersister
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return array<string, LayoutPresetSpecificationDto>
      */
-    private function loadRaw(AppPersistContext $context): array
+    private function loadDtos(AppPersistContext $context): array
     {
         $presetsDir = $context->appFilesystem->path(self::PRESETS_DIRECTORY);
 
         try {
-            return $this->loader->readRawFromDirectory($presetsDir, 'app:' . $context->app->getName(), $context->app->getName());
+            return $this->loader->loadDtosFromDirectory($presetsDir, 'app:' . $context->app->getName(), $context->app->getName());
         } catch (ContentSystemException $e) {
             throw AppException::contentSystemLayoutPresetLoadFailed(self::PRESETS_DIRECTORY, $e->getMessage(), $e);
         }
@@ -93,11 +96,11 @@ class ContentSystemLayoutPresetPersister
     }
 
     /**
-     * @param array<string, array<string, mixed>> $raw
+     * @param array<string, LayoutPresetSpecificationDto> $dtos
      *
      * @return list<array<string, mixed>>
      */
-    private function buildUpserts(array $raw, AppContentSystemLayoutPresetCollection $existing, string $appId): array
+    private function buildUpserts(array $dtos, AppContentSystemLayoutPresetCollection $existing, string $appId): array
     {
         $existingByName = [];
         foreach ($existing as $entity) {
@@ -106,8 +109,9 @@ class ContentSystemLayoutPresetPersister
 
         $upserts = [];
 
-        foreach ($raw as $name => $data) {
-            $hash = Hasher::hash(json_encode($data, \JSON_THROW_ON_ERROR));
+        foreach ($dtos as $name => $dto) {
+            $schema = $this->serializer->normalize($dto);
+            $hash = Hasher::hash(json_encode($schema, \JSON_THROW_ON_ERROR));
             $existingEntity = $existingByName[$name] ?? null;
 
             if ($existingEntity !== null && $existingEntity->getHash() === $hash) {
@@ -117,7 +121,7 @@ class ContentSystemLayoutPresetPersister
             $upserts[] = [
                 'id' => $existingEntity?->getId() ?? Uuid::randomHex(),
                 'name' => $name,
-                'schema' => $data,
+                'schema' => $schema,
                 'hash' => $hash,
                 'appId' => $appId,
             ];
@@ -127,16 +131,16 @@ class ContentSystemLayoutPresetPersister
     }
 
     /**
-     * @param array<string, array<string, mixed>> $raw
+     * @param array<string, LayoutPresetSpecificationDto> $dtos
      *
      * @return list<array{id: string}>
      */
-    private function buildDeletes(array $raw, AppContentSystemLayoutPresetCollection $existing): array
+    private function buildDeletes(array $dtos, AppContentSystemLayoutPresetCollection $existing): array
     {
         $deleteIds = [];
 
         foreach ($existing as $existingEntity) {
-            if (!\array_key_exists($existingEntity->getName(), $raw)) {
+            if (!\array_key_exists($existingEntity->getName(), $dtos)) {
                 $deleteIds[] = ['id' => $existingEntity->getId()];
             }
         }

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Persister;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetCollection;
 use Shopware\Core\Framework\App\AppException;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Lock\LockFactory;
 
 /**
  * @internal
@@ -35,6 +37,8 @@ class ContentSystemLayoutPresetPersister
         private readonly YamlLayoutPresetLoader $loader,
         private readonly LayoutPresetSpecificationSerializer $serializer,
         private readonly AbstractContentSystemLayoutPresetRegistry $registry,
+        private readonly Connection $connection,
+        private readonly LockFactory $lockFactory,
     ) {
     }
 
@@ -43,33 +47,46 @@ class ContentSystemLayoutPresetPersister
         $appId = $context->app->getId();
 
         $dtos = $this->loadDtos($context);
-        $existing = $this->getExistingPresets($appId, $context->context);
 
-        if ($dtos === [] && $existing->count() === 0) {
-            return;
-        }
+        // Serialize concurrent same-app persists so the delta is never computed from a stale snapshot.
+        $lock = $this->lockFactory->createLock('content_system_layout_preset_persist_' . $appId, 15.0);
+        $lock->acquire(true);
 
-        $upserts = $this->buildUpserts($dtos, $existing, $appId);
-        $deleteIds = $this->buildDeletes($dtos, $existing);
+        try {
+            $existing = $this->getExistingPresets($appId, $context->context);
 
-        if ($upserts !== []) {
-            try {
-                $this->presetRepository->upsert($upserts, $context->context);
-            } catch (UniqueConstraintViolationException $e) {
-                throw AppException::contentSystemLayoutPresetDuplicate(
-                    array_keys($dtos),
-                    'app:' . $context->app->getName(),
-                    $e,
-                );
+            if ($dtos === [] && $existing->count() === 0) {
+                return;
             }
-        }
 
-        if ($deleteIds !== []) {
-            $this->presetRepository->delete($deleteIds, $context->context);
-        }
+            $upserts = $this->buildUpserts($dtos, $existing, $appId);
+            $deleteIds = $this->buildDeletes($dtos, $existing);
 
-        if ($upserts !== [] || $deleteIds !== []) {
-            $this->registry->invalidate();
+            // Upsert and delete are one atomic unit so a partial failure cannot leave a half-synced preset set.
+            $this->connection->transactional(function () use ($upserts, $deleteIds, $dtos, $context): void {
+                if ($upserts !== []) {
+                    try {
+                        $this->presetRepository->upsert($upserts, $context->context);
+                    } catch (UniqueConstraintViolationException $e) {
+                        throw AppException::contentSystemLayoutPresetDuplicate(
+                            array_keys($dtos),
+                            'app:' . $context->app->getName(),
+                            $e,
+                        );
+                    }
+                }
+
+                if ($deleteIds !== []) {
+                    $this->presetRepository->delete($deleteIds, $context->context);
+                }
+            });
+
+            // Keep invalidation inside the lock and after commit so no concurrent persist can repopulate stale data.
+            if ($upserts !== [] || $deleteIds !== []) {
+                $this->registry->invalidate();
+            }
+        } finally {
+            $lock->release();
         }
     }
 

--- a/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersister.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle\Persister;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetCollection;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ContentSystemLayoutPresetPersister
+{
+    private const PRESETS_DIRECTORY = 'Resources/content-system/presets';
+
+    /**
+     * @param EntityRepository<AppContentSystemLayoutPresetCollection> $presetRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $presetRepository,
+        private readonly YamlLayoutPresetLoader $loader,
+        private readonly AbstractContentSystemLayoutPresetRegistry $registry,
+    ) {
+    }
+
+    public function persist(AppPersistContext $context): void
+    {
+        $appId = $context->app->getId();
+
+        $raw = $this->loadRaw($context);
+        $existing = $this->getExistingPresets($appId, $context->context);
+
+        if ($raw === [] && $existing->count() === 0) {
+            return;
+        }
+
+        $upserts = $this->buildUpserts($raw, $existing, $appId);
+        $deleteIds = $this->buildDeletes($raw, $existing);
+
+        if ($upserts !== []) {
+            try {
+                $this->presetRepository->upsert($upserts, $context->context);
+            } catch (UniqueConstraintViolationException $e) {
+                throw AppException::contentSystemLayoutPresetDuplicate(
+                    array_keys($raw),
+                    'app:' . $context->app->getName(),
+                    $e,
+                );
+            }
+        }
+
+        if ($deleteIds !== []) {
+            $this->presetRepository->delete($deleteIds, $context->context);
+        }
+
+        if ($upserts !== [] || $deleteIds !== []) {
+            $this->registry->invalidate();
+        }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadRaw(AppPersistContext $context): array
+    {
+        $presetsDir = $context->appFilesystem->path(self::PRESETS_DIRECTORY);
+
+        try {
+            return $this->loader->readRawFromDirectory($presetsDir, 'app:' . $context->app->getName(), $context->app->getName());
+        } catch (ContentSystemException $e) {
+            throw AppException::contentSystemLayoutPresetLoadFailed(self::PRESETS_DIRECTORY, $e->getMessage(), $e);
+        }
+    }
+
+    private function getExistingPresets(string $appId, Context $context): AppContentSystemLayoutPresetCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('appId', $appId));
+
+        return $this->presetRepository->search($criteria, $context)->getEntities();
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $raw
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function buildUpserts(array $raw, AppContentSystemLayoutPresetCollection $existing, string $appId): array
+    {
+        $existingByName = [];
+        foreach ($existing as $entity) {
+            $existingByName[$entity->getName()] = $entity;
+        }
+
+        $upserts = [];
+
+        foreach ($raw as $name => $data) {
+            $hash = Hasher::hash(json_encode($data, \JSON_THROW_ON_ERROR));
+            $existingEntity = $existingByName[$name] ?? null;
+
+            if ($existingEntity !== null && $existingEntity->getHash() === $hash) {
+                continue;
+            }
+
+            $upserts[] = [
+                'id' => $existingEntity?->getId() ?? Uuid::randomHex(),
+                'name' => $name,
+                'schema' => $data,
+                'hash' => $hash,
+                'appId' => $appId,
+            ];
+        }
+
+        return $upserts;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $raw
+     *
+     * @return list<array{id: string}>
+     */
+    private function buildDeletes(array $raw, AppContentSystemLayoutPresetCollection $existing): array
+    {
+        $deleteIds = [];
+
+        foreach ($existing as $existingEntity) {
+            if (!\array_key_exists($existingEntity->getName(), $raw)) {
+                $deleteIds[] = ['id' => $existingEntity->getId()];
+            }
+        }
+
+        return $deleteIds;
+    }
+}

--- a/src/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidator.php
+++ b/src/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidator.php
@@ -29,7 +29,7 @@ class ContentSystemLayoutPresetAppValidator extends AbstractManifestValidator
         $appName = $manifest->getMetadata()->getName();
 
         try {
-            $this->loader->readRawFromDirectory($presetsDir, 'app:' . $appName, $appName);
+            $this->loader->loadDtosFromDirectory($presetsDir, 'app:' . $appName, $appName);
         } catch (ContentSystemException $e) {
             $errors->add(new ContentSystemLayoutPresetSchemaError(
                 $presetsDir,

--- a/src/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidator.php
+++ b/src/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidator.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Validation;
+
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Validation\Error\ContentSystemLayoutPresetSchemaError;
+use Shopware\Core\Framework\App\Validation\Error\ErrorCollection;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class ContentSystemLayoutPresetAppValidator extends AbstractManifestValidator
+{
+    public function __construct(
+        private readonly YamlLayoutPresetLoader $loader,
+    ) {
+    }
+
+    public function validate(Manifest $manifest, Context $context): ErrorCollection
+    {
+        $errors = new ErrorCollection();
+
+        $presetsDir = $manifest->getPath() . '/Resources/content-system/presets';
+        $appName = $manifest->getMetadata()->getName();
+
+        try {
+            $this->loader->readRawFromDirectory($presetsDir, 'app:' . $appName, $appName);
+        } catch (ContentSystemException $e) {
+            $errors->add(new ContentSystemLayoutPresetSchemaError(
+                $presetsDir,
+                $e->getMessage()
+            ));
+        }
+
+        return $errors;
+    }
+}

--- a/src/Core/Framework/App/Validation/Error/ContentSystemLayoutPresetSchemaError.php
+++ b/src/Core/Framework/App/Validation/Error/ContentSystemLayoutPresetSchemaError.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Validation\Error;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class ContentSystemLayoutPresetSchemaError extends Error
+{
+    private const KEY = 'manifest-invalid-layout-preset-schema';
+
+    public function __construct(string $filename, string $reason)
+    {
+        $this->message = \sprintf(
+            'Invalid layout preset in "%s": %s',
+            $filename,
+            $reason
+        );
+
+        parent::__construct($this->message);
+    }
+
+    public function getMessageKey(): string
+    {
+        return self::KEY;
+    }
+}

--- a/src/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoader.php
+++ b/src/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoader.php
@@ -4,9 +4,12 @@ namespace Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader;
 
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSerializer;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\LayoutPresetPayloadCompiler;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSpecificationSerializer;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\ContentSystemLayoutPresetSpecification;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\Dto\LayoutPresetSpecificationDtoCollection;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
@@ -17,7 +20,9 @@ use Shopware\Core\Framework\Log\Package;
 class DatabaseLayoutPresetLoader extends AbstractContentSystemLayoutPresetLoader
 {
     public function __construct(
-        private readonly LayoutPresetSerializer $serializer,
+        private readonly LayoutPresetSpecificationSerializer $serializer,
+        private readonly LayoutPresetPayloadCompiler $compiler,
+        private readonly ValidatorInterface $validator,
         private readonly Connection $connection,
         private readonly string $environment,
         private readonly LoggerInterface $logger,
@@ -60,8 +65,23 @@ class DatabaseLayoutPresetLoader extends AbstractContentSystemLayoutPresetLoader
                 continue;
             }
 
+            $dto = $this->serializer->denormalize($data);
+
+            $violations = $this->validator->validate(new LayoutPresetSpecificationDtoCollection([$row['name'] => $dto]));
+            if ($violations->count() > 0) {
+                $this->logger->warning(\sprintf('Skipping layout preset "%s": %s', $identifier, (string) $violations));
+
+                continue;
+            }
+
             try {
-                $presets[] = $this->serializer->denormalize($data, $row['name']);
+                $presets[] = new ContentSystemLayoutPresetSpecification(
+                    $row['name'],
+                    $dto->name,
+                    $dto->description,
+                    $dto->icon,
+                    $this->compiler->compile($dto->layout),
+                );
             } catch (\Throwable $e) {
                 $this->logger->warning(\sprintf('Skipping layout preset "%s": %s', $identifier, $e->getMessage()));
             }

--- a/src/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoader.php
+++ b/src/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoader.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSerializer;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\ContentSystemLayoutPresetSpecification;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @final
+ */
+#[Package('framework')]
+class DatabaseLayoutPresetLoader extends AbstractContentSystemLayoutPresetLoader
+{
+    public function __construct(
+        private readonly LayoutPresetSerializer $serializer,
+        private readonly Connection $connection,
+        private readonly string $environment,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return list<ContentSystemLayoutPresetSpecification>
+     */
+    public function load(): array
+    {
+        if ($this->environment === 'dev') {
+            return [];
+        }
+
+        /** @var list<array{name: string, schema: string, app_name: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT p.name, p.schema, a.name as app_name
+             FROM app_content_system_layout_preset p
+             INNER JOIN app a ON p.app_id = a.id
+             WHERE a.active = 1'
+        );
+
+        $presets = [];
+
+        foreach ($rows as $row) {
+            $identifier = 'app:' . $row['app_name'] . ':' . ($row['name'] ?: '<unknown>');
+
+            try {
+                $data = json_decode($row['schema'], true, 512, \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                $this->logger->warning(\sprintf('Skipping layout preset "%s": invalid JSON data: %s', $identifier, $e->getMessage()));
+
+                continue;
+            }
+
+            if (!\is_array($data)) {
+                $this->logger->warning(\sprintf('Skipping layout preset "%s": persisted data must decode to an array/map, got %s', $identifier, get_debug_type($data)));
+
+                continue;
+            }
+
+            try {
+                $presets[] = $this->serializer->denormalize($data, $row['name']);
+            } catch (\Throwable $e) {
+                $this->logger->warning(\sprintf('Skipping layout preset "%s": %s', $identifier, $e->getMessage()));
+            }
+        }
+
+        return $presets;
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -508,11 +508,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(YamlLayoutPresetLoader::class),
             service(LayoutPresetSpecificationSerializer::class),
             service(ContentSystemLayoutPresetRegistry::class),
+            service(Connection::class),
+            service('lock.factory'),
         ]);
 
     $services->set(ContentSystemLayoutPresetLifecycleHandler::class)
         ->args([
             service(ContentSystemLayoutPresetPersister::class),
+            service(ContentSystemLayoutPresetRegistry::class),
         ])
         ->tag('shopware.app_lifecycle.handler', ['priority' => -1403]);
 

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -178,6 +178,7 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Serialization\Sty
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Validation\StyleOptionCollisionDetector;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\ContentSystemLayoutPresetRegistry;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSpecificationSerializer;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Loader\YamlTypeLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\ContentSystemElementTypeRegistry;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Serialization\ElementTypeSpecificationSerializer;
@@ -505,6 +506,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('app_content_system_layout_preset.repository'),
             service(YamlLayoutPresetLoader::class),
+            service(LayoutPresetSpecificationSerializer::class),
             service(ContentSystemLayoutPresetRegistry::class),
         ]);
 

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonDefinition;
 use Shopware\Core\Framework\App\Aggregate\ActionButtonTranslation\ActionButtonTranslationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemBindingSpecification\AppContentSystemBindingSpecificationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemElementType\AppContentSystemElementTypeDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppContentSystemStyleOption\AppContentSystemStyleOptionDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionDefinition;
@@ -95,6 +96,7 @@ use Shopware\Core\Framework\App\Lifecycle\Handler\ActionButtonLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\CmsBlockLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemBindingSpecificationLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemElementTypeLifecycleHandler;
+use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemLayoutPresetLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemStyleOptionLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\CustomFieldLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\FlowActionLifecycleHandler;
@@ -110,6 +112,7 @@ use Shopware\Core\Framework\App\Lifecycle\Handler\WebhookLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemBindingSpecificationPersister;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemElementTypePersister;
+use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemStyleOptionPersister;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory;
@@ -159,6 +162,7 @@ use Shopware\Core\Framework\App\Validation\AppRequirementsValidator;
 use Shopware\Core\Framework\App\Validation\ConfigValidator;
 use Shopware\Core\Framework\App\Validation\ContentSystemBindingSpecificationAppValidator;
 use Shopware\Core\Framework\App\Validation\ContentSystemElementTypeAppValidator;
+use Shopware\Core\Framework\App\Validation\ContentSystemLayoutPresetAppValidator;
 use Shopware\Core\Framework\App\Validation\ContentSystemStyleOptionAppValidator;
 use Shopware\Core\Framework\App\Validation\HookableValidator;
 use Shopware\Core\Framework\App\Validation\ManifestValidator;
@@ -172,6 +176,8 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Loader\YamlStyleO
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Registry\ContentSystemStyleOptionRegistry;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Serialization\StyleOptionSpecificationSerializer;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\Validation\StyleOptionCollisionDetector;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\ContentSystemLayoutPresetRegistry;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Loader\YamlTypeLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Registry\ContentSystemElementTypeRegistry;
 use Shopware\Core\Framework\ContentSystem\Layout\Type\Serialization\ElementTypeSpecificationSerializer;
@@ -492,6 +498,25 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(YamlBindingSpecificationLoader::class),
             service(YamlTypeLoader::class),
+        ])
+        ->tag('shopware.app_manifest.validator');
+
+    $services->set(ContentSystemLayoutPresetPersister::class)
+        ->args([
+            service('app_content_system_layout_preset.repository'),
+            service(YamlLayoutPresetLoader::class),
+            service(ContentSystemLayoutPresetRegistry::class),
+        ]);
+
+    $services->set(ContentSystemLayoutPresetLifecycleHandler::class)
+        ->args([
+            service(ContentSystemLayoutPresetPersister::class),
+        ])
+        ->tag('shopware.app_lifecycle.handler', ['priority' => -1403]);
+
+    $services->set(ContentSystemLayoutPresetAppValidator::class)
+        ->args([
+            service(YamlLayoutPresetLoader::class),
         ])
         ->tag('shopware.app_manifest.validator');
 
@@ -1038,6 +1063,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('shopware.entity.definition');
 
     $services->set(AppContentSystemBindingSpecificationDefinition::class)
+        ->tag('shopware.entity.definition');
+
+    $services->set(AppContentSystemLayoutPresetDefinition::class)
         ->tag('shopware.entity.definition');
 
     $services->set(AppFlowActionLoadedSubscriber::class)

--- a/src/Core/Framework/DependencyInjection/content-system.php
+++ b/src/Core/Framework/DependencyInjection/content-system.php
@@ -503,7 +503,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(DatabaseLayoutPresetLoader::class)
         ->args([
-            service(LayoutPresetSerializer::class),
+            service(LayoutPresetSpecificationSerializer::class),
+            service(LayoutPresetPayloadCompiler::class),
+            service('validator'),
             service(Connection::class),
             param('kernel.environment'),
             service('logger'),

--- a/src/Core/Framework/DependencyInjection/content-system.php
+++ b/src/Core/Framework/DependencyInjection/content-system.php
@@ -68,6 +68,7 @@ use Shopware\Core\Framework\ContentSystem\Layout\Field\StoredElementListFieldSer
 use Shopware\Core\Framework\ContentSystem\Layout\LayoutDefaultSeeder;
 use Shopware\Core\Framework\ContentSystem\Layout\LayoutWriteBoundary;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\LayoutPresetPayloadCompiler;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\DatabaseLayoutPresetLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\LayoutPresetNameResolver;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\CachedContentSystemLayoutPresetRegistry;
@@ -498,6 +499,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(LayoutPresetNameResolver::class),
         ])
         ->arg('$directories', [])
+        ->tag('content_system.layout_preset_loader');
+
+    $services->set(DatabaseLayoutPresetLoader::class)
+        ->args([
+            service(LayoutPresetSerializer::class),
+            service(Connection::class),
+            param('kernel.environment'),
+            service('logger'),
+        ])
         ->tag('content_system.layout_preset_loader');
 
     $services->set(ContentSystemLayoutPresetRegistry::class)

--- a/src/Core/Migration/V6_7/Migration1788858711AddAppContentSystemLayoutPresetTable.php
+++ b/src/Core/Migration/V6_7/Migration1788858711AddAppContentSystemLayoutPresetTable.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1788858711AddAppContentSystemLayoutPresetTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1788858711;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `app_content_system_layout_preset` (
+                `id` BINARY(16) NOT NULL,
+                `app_id` BINARY(16) NOT NULL,
+                `name` VARCHAR(255) NOT NULL,
+                `schema` JSON NOT NULL,
+                `hash` VARCHAR(64) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `uniq.app_content_system_layout_preset.name` (`name`),
+                KEY `fk.app_content_system_layout_preset.app_id` (`app_id`),
+                CONSTRAINT `fk.app_content_system_layout_preset.app_id`
+                    FOREIGN KEY (`app_id`) REFERENCES `app` (`id`)
+                    ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+}

--- a/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
+++ b/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
@@ -51,6 +51,8 @@
     "app_content_system_style_option.updatedAt",
     "app_content_system_binding_specification.createdAt",
     "app_content_system_binding_specification.updatedAt",
+    "app_content_system_layout_preset.createdAt",
+    "app_content_system_layout_preset.updatedAt",
     "app_mcp_prompt.createdAt",
     "app_mcp_prompt.updatedAt",
     "app_mcp_prompt.translated",

--- a/tests/migration/Core/V6_7/Migration1788858711AddAppContentSystemLayoutPresetTableTest.php
+++ b/tests/migration/Core/V6_7/Migration1788858711AddAppContentSystemLayoutPresetTableTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1788858711AddAppContentSystemLayoutPresetTable;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1788858711AddAppContentSystemLayoutPresetTable::class)]
+class Migration1788858711AddAppContentSystemLayoutPresetTableTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `app_content_system_layout_preset`;');
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1788858711, (new Migration1788858711AddAppContentSystemLayoutPresetTable())->getCreationTimestamp());
+    }
+
+    public function testMigration(): void
+    {
+        static::assertFalse(TableHelper::tableExists($this->connection, 'app_content_system_layout_preset'));
+
+        $migration = new Migration1788858711AddAppContentSystemLayoutPresetTable();
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::tableExists($this->connection, 'app_content_system_layout_preset'));
+
+        $table = TableHelper::getTable($this->connection, 'app_content_system_layout_preset');
+
+        static::assertCount(7, $table->columns);
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'id'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'app_id'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'name'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'schema'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'hash'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'created_at'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'app_content_system_layout_preset', 'updated_at'));
+    }
+}

--- a/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandlerTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandlerTest.php
@@ -6,10 +6,13 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppActivationContext;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppRemovalContext;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemLayoutPresetLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Filesystem;
@@ -29,7 +32,10 @@ class ContentSystemLayoutPresetLifecycleHandlerTest extends TestCase
         $persister = $this->createMock(ContentSystemLayoutPresetPersister::class);
         $persister->expects($this->once())->method('persist')->with($context);
 
-        (new ContentSystemLayoutPresetLifecycleHandler($persister))->install($context);
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        (new ContentSystemLayoutPresetLifecycleHandler($persister, $registry))->install($context);
     }
 
     #[TestDox('update persists the app presets')]
@@ -40,29 +46,95 @@ class ContentSystemLayoutPresetLifecycleHandlerTest extends TestCase
         $persister = $this->createMock(ContentSystemLayoutPresetPersister::class);
         $persister->expects($this->once())->method('persist')->with($context);
 
-        (new ContentSystemLayoutPresetLifecycleHandler($persister))->update($context);
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        (new ContentSystemLayoutPresetLifecycleHandler($persister, $registry))->update($context);
+    }
+
+    #[TestDox('activation invalidates the registry so the app presets become available')]
+    public function testActivateInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->activate($this->buildActivationContext());
+    }
+
+    #[TestDox('deactivation invalidates the registry so the app presets disappear')]
+    public function testDeactivateInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->deactivate($this->buildActivationContext());
+    }
+
+    #[TestDox('uninstall invalidates the registry')]
+    public function testUninstallInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->uninstall($this->buildRemovalContext());
+    }
+
+    #[TestDox('local deletion invalidates the registry')]
+    public function testDeleteInvalidates(): void
+    {
+        $this->handlerExpectingInvalidation()->delete($this->buildRemovalContext());
     }
 
     #[TestDox('propagates a persister failure on install rather than swallowing it')]
     public function testInstallPropagatesPersisterException(): void
     {
+        $exception = new \RuntimeException('persist failed');
         $persister = static::createStub(ContentSystemLayoutPresetPersister::class);
-        $persister->method('persist')->willThrowException(new \RuntimeException('persist failed'));
+        $persister->method('persist')->willThrowException($exception);
 
-        $this->expectExceptionObject(new \RuntimeException('persist failed'));
-
-        (new ContentSystemLayoutPresetLifecycleHandler($persister))->install($this->buildPersistContext());
+        $this->expectExceptionObject($exception);
+        (new ContentSystemLayoutPresetLifecycleHandler($persister, static::createStub(AbstractContentSystemLayoutPresetRegistry::class)))
+            ->install($this->buildPersistContext());
     }
 
-    private function buildPersistContext(): AppPersistContext
+    #[TestDox('a registry invalidation failure is propagated')]
+    public function testPropagatesRegistryException(): void
+    {
+        $exception = new \RuntimeException('invalidate failed');
+        $registry = static::createStub(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->method('invalidate')->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+        (new ContentSystemLayoutPresetLifecycleHandler(static::createStub(ContentSystemLayoutPresetPersister::class), $registry))
+            ->activate($this->buildActivationContext());
+    }
+
+    private function handlerExpectingInvalidation(): ContentSystemLayoutPresetLifecycleHandler
+    {
+        $persister = $this->createMock(ContentSystemLayoutPresetPersister::class);
+        $persister->expects($this->never())->method('persist');
+
+        $registry = $this->createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->once())->method('invalidate');
+
+        return new ContentSystemLayoutPresetLifecycleHandler($persister, $registry);
+    }
+
+    private function buildApp(): AppEntity
     {
         $app = new AppEntity();
         $app->setId('app-id');
         $app->setName('DemoApp');
 
+        return $app;
+    }
+
+    private function buildActivationContext(): AppActivationContext
+    {
+        return new AppActivationContext($this->buildApp(), Context::createDefaultContext());
+    }
+
+    private function buildRemovalContext(): AppRemovalContext
+    {
+        return new AppRemovalContext($this->buildApp(), Context::createDefaultContext());
+    }
+
+    private function buildPersistContext(): AppPersistContext
+    {
         return new AppPersistContext(
             manifest: static::createStub(Manifest::class),
-            app: $app,
+            app: $this->buildApp(),
             context: Context::createDefaultContext(),
             appFilesystem: static::createStub(Filesystem::class),
             defaultLocale: 'en-GB',

--- a/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandlerTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Handler/ContentSystemLayoutPresetLifecycleHandlerTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Handler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Handler\ContentSystemLayoutPresetLifecycleHandler;
+use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ContentSystemLayoutPresetLifecycleHandler::class)]
+class ContentSystemLayoutPresetLifecycleHandlerTest extends TestCase
+{
+    #[TestDox('install persists the app presets')]
+    public function testInstallPersists(): void
+    {
+        $context = $this->buildPersistContext();
+
+        $persister = $this->createMock(ContentSystemLayoutPresetPersister::class);
+        $persister->expects($this->once())->method('persist')->with($context);
+
+        (new ContentSystemLayoutPresetLifecycleHandler($persister))->install($context);
+    }
+
+    #[TestDox('update persists the app presets')]
+    public function testUpdatePersists(): void
+    {
+        $context = $this->buildPersistContext();
+
+        $persister = $this->createMock(ContentSystemLayoutPresetPersister::class);
+        $persister->expects($this->once())->method('persist')->with($context);
+
+        (new ContentSystemLayoutPresetLifecycleHandler($persister))->update($context);
+    }
+
+    #[TestDox('propagates a persister failure on install rather than swallowing it')]
+    public function testInstallPropagatesPersisterException(): void
+    {
+        $persister = static::createStub(ContentSystemLayoutPresetPersister::class);
+        $persister->method('persist')->willThrowException(new \RuntimeException('persist failed'));
+
+        $this->expectExceptionObject(new \RuntimeException('persist failed'));
+
+        (new ContentSystemLayoutPresetLifecycleHandler($persister))->install($this->buildPersistContext());
+    }
+
+    private function buildPersistContext(): AppPersistContext
+    {
+        $app = new AppEntity();
+        $app->setId('app-id');
+        $app->setName('DemoApp');
+
+        return new AppPersistContext(
+            manifest: static::createStub(Manifest::class),
+            app: $app,
+            context: Context::createDefaultContext(),
+            appFilesystem: static::createStub(Filesystem::class),
+            defaultLocale: 'en-GB',
+        );
+    }
+}

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -28,6 +29,9 @@ use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 /**
  * @internal
@@ -185,6 +189,87 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         static::assertSame([], $repo->deletes);
     }
 
+    #[TestDox('holds the per-app lock from the existing-state read through cache invalidation')]
+    public function testHoldsLockAroundReconciliationAndInvalidation(): void
+    {
+        $lockHeld = false;
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturnCallback(
+            static function () use (&$lockHeld): bool {
+                $lockHeld = true;
+
+                return true;
+            }
+        );
+        $lock->expects($this->once())->method('release')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+                $lockHeld = false;
+            }
+        );
+
+        $lockFactory = static::createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('content_system_layout_preset_persist_' . $this->ids->get('app'), 15.0)
+            ->willReturn($lock);
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            static function (Criteria $criteria, Context $context) use (&$lockHeld): AppContentSystemLayoutPresetCollection {
+                static::assertTrue($lockHeld);
+
+                return new AppContentSystemLayoutPresetCollection();
+            },
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->once())->method('invalidate')->willReturnCallback(
+            static function () use (&$lockHeld): void {
+                static::assertTrue($lockHeld);
+            }
+        );
+
+        $this->buildPersister($repo, $this->dtoLoader(['DemoApp:Hero' => $this->dto('Hero')]), $registry, lockFactory: $lockFactory)
+            ->persist($this->buildContext());
+
+        static::assertFalse($lockHeld);
+    }
+
+    #[TestDox('releases the lock and leaves the cache untouched when the transaction fails')]
+    public function testReleasesLockWhenTransactionFails(): void
+    {
+        $failure = new \RuntimeException('transaction failed');
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willThrowException($failure);
+
+        $lock = static::createMock(SharedLockInterface::class);
+        $lock->expects($this->once())->method('acquire')->with(true)->willReturn(true);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection(),
+        ]);
+
+        $this->expectExceptionObject($failure);
+        $this->buildPersister(
+            $repo,
+            $this->dtoLoader(['DemoApp:Hero' => $this->dto('Hero')]),
+            $registry,
+            connection: $connection,
+            lockFactory: $lockFactory,
+        )->persist($this->buildContext());
+    }
+
     #[TestDox('wraps a loader ContentSystemException as an AppException')]
     public function testThrowsAppExceptionWhenLoaderFails(): void
     {
@@ -229,6 +314,8 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
             $loader,
             new LayoutPresetSpecificationSerializer(),
             static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
+            $this->runTransactionStub(),
+            new LockFactory(new InMemoryStore()),
         );
 
         try {
@@ -290,13 +377,29 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         StaticEntityRepository $repo,
         YamlLayoutPresetLoader $loader,
         ?AbstractContentSystemLayoutPresetRegistry $registry = null,
+        ?Connection $connection = null,
+        ?LockFactory $lockFactory = null,
     ): ContentSystemLayoutPresetPersister {
         return new ContentSystemLayoutPresetPersister(
             $repo,
             $loader,
             new LayoutPresetSpecificationSerializer(),
             $registry ?? static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
+            $connection ?? $this->runTransactionStub(),
+            $lockFactory ?? new LockFactory(new InMemoryStore()),
         );
+    }
+
+    private function runTransactionStub(): Connection
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willReturnCallback(static function (\Closure $work) {
+            $work();
+
+            return null;
+        });
+
+        return $connection;
     }
 
     private function buildContext(): AppPersistContext

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSpecificationSerializer;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\Dto\LayoutPresetSpecificationDto;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -41,10 +43,10 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $this->ids = new IdsCollection();
     }
 
-    #[TestDox('inserts a new preset with the raw authoring data as schema')]
+    #[TestDox('inserts a new preset with the normalized authoring data as schema')]
     public function testInsertsNewPresetWhenNoneExist(): void
     {
-        $raw = ['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]];
+        $dto = $this->dto('Hero');
 
         /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
         $repo = new StaticEntityRepository([
@@ -58,14 +60,14 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
             },
         ]);
 
-        $persister = $this->buildPersister($repo, $this->rawLoader($raw));
+        $persister = $this->buildPersister($repo, $this->dtoLoader(['DemoApp:Hero' => $dto]));
         $persister->persist($this->buildContext());
 
         static::assertCount(1, $repo->upserts);
         $payload = $repo->upserts[0][0];
 
         static::assertSame('DemoApp:Hero', $payload['name']);
-        static::assertSame(['name' => 'Hero', 'layout' => []], $payload['schema']);
+        static::assertSame($this->normalize($dto), $payload['schema']);
         static::assertSame($this->ids->get('app'), $payload['appId']);
         static::assertIsString($payload['id']);
         static::assertIsString($payload['hash']);
@@ -82,7 +84,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
             new AppContentSystemLayoutPresetCollection([$existing]),
         ]);
 
-        $persister = $this->buildPersister($repo, $this->rawLoader(['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]]));
+        $persister = $this->buildPersister($repo, $this->dtoLoader(['DemoApp:Hero' => $this->dto('Hero')]));
         $persister->persist($this->buildContext());
 
         static::assertCount(1, $repo->upserts);
@@ -96,17 +98,16 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
     #[TestDox('skips the upsert when the stored hash matches the current data')]
     public function testSkipsUpsertWhenHashMatches(): void
     {
-        $data = ['name' => 'Hero', 'layout' => []];
-        $hash = Hasher::hash(json_encode($data, \JSON_THROW_ON_ERROR));
+        $dto = $this->dto('Hero');
 
-        $existing = $this->existingEntity('preset-hero', 'DemoApp:Hero', $hash);
+        $existing = $this->existingEntity('preset-hero', 'DemoApp:Hero', $this->hashOf($dto));
 
         /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
         $repo = new StaticEntityRepository([
             new AppContentSystemLayoutPresetCollection([$existing]),
         ]);
 
-        $persister = $this->buildPersister($repo, $this->rawLoader(['DemoApp:Hero' => $data]));
+        $persister = $this->buildPersister($repo, $this->dtoLoader(['DemoApp:Hero' => $dto]));
         $persister->persist($this->buildContext());
 
         static::assertSame([], $repo->upserts);
@@ -126,7 +127,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
         $registry->expects($this->once())->method('invalidate');
 
-        $persister = $this->buildPersister($repo, $this->rawLoader([]), $registry);
+        $persister = $this->buildPersister($repo, $this->dtoLoader([]), $registry);
         $persister->persist($this->buildContext());
 
         static::assertSame([], $repo->upserts);
@@ -137,10 +138,9 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
     #[TestDox('upserts only the changed preset when multiple exist and one hash matches')]
     public function testUpsertsOnlyChangedPresetWhenMultipleExist(): void
     {
-        $unchanged = ['name' => 'Hero', 'layout' => []];
-        $matchingHash = Hasher::hash(json_encode($unchanged, \JSON_THROW_ON_ERROR));
+        $unchanged = $this->dto('Hero');
 
-        $existingHero = $this->existingEntity('preset-hero', 'DemoApp:Hero', $matchingHash);
+        $existingHero = $this->existingEntity('preset-hero', 'DemoApp:Hero', $this->hashOf($unchanged));
         $existingBanner = $this->existingEntity('preset-banner', 'DemoApp:Banner', 'outdated-hash');
 
         /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
@@ -151,9 +151,9 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
         $registry->expects($this->once())->method('invalidate');
 
-        $loader = $this->rawLoader([
+        $loader = $this->dtoLoader([
             'DemoApp:Hero' => $unchanged,
-            'DemoApp:Banner' => ['name' => 'Banner', 'layout' => []],
+            'DemoApp:Banner' => $this->dto('Banner'),
         ]);
 
         $persister = $this->buildPersister($repo, $loader, $registry);
@@ -178,7 +178,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
         $registry->expects($this->never())->method('invalidate');
 
-        $persister = $this->buildPersister($repo, $this->rawLoader([]), $registry);
+        $persister = $this->buildPersister($repo, $this->dtoLoader([]), $registry);
         $persister->persist($this->buildContext());
 
         static::assertSame([], $repo->upserts);
@@ -191,7 +191,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $loaderException = ContentSystemException::layoutPresetLoadFailed('hero.yaml', 'Invalid YAML syntax');
 
         $loader = static::createStub(YamlLayoutPresetLoader::class);
-        $loader->method('readRawFromDirectory')->willThrowException($loaderException);
+        $loader->method('loadDtosFromDirectory')->willThrowException($loaderException);
 
         /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
         $repo = new StaticEntityRepository([]);
@@ -207,7 +207,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
     #[TestDox('wraps a UniqueConstraintViolationException as an AppException on concurrent id collision')]
     public function testWrapsUniqueConstraintViolationAsAppException(): void
     {
-        $loader = $this->rawLoader(['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]]);
+        $loader = $this->dtoLoader(['DemoApp:Hero' => $this->dto('Hero')]);
 
         $dbalException = static::createStub(UniqueConstraintViolationException::class);
 
@@ -227,6 +227,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         $persister = new ContentSystemLayoutPresetPersister(
             $repo,
             $loader,
+            new LayoutPresetSpecificationSerializer(),
             static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
         );
 
@@ -239,6 +240,24 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
             static::assertStringContainsString('app:DemoApp', $e->getMessage());
             static::assertSame($dbalException, $e->getPrevious());
         }
+    }
+
+    private function dto(string $name): LayoutPresetSpecificationDto
+    {
+        return new LayoutPresetSpecificationDto($name, 'A preset.', 'regular-star', []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalize(LayoutPresetSpecificationDto $dto): array
+    {
+        return (new LayoutPresetSpecificationSerializer())->normalize($dto);
+    }
+
+    private function hashOf(LayoutPresetSpecificationDto $dto): string
+    {
+        return Hasher::hash(json_encode($this->normalize($dto), \JSON_THROW_ON_ERROR));
     }
 
     private function existingEntity(string $idKey, string $name, string $hash): AppContentSystemLayoutPresetEntity
@@ -254,12 +273,12 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, mixed>> $raw
+     * @param array<string, LayoutPresetSpecificationDto> $dtos
      */
-    private function rawLoader(array $raw): YamlLayoutPresetLoader
+    private function dtoLoader(array $dtos): YamlLayoutPresetLoader
     {
         $loader = static::createStub(YamlLayoutPresetLoader::class);
-        $loader->method('readRawFromDirectory')->willReturn($raw);
+        $loader->method('loadDtosFromDirectory')->willReturn($dtos);
 
         return $loader;
     }
@@ -275,6 +294,7 @@ class ContentSystemLayoutPresetPersisterTest extends TestCase
         return new ContentSystemLayoutPresetPersister(
             $repo,
             $loader,
+            new LayoutPresetSpecificationSerializer(),
             $registry ?? static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
         );
     }

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ContentSystemLayoutPresetPersisterTest.php
@@ -1,0 +1,296 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetCollection;
+use Shopware\Core\Framework\App\Aggregate\AppContentSystemLayoutPreset\AppContentSystemLayoutPresetEntity;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\App\Lifecycle\Persister\ContentSystemLayoutPresetPersister;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Registry\AbstractContentSystemLayoutPresetRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Filesystem;
+use Shopware\Core\Framework\Util\Hasher;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ContentSystemLayoutPresetPersister::class)]
+class ContentSystemLayoutPresetPersisterTest extends TestCase
+{
+    private IdsCollection $ids;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+    }
+
+    #[TestDox('inserts a new preset with the raw authoring data as schema')]
+    public function testInsertsNewPresetWhenNoneExist(): void
+    {
+        $raw = ['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]];
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            static function (Criteria $criteria, Context $context): AppContentSystemLayoutPresetCollection {
+                static::assertCount(1, $criteria->getFilters());
+                $filter = $criteria->getFilters()[0];
+                static::assertInstanceOf(EqualsFilter::class, $filter);
+                static::assertSame('appId', $filter->getField());
+
+                return new AppContentSystemLayoutPresetCollection();
+            },
+        ]);
+
+        $persister = $this->buildPersister($repo, $this->rawLoader($raw));
+        $persister->persist($this->buildContext());
+
+        static::assertCount(1, $repo->upserts);
+        $payload = $repo->upserts[0][0];
+
+        static::assertSame('DemoApp:Hero', $payload['name']);
+        static::assertSame(['name' => 'Hero', 'layout' => []], $payload['schema']);
+        static::assertSame($this->ids->get('app'), $payload['appId']);
+        static::assertIsString($payload['id']);
+        static::assertIsString($payload['hash']);
+        static::assertSame([], $repo->deletes);
+    }
+
+    #[TestDox('updates an existing preset when its hash changes, reusing the row id')]
+    public function testUpdatesExistingPresetWhenHashChanges(): void
+    {
+        $existing = $this->existingEntity('preset-hero', 'DemoApp:Hero', 'outdated-hash');
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection([$existing]),
+        ]);
+
+        $persister = $this->buildPersister($repo, $this->rawLoader(['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]]));
+        $persister->persist($this->buildContext());
+
+        static::assertCount(1, $repo->upserts);
+        $payload = $repo->upserts[0][0];
+
+        static::assertSame($this->ids->get('preset-hero'), $payload['id']);
+        static::assertSame('DemoApp:Hero', $payload['name']);
+        static::assertNotSame('outdated-hash', $payload['hash']);
+    }
+
+    #[TestDox('skips the upsert when the stored hash matches the current data')]
+    public function testSkipsUpsertWhenHashMatches(): void
+    {
+        $data = ['name' => 'Hero', 'layout' => []];
+        $hash = Hasher::hash(json_encode($data, \JSON_THROW_ON_ERROR));
+
+        $existing = $this->existingEntity('preset-hero', 'DemoApp:Hero', $hash);
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection([$existing]),
+        ]);
+
+        $persister = $this->buildPersister($repo, $this->rawLoader(['DemoApp:Hero' => $data]));
+        $persister->persist($this->buildContext());
+
+        static::assertSame([], $repo->upserts);
+        static::assertSame([], $repo->deletes);
+    }
+
+    #[TestDox('deletes stored presets that are no longer shipped by the app, and invalidates the registry')]
+    public function testDeletesPresetsNotPresentInFiles(): void
+    {
+        $obsolete = $this->existingEntity('preset-old', 'DemoApp:Old', 'hash');
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection([$obsolete]),
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->once())->method('invalidate');
+
+        $persister = $this->buildPersister($repo, $this->rawLoader([]), $registry);
+        $persister->persist($this->buildContext());
+
+        static::assertSame([], $repo->upserts);
+        static::assertCount(1, $repo->deletes);
+        static::assertSame([['id' => $this->ids->get('preset-old')]], $repo->deletes[0]);
+    }
+
+    #[TestDox('upserts only the changed preset when multiple exist and one hash matches')]
+    public function testUpsertsOnlyChangedPresetWhenMultipleExist(): void
+    {
+        $unchanged = ['name' => 'Hero', 'layout' => []];
+        $matchingHash = Hasher::hash(json_encode($unchanged, \JSON_THROW_ON_ERROR));
+
+        $existingHero = $this->existingEntity('preset-hero', 'DemoApp:Hero', $matchingHash);
+        $existingBanner = $this->existingEntity('preset-banner', 'DemoApp:Banner', 'outdated-hash');
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection([$existingHero, $existingBanner]),
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->once())->method('invalidate');
+
+        $loader = $this->rawLoader([
+            'DemoApp:Hero' => $unchanged,
+            'DemoApp:Banner' => ['name' => 'Banner', 'layout' => []],
+        ]);
+
+        $persister = $this->buildPersister($repo, $loader, $registry);
+        $persister->persist($this->buildContext());
+
+        static::assertCount(1, $repo->upserts);
+        $payload = $repo->upserts[0][0];
+
+        static::assertSame($this->ids->get('preset-banner'), $payload['id']);
+        static::assertSame('DemoApp:Banner', $payload['name']);
+        static::assertSame([], $repo->deletes);
+    }
+
+    #[TestDox('returns early without touching the repository when the app ships and stores no presets')]
+    public function testEarlyReturnWhenBothEmpty(): void
+    {
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([
+            new AppContentSystemLayoutPresetCollection(),
+        ]);
+
+        $registry = static::createMock(AbstractContentSystemLayoutPresetRegistry::class);
+        $registry->expects($this->never())->method('invalidate');
+
+        $persister = $this->buildPersister($repo, $this->rawLoader([]), $registry);
+        $persister->persist($this->buildContext());
+
+        static::assertSame([], $repo->upserts);
+        static::assertSame([], $repo->deletes);
+    }
+
+    #[TestDox('wraps a loader ContentSystemException as an AppException')]
+    public function testThrowsAppExceptionWhenLoaderFails(): void
+    {
+        $loaderException = ContentSystemException::layoutPresetLoadFailed('hero.yaml', 'Invalid YAML syntax');
+
+        $loader = static::createStub(YamlLayoutPresetLoader::class);
+        $loader->method('readRawFromDirectory')->willThrowException($loaderException);
+
+        /** @var StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo */
+        $repo = new StaticEntityRepository([]);
+
+        $persister = $this->buildPersister($repo, $loader);
+
+        $this->expectExceptionObject(
+            AppException::contentSystemLayoutPresetLoadFailed('Resources/content-system/presets', $loaderException->getMessage(), $loaderException)
+        );
+        $persister->persist($this->buildContext());
+    }
+
+    #[TestDox('wraps a UniqueConstraintViolationException as an AppException on concurrent id collision')]
+    public function testWrapsUniqueConstraintViolationAsAppException(): void
+    {
+        $loader = $this->rawLoader(['DemoApp:Hero' => ['name' => 'Hero', 'layout' => []]]);
+
+        $dbalException = static::createStub(UniqueConstraintViolationException::class);
+
+        $emptyResult = new EntitySearchResult(
+            'app_content_system_layout_preset',
+            0,
+            new AppContentSystemLayoutPresetCollection(),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $repo = static::createStub(EntityRepository::class);
+        $repo->method('search')->willReturn($emptyResult);
+        $repo->method('upsert')->willThrowException($dbalException);
+
+        $persister = new ContentSystemLayoutPresetPersister(
+            $repo,
+            $loader,
+            static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
+        );
+
+        try {
+            $persister->persist($this->buildContext());
+            static::fail('Expected AppException was not thrown');
+        } catch (AppException $e) {
+            static::assertSame(AppException::CONTENT_SYSTEM_LAYOUT_PRESET_DUPLICATE, $e->getErrorCode());
+            static::assertStringContainsString('DemoApp:Hero', $e->getMessage());
+            static::assertStringContainsString('app:DemoApp', $e->getMessage());
+            static::assertSame($dbalException, $e->getPrevious());
+        }
+    }
+
+    private function existingEntity(string $idKey, string $name, string $hash): AppContentSystemLayoutPresetEntity
+    {
+        $entity = new AppContentSystemLayoutPresetEntity();
+        $entity->setId($this->ids->create($idKey));
+        $entity->setName($name);
+        $entity->setSchema([]);
+        $entity->setHash($hash);
+        $entity->setAppId($this->ids->get('app'));
+
+        return $entity;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $raw
+     */
+    private function rawLoader(array $raw): YamlLayoutPresetLoader
+    {
+        $loader = static::createStub(YamlLayoutPresetLoader::class);
+        $loader->method('readRawFromDirectory')->willReturn($raw);
+
+        return $loader;
+    }
+
+    /**
+     * @param StaticEntityRepository<AppContentSystemLayoutPresetCollection> $repo
+     */
+    private function buildPersister(
+        StaticEntityRepository $repo,
+        YamlLayoutPresetLoader $loader,
+        ?AbstractContentSystemLayoutPresetRegistry $registry = null,
+    ): ContentSystemLayoutPresetPersister {
+        return new ContentSystemLayoutPresetPersister(
+            $repo,
+            $loader,
+            $registry ?? static::createStub(AbstractContentSystemLayoutPresetRegistry::class),
+        );
+    }
+
+    private function buildContext(): AppPersistContext
+    {
+        $app = new AppEntity();
+        $app->setId($this->ids->get('app'));
+        $app->setName('DemoApp');
+
+        return new AppPersistContext(
+            manifest: static::createStub(Manifest::class),
+            app: $app,
+            context: Context::createDefaultContext(),
+            appFilesystem: new Filesystem(sys_get_temp_dir()),
+            defaultLocale: 'en-GB',
+        );
+    }
+}

--- a/tests/unit/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidatorTest.php
+++ b/tests/unit/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidatorTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Manifest\Xml\Meta\Metadata;
+use Shopware\Core\Framework\App\Validation\ContentSystemLayoutPresetAppValidator;
+use Shopware\Core\Framework\App\Validation\Error\ContentSystemLayoutPresetSchemaError;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\YamlLayoutPresetLoader;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ContentSystemLayoutPresetAppValidator::class)]
+class ContentSystemLayoutPresetAppValidatorTest extends TestCase
+{
+    #[TestDox('returns no errors when the presets directory is valid')]
+    public function testReturnsNoErrorsWhenPresetsDirectoryIsValid(): void
+    {
+        $loader = static::createStub(YamlLayoutPresetLoader::class);
+
+        $manifest = $this->buildManifest('/app/path', 'TestApp');
+
+        $validator = new ContentSystemLayoutPresetAppValidator($loader);
+        $errors = $validator->validate($manifest, Context::createDefaultContext());
+
+        static::assertCount(0, $errors->getElements());
+    }
+
+    #[TestDox('returns a schema error when the presets directory contains invalid definitions')]
+    public function testReturnsSchemaErrorWhenPresetsDirectoryIsInvalid(): void
+    {
+        $loader = static::createStub(YamlLayoutPresetLoader::class);
+        $loader->method('readRawFromDirectory')
+            ->willThrowException(ContentSystemException::layoutPresetLoadFailed('broken.yaml', 'Invalid YAML syntax'));
+
+        $manifest = $this->buildManifest('/app/path', 'TestApp');
+
+        $validator = new ContentSystemLayoutPresetAppValidator($loader);
+        $errors = $validator->validate($manifest, Context::createDefaultContext());
+
+        static::assertCount(1, $errors->getElements());
+
+        $error = $errors->first();
+        static::assertInstanceOf(ContentSystemLayoutPresetSchemaError::class, $error);
+        static::assertSame(
+            'Invalid layout preset in "/app/path/Resources/content-system/presets": Failed to load layout preset from "broken.yaml": Invalid YAML syntax',
+            $error->getMessage()
+        );
+        static::assertSame('manifest-invalid-layout-preset-schema', $error->getMessageKey());
+    }
+
+    #[TestDox('propagates non-content-system exceptions without catching')]
+    public function testPropagatesNonContentSystemExceptions(): void
+    {
+        $loader = static::createStub(YamlLayoutPresetLoader::class);
+        $loader->method('readRawFromDirectory')
+            ->willThrowException(new \RuntimeException('Unexpected filesystem error'));
+
+        $manifest = $this->buildManifest('/app/path', 'TestApp');
+
+        $validator = new ContentSystemLayoutPresetAppValidator($loader);
+
+        $this->expectExceptionObject(new \RuntimeException('Unexpected filesystem error'));
+        $validator->validate($manifest, Context::createDefaultContext());
+    }
+
+    private function buildManifest(string $path, string $appName): Manifest
+    {
+        $metadata = static::createStub(Metadata::class);
+        $metadata->method('getName')->willReturn($appName);
+
+        $manifest = static::createStub(Manifest::class);
+        $manifest->method('getPath')->willReturn($path);
+        $manifest->method('getMetadata')->willReturn($metadata);
+
+        return $manifest;
+    }
+}

--- a/tests/unit/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidatorTest.php
+++ b/tests/unit/Core/Framework/App/Validation/ContentSystemLayoutPresetAppValidatorTest.php
@@ -38,7 +38,7 @@ class ContentSystemLayoutPresetAppValidatorTest extends TestCase
     public function testReturnsSchemaErrorWhenPresetsDirectoryIsInvalid(): void
     {
         $loader = static::createStub(YamlLayoutPresetLoader::class);
-        $loader->method('readRawFromDirectory')
+        $loader->method('loadDtosFromDirectory')
             ->willThrowException(ContentSystemException::layoutPresetLoadFailed('broken.yaml', 'Invalid YAML syntax'));
 
         $manifest = $this->buildManifest('/app/path', 'TestApp');
@@ -61,7 +61,7 @@ class ContentSystemLayoutPresetAppValidatorTest extends TestCase
     public function testPropagatesNonContentSystemExceptions(): void
     {
         $loader = static::createStub(YamlLayoutPresetLoader::class);
-        $loader->method('readRawFromDirectory')
+        $loader->method('loadDtosFromDirectory')
             ->willThrowException(new \RuntimeException('Unexpected filesystem error'));
 
         $manifest = $this->buildManifest('/app/path', 'TestApp');

--- a/tests/unit/Core/Framework/App/Validation/Error/ContentSystemLayoutPresetSchemaErrorTest.php
+++ b/tests/unit/Core/Framework/App/Validation/Error/ContentSystemLayoutPresetSchemaErrorTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Validation\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Validation\Error\ContentSystemLayoutPresetSchemaError;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ContentSystemLayoutPresetSchemaError::class)]
+class ContentSystemLayoutPresetSchemaErrorTest extends TestCase
+{
+    #[TestDox('formats message with filename and reason')]
+    public function testFormatsMessageWithFilenameAndReason(): void
+    {
+        $error = new ContentSystemLayoutPresetSchemaError('/path/to/presets', 'YAML syntax invalid');
+
+        static::assertSame('Invalid layout preset in "/path/to/presets": YAML syntax invalid', $error->getMessage());
+    }
+
+    #[TestDox('returns correct message key')]
+    public function testReturnsCorrectMessageKey(): void
+    {
+        $error = new ContentSystemLayoutPresetSchemaError('file.yaml', 'reason');
+
+        static::assertSame('manifest-invalid-layout-preset-schema', $error->getMessageKey());
+    }
+}

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoaderTest.php
@@ -7,11 +7,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\LayoutPresetPayloadCompiler;
 use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\DatabaseLayoutPresetLoader;
-use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSerializer;
-use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\ContentSystemLayoutPresetSpecification;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSpecificationSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
@@ -26,34 +27,22 @@ class DatabaseLayoutPresetLoaderTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->never())->method('fetchAllAssociative');
 
-        $loader = new DatabaseLayoutPresetLoader(
-            static::createStub(LayoutPresetSerializer::class),
-            $connection,
-            'dev',
-            static::createStub(LoggerInterface::class),
-        );
-
-        static::assertSame([], $loader->load());
+        static::assertSame([], $this->loader($connection, 'dev', static::createStub(LoggerInterface::class))->load());
     }
 
-    #[TestDox('denormalizes each active-app row in prod')]
-    public function testProdDenormalizesRows(): void
+    #[TestDox('builds a compiled specification from each active-app row in prod')]
+    public function testProdBuildsSpecsFromRows(): void
     {
         $connection = static::createStub(Connection::class);
         $connection->method('fetchAllAssociative')->willReturn([
-            ['name' => 'MyApp:Hero', 'schema' => '{"name":"Hero","layout":[]}', 'app_name' => 'MyApp'],
+            ['name' => 'MyApp:Hero', 'schema' => '{"name":"Hero","description":"A hero.","icon":"regular-star","layout":[]}', 'app_name' => 'MyApp'],
         ]);
 
-        $serializer = static::createStub(LayoutPresetSerializer::class);
-        $serializer->method('denormalize')->willReturnCallback(
-            static fn (array $data, string $id): ContentSystemLayoutPresetSpecification => new ContentSystemLayoutPresetSpecification($id, 'Hero', null, null, [])
-        );
+        $presets = $this->loader($connection, 'prod', static::createStub(LoggerInterface::class))->load();
 
-        $loader = new DatabaseLayoutPresetLoader($serializer, $connection, 'prod', static::createStub(LoggerInterface::class));
-
-        $presets = $loader->load();
         static::assertCount(1, $presets);
         static::assertSame('MyApp:Hero', $presets[0]->id);
+        static::assertSame('Hero', $presets[0]->name);
     }
 
     #[TestDox('skips and logs a row whose stored data is not valid JSON')]
@@ -67,36 +56,41 @@ class DatabaseLayoutPresetLoaderTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('warning');
 
-        $loader = new DatabaseLayoutPresetLoader(static::createStub(LayoutPresetSerializer::class), $connection, 'prod', $logger);
-
-        static::assertSame([], $loader->load());
+        static::assertSame([], $this->loader($connection, 'prod', $logger)->load());
     }
 
-    #[TestDox('skips and logs a row the serializer rejects, keeping the rest')]
-    public function testSkipsUndeserializableRow(): void
+    #[TestDox('skips and logs a row that fails validation, keeping the rest')]
+    public function testSkipsInvalidRow(): void
     {
         $connection = static::createStub(Connection::class);
         $connection->method('fetchAllAssociative')->willReturn([
-            ['name' => 'MyApp:Bad', 'schema' => '{}', 'app_name' => 'MyApp'],
-            ['name' => 'MyApp:Good', 'schema' => '{"name":"Good","layout":[]}', 'app_name' => 'MyApp'],
+            ['name' => 'MyApp:Bad', 'schema' => '{"layout":[]}', 'app_name' => 'MyApp'],
+            ['name' => 'MyApp:Good', 'schema' => '{"name":"Good","description":"Good preset.","icon":"regular-star","layout":[]}', 'app_name' => 'MyApp'],
         ]);
-
-        $serializer = static::createStub(LayoutPresetSerializer::class);
-        $serializer->method('denormalize')->willReturnCallback(static function (array $data, string $id): ContentSystemLayoutPresetSpecification {
-            if ($id === 'MyApp:Bad') {
-                throw ContentSystemException::layoutPresetInvalid('missing name');
-            }
-
-            return new ContentSystemLayoutPresetSpecification($id, 'Good', null, null, []);
-        });
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('warning');
 
-        $loader = new DatabaseLayoutPresetLoader($serializer, $connection, 'prod', $logger);
+        $presets = $this->loader($connection, 'prod', $logger)->load();
 
-        $presets = $loader->load();
         static::assertCount(1, $presets);
         static::assertSame('MyApp:Good', $presets[0]->id);
+    }
+
+    private function loader(Connection $connection, string $environment, LoggerInterface $logger): DatabaseLayoutPresetLoader
+    {
+        return new DatabaseLayoutPresetLoader(
+            new LayoutPresetSpecificationSerializer(),
+            static::createStub(LayoutPresetPayloadCompiler::class),
+            $this->validator(),
+            $connection,
+            $environment,
+            $logger,
+        );
+    }
+
+    private function validator(): ValidatorInterface
+    {
+        return Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Preset/Loader/DatabaseLayoutPresetLoaderTest.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\ContentSystem\Layout\Preset\Loader;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Loader\DatabaseLayoutPresetLoader;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Serialization\LayoutPresetSerializer;
+use Shopware\Core\Framework\ContentSystem\Layout\Preset\Specification\ContentSystemLayoutPresetSpecification;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DatabaseLayoutPresetLoader::class)]
+class DatabaseLayoutPresetLoaderTest extends TestCase
+{
+    #[TestDox('returns nothing in dev, where app presets come from the filesystem')]
+    public function testDevReturnsEmpty(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchAllAssociative');
+
+        $loader = new DatabaseLayoutPresetLoader(
+            static::createStub(LayoutPresetSerializer::class),
+            $connection,
+            'dev',
+            static::createStub(LoggerInterface::class),
+        );
+
+        static::assertSame([], $loader->load());
+    }
+
+    #[TestDox('denormalizes each active-app row in prod')]
+    public function testProdDenormalizesRows(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['name' => 'MyApp:Hero', 'schema' => '{"name":"Hero","layout":[]}', 'app_name' => 'MyApp'],
+        ]);
+
+        $serializer = static::createStub(LayoutPresetSerializer::class);
+        $serializer->method('denormalize')->willReturnCallback(
+            static fn (array $data, string $id): ContentSystemLayoutPresetSpecification => new ContentSystemLayoutPresetSpecification($id, 'Hero', null, null, [])
+        );
+
+        $loader = new DatabaseLayoutPresetLoader($serializer, $connection, 'prod', static::createStub(LoggerInterface::class));
+
+        $presets = $loader->load();
+        static::assertCount(1, $presets);
+        static::assertSame('MyApp:Hero', $presets[0]->id);
+    }
+
+    #[TestDox('skips and logs a row whose stored data is not valid JSON')]
+    public function testSkipsInvalidJson(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['name' => 'MyApp:Broken', 'schema' => '{ not json', 'app_name' => 'MyApp'],
+        ]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $loader = new DatabaseLayoutPresetLoader(static::createStub(LayoutPresetSerializer::class), $connection, 'prod', $logger);
+
+        static::assertSame([], $loader->load());
+    }
+
+    #[TestDox('skips and logs a row the serializer rejects, keeping the rest')]
+    public function testSkipsUndeserializableRow(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['name' => 'MyApp:Bad', 'schema' => '{}', 'app_name' => 'MyApp'],
+            ['name' => 'MyApp:Good', 'schema' => '{"name":"Good","layout":[]}', 'app_name' => 'MyApp'],
+        ]);
+
+        $serializer = static::createStub(LayoutPresetSerializer::class);
+        $serializer->method('denormalize')->willReturnCallback(static function (array $data, string $id): ContentSystemLayoutPresetSpecification {
+            if ($id === 'MyApp:Bad') {
+                throw ContentSystemException::layoutPresetInvalid('missing name');
+            }
+
+            return new ContentSystemLayoutPresetSpecification($id, 'Good', null, null, []);
+        });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $loader = new DatabaseLayoutPresetLoader($serializer, $connection, 'prod', $logger);
+
+        $presets = $loader->load();
+        static::assertCount(1, $presets);
+        static::assertSame('MyApp:Good', $presets[0]->id);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The base layout-preset system only loaded presets from the filesystem, so apps and plugins couldn't ship their own presets to the experience-studio page builder.

  ### 2. What does this change do, exactly?

  Adds app/plugin persistence for layout presets on top of the file-based system:

  - New `app_content_system_layout_preset` table (migration) with `AppContentSystemLayoutPreset` DAL definition/entity/collection.
  - App lifecycle: `ContentSystemLayoutPresetPersister` diff-upserts an app's presets on install/update, `ContentSystemLayoutPresetLifecycleHandler` wires it in, and `ContentSystemLayoutPresetAppValidator` validates them at manifest time (`ContentSystemLayoutPresetSchemaError`).
  - `DatabaseLayoutPresetLoader` loads active apps' presets in prod (empty in dev, where they come from the filesystem), mirroring the element-type/binding/style loaders.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Ship an app with a `*.yaml` preset under its content-system presets directory.
  2. Install/activate the app — its presets are persisted to `app_content_system_layout_preset`.
  3. Boot the kernel in prod — `DatabaseLayoutPresetLoader` surfaces them in the registry alongside core presets.

  ### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/shopware/issues/9349

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  - [x] I have written or adjusted the documentation and agent skills according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them