### PR TITLE
fix(content-system): let ContentPreviewPayloadStore take the container's validator

### DIFF
--- a/src/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStore.php
+++ b/src/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStore.php
@@ -6,7 +6,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
-use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -26,15 +25,10 @@ class ContentPreviewPayloadStore
 {
     private const CACHE_PREFIX = 'content-system.preview.';
 
-    private readonly ValidatorInterface $validator;
-
-    /**
-     * @internal
-     */
     public function __construct(
         private readonly CacheItemPoolInterface $cache,
+        private readonly ValidatorInterface $validator,
     ) {
-        $this->validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
     }
 
     public function store(ContentPreviewRequest $payload): string
@@ -151,7 +145,10 @@ class ContentPreviewPayloadStore
 
     /**
      * Runs {@see ContentPreviewRequest}'s own constraint attributes against the rebuilt DTO, so the stored
-     * envelope is admitted on exactly the terms `#[MapRequestPayload]` admitted it at the HTTP boundary.
+     * envelope is admitted on exactly the terms `#[MapRequestPayload]` admitted it at the HTTP boundary. That
+     * equivalence is why the validator is injected rather than built here: a self-built one carries no
+     * configured constraint-validator factory, so a constraint whose validator has constructor dependencies
+     * would resolve at the boundary and fail on the read.
      */
     private function assertDeclaredConstraints(ContentPreviewRequest $request): void
     {

--- a/src/Core/Framework/DependencyInjection/content-system.php
+++ b/src/Core/Framework/DependencyInjection/content-system.php
@@ -718,6 +718,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ContentPreviewPayloadStore::class)
         ->args([
             service('cache.system'),
+            service('validator'),
         ]);
 
     // Preview Action (Admin API)

--- a/tests/integration/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStoreTest.php
+++ b/tests/integration/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStoreTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\ContentSystem\Api;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\ContentSystem\Api\ContentPreviewPayloadStore;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * The store validates a rebuilt envelope with the validator it is handed, and the unit tests hand it one they
+ * build themselves — so they establish that a validator runs, never that the wired one enforces anything. The
+ * read path depends on the container's validator finding constraints the DTO declares as attributes, which
+ * holds only while `framework.validation.enable_attributes` is true. Flip that flag or wire a different
+ * validator and the read silently stops enforcing constraints, with every other test still green.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class ContentPreviewPayloadStoreTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    #[TestDox('the container-wired validator enforces the constraints the DTO declares')]
+    public function testLoadRejectsAConstraintViolationThroughTheContainerValidator(): void
+    {
+        $token = Uuid::randomHex();
+        $key = 'content-system.preview.' . $token;
+        $cache = static::getContainer()->get('cache.system');
+
+        // A structurally complete envelope — every field the DTO declares, each of the right PHP type — so the
+        // field and type gates pass and the blank entityType reaches the constraint check, the only gate the
+        // validator owns.
+        $item = $cache->getItem($key);
+        $item->set([
+            'layout' => [['id' => Uuid::randomHex(), 'component' => 'Sw:Content:Text']],
+            'entityType' => '',
+            'entityId' => Uuid::randomHex(),
+            'salesChannelId' => Uuid::randomHex(),
+            'languageId' => null,
+            'currencyId' => null,
+            'domainId' => null,
+            'customerId' => null,
+            'queryParameters' => [],
+        ]);
+        $cache->save($item);
+
+        try {
+            $this->expectExceptionObject(ContentSystemException::previewPayloadInvalid(
+                'entityType',
+                'accepted by the constraints ContentPreviewRequest declares',
+                'This value should not be blank.',
+            ));
+
+            static::getContainer()->get(ContentPreviewPayloadStore::class)->load($token);
+        } finally {
+            $cache->deleteItem($key);
+        }
+    }
+}

--- a/tests/unit/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStoreTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStoreTest.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\ContentSystem\Api\ContentPreviewRequest;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
@@ -22,7 +24,7 @@ class ContentPreviewPayloadStoreTest extends TestCase
     #[TestDox('returns the stored request unchanged for the token store minted')]
     public function testRoundTripsTheStoredRequest(): void
     {
-        $store = new ContentPreviewPayloadStore(new ArrayAdapter());
+        $store = new ContentPreviewPayloadStore(new ArrayAdapter(), self::validator());
         $payload = new ContentPreviewRequest(
             layout: [['id' => 'el-1', 'component' => 'Sw:Block']],
             entityType: 'product',
@@ -57,7 +59,7 @@ class ContentPreviewPayloadStoreTest extends TestCase
     #[TestDox('returns null for a token that addresses no entry')]
     public function testLoadReturnsNullForUnknownToken(): void
     {
-        $store = new ContentPreviewPayloadStore(new ArrayAdapter());
+        $store = new ContentPreviewPayloadStore(new ArrayAdapter(), self::validator());
 
         static::assertNull($store->load('no-such-token'));
     }
@@ -70,7 +72,7 @@ class ContentPreviewPayloadStoreTest extends TestCase
         $item->set('not-an-array');
         $cache->save($item);
 
-        $store = new ContentPreviewPayloadStore($cache);
+        $store = new ContentPreviewPayloadStore($cache, self::validator());
 
         $this->expectExceptionObject(ContentSystemException::previewPayloadInvalid('payload', 'array', 'string'));
 
@@ -176,6 +178,16 @@ class ContentPreviewPayloadStoreTest extends TestCase
     }
 
     /**
+     * The container's validator has attribute mapping enabled (`framework.validation.enable_attributes`), and
+     * the DTO declares its constraints as attributes, so a bare validator would find none and the
+     * constraint cases below would pass without validating anything.
+     */
+    private static function validator(): ValidatorInterface
+    {
+        return Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+    }
+
+    /**
      * @param array<string, mixed> $stored
      */
     private static function storeHolding(array $stored): ContentPreviewPayloadStore
@@ -185,7 +197,7 @@ class ContentPreviewPayloadStoreTest extends TestCase
         $item->set($stored);
         $cache->save($item);
 
-        return new ContentPreviewPayloadStore($cache);
+        return new ContentPreviewPayloadStore($cache, self::validator());
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

`Api/ContentPreviewPayloadStore` is a DI-registered service that built its own validator:

```php
$this->validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
```

A self-built validator carries no configured constraint-validator factory, so a constraint whose validator has constructor dependencies cannot be resolved. That matters here more than it would elsewhere, because the class exists to guarantee an equivalence — its own docblock states the stored envelope is admitted "on exactly the terms `#[MapRequestPayload]` admitted it at the HTTP boundary". That boundary validates with the container's validator. For any DI-dependent constraint the two would therefore disagree, and disagree in the worst direction: the write passes, and the read fails later against a token whose originating request is long gone.

Latent today: `ContentPreviewRequest` declares only `NotBlank`, `Type` and `Callback`, none of whose validators take constructor arguments. Nothing is broken at runtime; what is broken is that the guarantee cannot be kept if a constraint is ever added.

The same DI file already injects `service('validator')` into six other content-system services. This store was the only one building its own.

### 2. What does this change do, exactly?

`ValidatorInterface` becomes a constructor argument, wired as `service('validator')` in `src/Core/Framework/DependencyInjection/content-system.php`. The self-built validator and the now-unused `Validation` import go.

The docblock on `assertDeclaredConstraints()` records why the validator is injected rather than built, so the change is not undone as a simplification later.

The container's validator is equivalent for this DTO because `framework.validation.enable_attributes` is `true` (`src/Core/Framework/Resources/config/packages/framework.yaml:31`) and the DTO declares its constraints as attributes. The unit test supplies a validator with attribute mapping enabled for that reason and states it: with a bare `Validation::createValidator()`, four `NotBlank` cases silently stop being enforced and the constraint tests pass without validating anything. (`queryParameters integer-keyed` still fails correctly there, because `stringKeyedField()` rejects it before validation runs — as the DTO's own docblock describes.)

Also removed: the redundant `@internal` on the constructor of an already-`@internal` class, in the block being rewritten.

`tests/integration/Core/Framework/ContentSystem/Api/ContentPreviewPayloadStoreTest.php` covers the step nothing covered before: the unit tests hand the store a validator they build themselves, so they establish that a validator runs, never that the wired one enforces anything; the Storefront controller test proves the service resolves, and its malformed-envelope case is refused by the field gate before validation is reached. The new test drives the container-resolved store against a structurally complete envelope whose `entityType` is blank, so the constraint check — the only gate the validator owns — is what has to refuse it. Setting `enable_attributes` to `false` makes it fail and leaves the rest of the suite green.

It does **not** fail against the self-built validator this PR removes: that one enabled attribute mapping too, so the two agree on every constraint `ContentPreviewRequest` declares today. The removed defect is observable only through a constraint whose validator takes constructor dependencies, and adding one to production code to demonstrate it is not worth it — hence the unchecked test box below. What the test pins is the assumption the fix rests on, not the fix itself.

### 3. Describe each step to reproduce the issue or behaviour.

No runtime reproduction exists at present; the defect is that the stated equivalence cannot hold. To observe it, add a constraint to `ContentPreviewRequest` whose validator takes a constructor dependency:

1. `POST /api/_action/content-system/preview` — `#[MapRequestPayload]` validates with the container's validator, which resolves the constraint's validator through the configured factory. The token is minted.
2. `GET /content-system/preview/{token}` — `ContentPreviewPayloadStore::load()` validates the rebuilt DTO with its self-built validator, which cannot construct that validator, and the redemption fails.

After this change both paths use the same validator, so both resolve it.

### 4. Please link to the relevant issues (if any).

- relates #19954 (second checklist item)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

