### PR TITLE
fix(content-system): reject unknown fields at write boundary

### DIFF
--- a/src/Core/Framework/ContentSystem/Layout/Codec/StoredElementWiringDecoder.php
+++ b/src/Core/Framework/ContentSystem/Layout/Codec/StoredElementWiringDecoder.php
@@ -34,11 +34,10 @@ use Shopware\Core\Framework\Log\Package;
  * element-local violation is unreadable here rather than repaired.
  *
  * A consumer entry's key set is closed exactly as the codec closes the element and data-requirement sets. A
- * provider entry is the one map that does carry extra keys: the declared distribution strategy's own fields
- * ride alongside `type` and `distribution`, and the strategy's config object reads them. Those strategy
- * fields are, in turn, judged by the distribution config's own `fromArray()`, which substitutes its declared
- * default for a field that is absent or null but rejects a present one of the wrong type; this class neither
- * validates nor repeats that judgement itself.
+ * provider entry carries only `type`, `distribution`, and the selected distribution strategy's own fields.
+ * Its config object reads those fields through `fromArray()` and exposes the canonical key set through
+ * `toArray()`; decode rejects every authored key absent from that round-trip rather than silently dropping it.
+ * The write-side descriptor closes the same selected set independently from the config's constraints.
  *
  * The write-side counterpart is {@see StoredTreeWiringConstraints} and the render-side one is
  * {@see WiringPlanner}. The three stay independent implementations of the same rules; StoredTreeShapeConformanceTest
@@ -106,10 +105,17 @@ final class StoredElementWiringDecoder
                 );
             }
 
-            $providers[$key] = new ContextProvider(
-                $contextType,
-                $this->distributionConfig($strategy, $this->stringKeyed($config, $path))
+            $config = $this->stringKeyed($config, $path);
+            $distributionConfig = $this->distributionConfig($strategy, $config);
+
+            $this->rejectUnknownKeys(
+                $config,
+                ['type', ...array_keys($distributionConfig->toArray())],
+                $path,
+                'provider'
             );
+
+            $providers[$key] = new ContextProvider($contextType, $distributionConfig);
         }
 
         return $providers;
@@ -281,8 +287,8 @@ final class StoredElementWiringDecoder
 
     /**
      * A key set decode closes: a key outside it is a decode failure, so a field the shape does not carry is
-     * never silently dropped on the way to the stored model. The write-path descriptor closes the same set,
-     * so neither side admits what the other refuses.
+     * never silently dropped on the way to the stored model. The write-path descriptor independently closes
+     * the same selected-strategy set from its constraints, so neither side admits what the other refuses.
      *
      * @param array<array-key, mixed> $data
      * @param list<string> $known

--- a/src/Core/Framework/ContentSystem/Layout/Codec/StoredTreeWiringConstraints.php
+++ b/src/Core/Framework/ContentSystem/Layout/Codec/StoredTreeWiringConstraints.php
@@ -154,7 +154,9 @@ final class StoredTreeWiringConstraints
 
     /**
      * The fields a provider carries beyond `type` and `distribution` depend on the declared strategy, which the
-     * `Collection` above admits as extra fields; each strategy's own constraint set is applied here.
+     * `Collection` above admits as extra fields. This descriptor independently closes the selected strategy's
+     * key set from its constraints, while {@see StoredElementWiringDecoder} uses the config object's canonical
+     * `toArray()` shape.
      */
     private function validateDistributionFields(mixed $value, ExecutionContextInterface $context): void
     {
@@ -175,7 +177,20 @@ final class StoredTreeWiringConstraints
             return;
         }
 
-        foreach ($configClass::buildConstraints() as $fieldName => $fieldConstraints) {
+        $constraints = $configClass::buildConstraints();
+        $knownKeys = ['type', 'distribution', ...array_keys($constraints)];
+
+        foreach (array_keys($value) as $fieldName) {
+            if (!\is_string($fieldName) || \in_array($fieldName, $knownKeys, true)) {
+                continue;
+            }
+
+            $context->buildViolation('This field was not expected.')
+                ->atPath("[$fieldName]")
+                ->addViolation();
+        }
+
+        foreach ($constraints as $fieldName => $fieldConstraints) {
             $fieldValue = $value[$fieldName] ?? null;
 
             foreach ($fieldConstraints as $constraint) {

--- a/src/Core/Framework/ContentSystem/Layout/Element/Style/ElementStyleNormalizer.php
+++ b/src/Core/Framework/ContentSystem/Layout/Element/Style/ElementStyleNormalizer.php
@@ -116,12 +116,12 @@ final class ElementStyleNormalizer
      */
     private function isUnsetValue(mixed $value, ?StyleOptionSpecification $option): bool
     {
-        if ($value === '') {
-            return true;
-        }
-
         if ($option === null) {
             return false;
+        }
+
+        if ($value === '') {
+            return true;
         }
 
         if (!\is_array($value)) {

--- a/tests/integration/Core/Framework/ContentSystem/Layout/Field/ElementStylePersistenceTest.php
+++ b/tests/integration/Core/Framework/ContentSystem/Layout/Field/ElementStylePersistenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\ContentSystem\Layout\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
@@ -87,17 +88,40 @@ class ElementStylePersistenceTest extends TestCase
         static::assertTrue($this->readElement($id, $context)->style->isEmpty());
     }
 
-    #[TestDox('rejects a write whose style references an option not in the registry')]
-    public function testRejectsUnknownStyleOption(): void
+    /**
+     * @param array<string, string|int|float|bool|array<string, string|int|float|bool>> $style
+     */
+    #[DataProvider('unknownStyleOptionProvider')]
+    #[TestDox('rejects a write whose style references $_dataName')]
+    public function testRejectsUnknownStyleOption(array $style, string $optionName): void
     {
         $context = Context::createDefaultContext();
+        $layoutId = $this->ids->get('unknown-option-layout');
 
         try {
-            $this->repository()->create([$this->layout(null, ['not-a-real-option' => ['md' => 1]])], $context);
+            $this->repository()->create([$this->layout($layoutId, $style)], $context);
             static::fail('Expected the field serializer to reject the unknown style option.');
         } catch (WriteException $exception) {
-            static::assertStringContainsString('not-a-real-option', $exception->getMessage());
+            static::assertStringContainsString($optionName, $exception->getMessage());
         }
+
+        static::assertNull($this->repository()->searchIds(new Criteria([$layoutId]), $context)->firstId());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string|array<string, int>>, string}>
+     */
+    public static function unknownStyleOptionProvider(): iterable
+    {
+        yield 'an unknown option with a breakpoint value' => [
+            ['not-a-real-option' => ['md' => 1]],
+            'not-a-real-option',
+        ];
+
+        yield 'an unknown option with an empty string' => [
+            ['removed-plugin-option' => ''],
+            'removed-plugin-option',
+        ];
     }
 
     #[TestDox('rejects a write whose style value falls outside the declared range')]

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredElementWiringDecoderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredElementWiringDecoderTest.php
@@ -480,6 +480,37 @@ class StoredElementWiringDecoderTest extends StoredElementCodecTestCase
             ContentSystemException::invalidFieldValueType('providesContext[product].distribution', implode('|', DistributionStrategy::values()), 'string'),
         ];
 
+        yield 'a broadcast provider carrying a keyed-only field' => [
+            self::baseWire([
+                'providesContext' => [
+                    'product' => ['type' => 'single', 'distribution' => 'broadcast', 'keyProperty' => 'sku'],
+                ],
+            ]),
+            ContentSystemException::invalidFieldValueType(
+                'providesContext[product]',
+                'only known provider keys',
+                'unknown key "keyProperty"'
+            ),
+        ];
+
+        yield 'an invalid provider context type is reported before a non-string config key' => [
+            self::baseWire([
+                'providesContext' => [
+                    'product' => (array) json_decode(
+                        '{"type":"bogus-type","distribution":"broadcast","12":"x"}',
+                        true,
+                        512,
+                        \JSON_THROW_ON_ERROR
+                    ),
+                ],
+            ]),
+            ContentSystemException::invalidFieldValueType(
+                'providesContext[product].type',
+                implode('|', ContextType::values()),
+                'string'
+            ),
+        ];
+
         yield 'a consumer entry missing type' => [
             self::baseWire(['acceptsContext' => ['items' => ['required' => true]]]),
             ContentSystemException::invalidFieldValueType('acceptsContext[items].type', implode('|', ContextType::values()), 'null'),

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredTreeShapeConformanceTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredTreeShapeConformanceTest.php
@@ -554,6 +554,14 @@ class StoredTreeShapeConformanceTest extends TestCase
             '',
         ];
 
+        yield 'a broadcast provider carrying a keyed-only field' => [
+            self::forest(['providesContext' => [
+                'product' => ['type' => 'single', 'distribution' => 'broadcast', 'keyProperty' => 'sku'],
+            ]]),
+            self::REJECTED,
+            '',
+        ];
+
         yield 'a style option the registry does not know' => [
             self::forest(['style' => ['removed-plugin-option' => ['md' => 2]]]),
             self::DESCRIPTOR_ONLY,

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredTreeWiringConstraintsTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredTreeWiringConstraintsTest.php
@@ -636,6 +636,11 @@ class StoredTreeWiringConstraintsTest extends StoredTreeConstraintsTestCase
             '[0][providesContext][product][consumerAlias]',
         ];
 
+        yield 'a broadcast provider carrying a keyed-only field' => [
+            ['type' => 'single', 'distribution' => 'broadcast', 'keyProperty' => 'sku'],
+            '[0][providesContext][product][keyProperty]',
+        ];
+
         yield 'a keyed provider with no key property' => [
             ['type' => 'collection', 'distribution' => 'keyed'],
             '[0][providesContext][product][keyProperty]',

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Element/Style/ElementStyleNormalizerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Element/Style/ElementStyleNormalizerTest.php
@@ -153,6 +153,14 @@ class ElementStyleNormalizerTest extends TestCase
         static::assertSame(['brand-gap' => '20'], $normalized->toArray());
     }
 
+    #[TestDox('passes an unregistered option with an empty string through untouched')]
+    public function testPassesAnUnregisteredEmptyStringOptionThroughUntouched(): void
+    {
+        $normalized = $this->normalizer()->normalize(new ElementStyle(['removed-plugin-option' => '']));
+
+        static::assertSame(['removed-plugin-option' => ''], $normalized->toArray());
+    }
+
     #[TestDox('normalizes a whole style map, dropping the options that resolve to unset')]
     public function testNormalizesAWholeStyleMap(): void
     {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Invalid style options and context-provider fields could be silently removed before write validation instead of being rejected.

### 2. What does this change do, exactly?

It preserves unknown style options for write validation and rejects provider fields not declared by the selected distribution strategy.

### 3. Describe each step to reproduce the issue or behaviour.

1. Write an unknown style option containing an empty string, or an undeclared context-provider field.
2. Observe that the write succeeds while silently removing the field.
3. With this change, the write is rejected with a validation error.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #19952

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
