### PR TITLE
chore(administration): deprecate axios 0.x support

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -433,6 +433,27 @@ The empty states of Extensions > My extensions and the Shopware Store activation
 
 The `assetFilter` computed of both components is deprecated for removal in v6.9.0; use `Shopware.Filter.getByName('asset')` instead.
 
+### Axios 0.x support in the Administration is deprecated
+
+The Administration currently ships two HTTP transports: axios 0.x and axios 1.x. Axios 0.x, and the compatibility layer that lets both run side by side, are deprecated and will be removed with Shopware 6.8. Axios 1.x then becomes the only transport.
+
+Deprecated for removal in 6.8:
+
+- The `useAxiosV1` request-configuration flag on `httpClient` requests.
+- The `axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0` and `defaultsV1` properties on the HTTP client. Use `httpClient.interceptors` and `httpClient.defaults`, which already apply to the active transport.
+- The `axios-v1` package alias. Axios 1.x will be installed as `axios`, so `import ... from 'axios-v1'` becomes `import ... from 'axios'`.
+- The `src/core/factory/http-client-adapter` module with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter`.
+
+What to do now:
+
+- Remove every `useAxiosV1: true` from your request configurations. With the `V6_8_0_0` feature flag active, axios 1.x is already the default, so the flag has no effect.
+- Replace every `useAxiosV1: false` with axios 1.x compatible code. The most common change is switching request cancellation from `CancelToken` to `AbortController`, and reading `error.code === 'ERR_CANCELED'` or `httpClient.isCancel(error)` instead of axios 0.x error shapes.
+- Import `axios` instead of `axios-v1` once the alias is gone. Until then, keep importing `axios-v1` if you need the 1.x types directly; new code should use `HttpClient`, `HttpRequestConfig` and `HttpResponse` from `src/core/factory/http-client.types` instead.
+
+Verify your extension with `FEATURE_ALL=major` so requests run through axios 1.x. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
+
+Removing axios 0.x also removes twelve suppressed npm audit advisories that only affect the 0.x line, among them CVE-2023-45857.
+
 ## Storefront
 
 ### Passive privacy notices without a checkbox

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -444,13 +444,17 @@ Deprecated for removal in 6.8:
 - The `axios-v1` package alias. Axios 1.x will be installed as `axios`, so `import ... from 'axios-v1'` becomes `import ... from 'axios'`.
 - The `src/core/factory/http-client-adapter` module with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter`.
 
+If you never set `useAxiosV1`, your direct HTTP requests run on axios 0.x today and will run on axios 1.x after the upgrade. That is the case most extensions are in. Repository calls are unaffected; they already use axios 1.x.
+
 What to do now:
 
-- Remove every `useAxiosV1: true` from your request configurations. With the `V6_8_0_0` feature flag active, axios 1.x is already the default, so the flag has no effect.
-- Replace every `useAxiosV1: false` with axios 1.x compatible code. The most common change is switching request cancellation from `CancelToken` to `AbortController`, and reading `error.code === 'ERR_CANCELED'` or `httpClient.isCancel(error)` instead of axios 0.x error shapes.
+- Move your direct requests onto axios 1.x one at a time with `useAxiosV1: true`, and check that cancellation and error handling still behave. The flag exists for exactly this dry run and is itself deprecated for removal in 6.8, so delete it again once the migration is done.
+- Replace `CancelToken` based cancellation with `AbortController`, and read `error.code === 'ERR_CANCELED'` or `httpClient.isCancel(error)` instead of axios 0.x error shapes.
+- Remove every `useAxiosV1: true` you already have. With the `V6_8_0_0` feature flag active, axios 1.x is the default and the flag has no effect.
+- Replace every `useAxiosV1: false` with axios 1.x compatible code. After the removal the flag stops selecting a transport without any warning, because axios ignores unknown request options.
 - Import `axios` instead of `axios-v1` once the alias is gone. Until then, keep importing `axios-v1` if you need the 1.x types directly; new code should use `HttpClient`, `HttpRequestConfig` and `HttpResponse` from `src/core/factory/http-client.types` instead.
 
-Verify your extension with `FEATURE_ALL=major` so requests run through axios 1.x. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
+Verify the whole extension with `FEATURE_ALL=major`, which routes every request through axios 1.x. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
 
 Removing axios 0.x also removes twelve suppressed npm audit advisories that only affect the 0.x line, among them CVE-2023-45857.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -435,16 +435,14 @@ The `assetFilter` computed of both components is deprecated for removal in v6.9.
 
 ### Axios 0.x support in the Administration is deprecated
 
-The Administration currently ships two HTTP transports: axios 0.x and axios 1.x. Axios 0.x, and the compatibility layer that lets both run side by side, are deprecated and will be removed with Shopware 6.8. Axios 1.x then becomes the only transport.
+Axios 0.x and its compatibility layer are deprecated and will be removed with Shopware 6.8. Axios 1.x then becomes the only transport.
 
 Deprecated for removal in 6.8:
 
 - The `useAxiosV1` request-configuration flag on `httpClient` requests.
-- The `axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0` and `defaultsV1` properties on the HTTP client. Use `httpClient.interceptors` and `httpClient.defaults`, which already apply to the active transport.
+- The `axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0` and `defaultsV1` properties on the HTTP client. Use `httpClient` itself instead of `axiosV0` and `axiosV1`, and `httpClient.interceptors` and `httpClient.defaults` instead of the four version-specific properties; both already apply to the active transport.
 - The `axios-v1` package alias. Axios 1.x will be installed as `axios`, so `import ... from 'axios-v1'` becomes `import ... from 'axios'`.
 - The `src/core/factory/http-client-adapter` module with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter`.
-
-If you never set `useAxiosV1`, your direct HTTP requests run on axios 0.x today and will run on axios 1.x after the upgrade. That is the case most extensions are in. Repository calls are unaffected; they already use axios 1.x.
 
 What to do now, while you are still on 6.7:
 
@@ -458,8 +456,6 @@ What to do before you upgrade to 6.8:
 - Import `axios` instead of `axios-v1` once the alias is gone. Until then, keep importing `axios-v1` if you need the 1.x types directly; new code should use `HttpClient`, `HttpRequestConfig` and `HttpResponse` from `src/core/factory/http-client.types` instead.
 
 Verify the whole extension with `FEATURE_ALL=major`. It makes axios 1.x the default, so every request that does not set `useAxiosV1` runs on it. A request that sets `useAxiosV1: false` still runs on axios 0.x even with the flag active, so those requests have to be migrated and verified separately. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
-
-Removing axios 0.x also removes twelve npm audit advisories that only affect the 0.x line and are currently suppressed in the Administration's audit ignore list: proxy bypasses, proxy authorization leaks, prototype pollution gadgets, form serializer denial of service and a ReDoS.
 
 ## Storefront
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -446,17 +446,20 @@ Deprecated for removal in 6.8:
 
 If you never set `useAxiosV1`, your direct HTTP requests run on axios 0.x today and will run on axios 1.x after the upgrade. That is the case most extensions are in. Repository calls are unaffected; they already use axios 1.x.
 
-What to do now:
+What to do now, while you are still on 6.7:
 
-- Move your direct requests onto axios 1.x one at a time with `useAxiosV1: true`, and check that cancellation and error handling still behave. The flag exists for exactly this dry run and is itself deprecated for removal in 6.8, so delete it again once the migration is done.
+- Move your direct requests onto axios 1.x one at a time with `useAxiosV1: true`, and check that cancellation and error handling still behave. The flag exists for exactly this dry run.
 - Replace `CancelToken` based cancellation with `AbortController`, and read `error.code === 'ERR_CANCELED'` or `httpClient.isCancel(error)` instead of axios 0.x error shapes.
-- Remove every `useAxiosV1: true` you already have. With the `V6_8_0_0` feature flag active, axios 1.x is the default and the flag has no effect.
+
+What to do before you upgrade to 6.8:
+
+- Remove the `useAxiosV1: true` flags again, including the ones you added for the dry run. With the `V6_8_0_0` feature flag active, axios 1.x is the default and the flag has no effect.
 - Replace every `useAxiosV1: false` with axios 1.x compatible code. After the removal the flag stops selecting a transport without any warning, because axios ignores unknown request options.
 - Import `axios` instead of `axios-v1` once the alias is gone. Until then, keep importing `axios-v1` if you need the 1.x types directly; new code should use `HttpClient`, `HttpRequestConfig` and `HttpResponse` from `src/core/factory/http-client.types` instead.
 
-Verify the whole extension with `FEATURE_ALL=major`, which routes every request through axios 1.x. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
+Verify the whole extension with `FEATURE_ALL=major`. It makes axios 1.x the default, so every request that does not set `useAxiosV1` runs on it. A request that sets `useAxiosV1: false` still runs on axios 0.x even with the flag active, so those requests have to be migrated and verified separately. The full migration path is described in the [Axios migration guide](src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md).
 
-Removing axios 0.x also removes twelve suppressed npm audit advisories that only affect the 0.x line, among them CVE-2023-45857.
+Removing axios 0.x also removes twelve npm audit advisories that only affect the 0.x line and are currently suppressed in the Administration's audit ignore list: proxy bypasses, proxy authorization leaks, prototype pollution gadgets, form serializer denial of service and a ReDoS.
 
 ## Storefront
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1465,60 +1465,104 @@ Please use the `dataSource` prop instead to align with the parent `sw-data-grid`
 
 ## Axios 1.x is the only HTTP client of the Administration
 
-The Administration used to ship two HTTP transports side by side: axios 0.30.2 and axios 1.x. Axios 1.x is now the only transport. Axios 0.x, the per-request version switch, and the compatibility layer that kept both transports in sync were removed. This also resolves CVE-2023-45857 and eleven further advisories that only affect the axios 0.x line.
+Until Shopware 6.7 the Administration performed its HTTP requests with axios 0.30.2. It now uses axios 1.x, and axios 0.x is gone. This resolves CVE-2023-45857 and eleven further advisories that only affect the axios 0.x line.
+
+Most code keeps working untouched. `httpClient.get`, `.post`, interceptors, defaults and the `error.response` properties behave the same. The differences below matter if your code cancels requests, inspects axios internals, or imports axios types directly.
 
 The removal was announced with Shopware 6.7.15.0.
+
+### Key differences between axios 0.30.2 and axios 1.x
+
+**Request cancellation**
+
+Axios 0.x used `CancelToken`. Axios 1.x uses the standard `AbortController`:
+
+```javascript
+// Axios 0.30.2
+const source = httpClient.CancelToken.source();
+
+httpClient.get('/api/endpoint', {
+    cancelToken: source.token,
+});
+
+source.cancel('Operation cancelled');
+
+// Axios 1.x
+const controller = new AbortController();
+
+httpClient.get('/api/endpoint', {
+    signal: controller.signal,
+});
+
+controller.abort();
+```
+
+`httpClient.CancelToken` and the `cancelToken` request option still exist, because axios 1.x still supports them. Axios deprecates both, so move to `AbortController`.
+
+**Error detection**
+
+```javascript
+// Works on both versions and stays the recommended check
+if (httpClient.isCancel(error)) {
+    // Handle cancellation
+}
+
+// Axios 1.x additionally reports standardized codes
+if (error.name === 'CanceledError' || error.code === 'ERR_CANCELED') {
+    // Handle cancellation
+}
+```
+
+**Interceptors and defaults**
+
+Registration is unchanged:
+
+```javascript
+const interceptorId = httpClient.interceptors.request.use(myRequestHandler);
+httpClient.defaults.headers.common['my-header'] = 'value';
+
+httpClient.interceptors.request.eject(interceptorId);
+```
+
+During 6.7 the HTTP client had to mirror every handler and every default onto two internal axios clients. With one transport there is nothing to mirror, so a handler is registered exactly once.
+
+### Trying axios 1.x before you upgrade
+
+Shopware 6.7 shipped both transports, and the request option `useAxiosV1` chose between them per request. It exists as a migration aid: on your current 6.7 installation you can move one request at a time onto axios 1.x, find what breaks, and fix it before you upgrade.
+
+```javascript
+// On Shopware 6.7: run this single request on axios 1.x
+this.httpClient.get('/api/endpoint', {
+    useAxiosV1: true,
+});
+```
+
+If you never set the flag, your direct requests ran on axios 0.30.2, which is the starting point this section is written for. Repository calls are unaffected either way; they already used axios 1.x during 6.7.
+
+The flag is a transitional aid, deprecated with 6.7.15.0 and removed together with axios 0.x:
+
+```javascript
+// Before, on 6.7
+httpClient.get('/api/endpoint', { useAxiosV1: true });
+httpClient.request({ method: 'get', url: '/api/endpoint', useAxiosV1: false });
+
+// After, on 6.8
+httpClient.get('/api/endpoint');
+httpClient.request({ method: 'get', url: '/api/endpoint' });
+```
+
+Axios ignores an unknown property in a request configuration, so a leftover `useAxiosV1` does not throw. It stops selecting a transport without any warning, which is why code that relied on `useAxiosV1: false` has to be migrated rather than left in place.
 
 ### What was removed
 
 | Removed | Replacement |
 | --- | --- |
-| The `useAxiosV1` flag in a request configuration | Nothing. Every request uses axios 1.x. Delete the flag. |
+| The `useAxiosV1` request option | Nothing. Every request uses axios 1.x. Delete the option. |
 | `httpClient.axiosV0`, `httpClient.axiosV1` | `httpClient` itself. The concrete axios instance is not part of the public contract. |
 | `httpClient.interceptorsV0`, `httpClient.interceptorsV1` | `httpClient.interceptors` |
 | `httpClient.defaultsV0`, `httpClient.defaultsV1` | `httpClient.defaults` |
 | The `axios-v1` package alias | `axios`, which now resolves to 1.x |
 | `src/core/factory/http-client-adapter` with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter` | Nothing. Call the HTTP client directly. |
-
-### Remove the version switch from requests
-
-The flag no longer exists in either direction.
-
-Before:
-
-```javascript
-httpClient.get('/api/endpoint', { useAxiosV1: true });
-httpClient.request({ method: 'get', url: '/api/endpoint', useAxiosV1: false });
-```
-
-After:
-
-```javascript
-httpClient.get('/api/endpoint');
-httpClient.request({ method: 'get', url: '/api/endpoint' });
-```
-
-An unknown property in a request configuration is ignored, so a leftover `useAxiosV1` does not throw. It silently stops selecting a transport, which is why code that relied on `useAxiosV1: false` must be migrated rather than left in place.
-
-### Migrate code that relied on axios 0.x behaviour
-
-Request cancellation is the most common case. Axios 0.x used `CancelToken`, axios 1.x uses `AbortController`:
-
-```javascript
-// Before
-const source = httpClient.CancelToken.source();
-httpClient.get('/api/endpoint', { cancelToken: source.token, useAxiosV1: false });
-source.cancel('Operation cancelled');
-
-// After
-const controller = new AbortController();
-httpClient.get('/api/endpoint', { signal: controller.signal });
-controller.abort();
-```
-
-`httpClient.isCancel(error)` keeps working and is the recommended way to detect a cancelled request. Axios 1.x additionally reports `error.name === 'CanceledError'` and `error.code === 'ERR_CANCELED'`.
-
-`httpClient.CancelToken` and the `cancelToken` request option still exist, because axios 1.x still supports them. Both are deprecated by axios itself; use `AbortController` in new code.
 
 ### Import `axios` instead of `axios-v1`
 
@@ -1537,19 +1581,6 @@ New Administration code should not import axios types at all. Use Shopware's own
 ```typescript
 import type { HttpClient, HttpRequestConfig, HttpResponse } from 'src/core/factory/http-client.types';
 ```
-
-### Interceptors and defaults
-
-Registering interceptors and defaults is unchanged:
-
-```javascript
-const interceptorId = httpClient.interceptors.request.use(myRequestHandler);
-httpClient.defaults.headers.common['my-header'] = 'value';
-
-httpClient.interceptors.request.eject(interceptorId);
-```
-
-With a single transport there is nothing left to mirror, so a handler is registered exactly once. Code that registered a handler on `interceptorsV0` or `interceptorsV1` to avoid the previous mirroring must move to `httpClient.interceptors`.
 
 The architectural rationale for the facade is documented in [One Axios transport behind the Administration HTTP client facade](adr/2026-09-08-administration-single-axios-transport.md).
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1463,99 +1463,95 @@ Please use the `dataSource` prop instead to align with the parent `sw-data-grid`
 />
 ```
 
-## Axios v1 is now the default HTTP client
+## Axios 1.x is the only HTTP client of the Administration
 
-Starting with Shopware 6.8, axios 1.x is the default HTTP client for the Administration, replacing axios 0.30.2.
-This change addresses the security vulnerability CVE-2023-45857 present in older axios versions.
+The Administration used to ship two HTTP transports side by side: axios 0.30.2 and axios 1.x. Axios 1.x is now the only transport. Axios 0.x, the per-request version switch, and the compatibility layer that kept both transports in sync were removed. This also resolves CVE-2023-45857 and eleven further advisories that only affect the axios 0.x line.
 
-### What changed
+The removal was announced with Shopware 6.7.15.0.
 
-**Shopware 6.7.x:**
-- Default: axios 0.30.2
-- Opt-in to v1: `useAxiosV1: true`
-- Repository requests use axios 1.x internally so the standard data-access path is migrated before the global switch. Their transport is not configurable through repository options because repositories do not expose axios as part of their public contract.
+### What was removed
 
-**Shopware 6.8.0+ (with `V6_8_0_0` feature flag active):**
-- Direct HTTP request default: axios 1.x
-- Direct HTTP request opt-out to v0: `useAxiosV1: false`
+| Removed | Replacement |
+| --- | --- |
+| The `useAxiosV1` flag in a request configuration | Nothing. Every request uses axios 1.x. Delete the flag. |
+| `httpClient.axiosV0`, `httpClient.axiosV1` | `httpClient` itself. The concrete axios instance is not part of the public contract. |
+| `httpClient.interceptorsV0`, `httpClient.interceptorsV1` | `httpClient.interceptors` |
+| `httpClient.defaultsV0`, `httpClient.defaultsV1` | `httpClient.defaults` |
+| The `axios-v1` package alias | `axios`, which now resolves to 1.x |
+| `src/core/factory/http-client-adapter` with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter` | Nothing. Call the HTTP client directly. |
 
-### Key differences between axios 0.30.2 and axios 1.x
+### Remove the version switch from requests
 
-**Request Cancellation:**
+The flag no longer exists in either direction.
+
+Before:
+
 ```javascript
-// Axios 0.30.2 (deprecated CancelToken)
-const { CancelToken } = Axios;
-const source = CancelToken.source();
+httpClient.get('/api/endpoint', { useAxiosV1: true });
+httpClient.request({ method: 'get', url: '/api/endpoint', useAxiosV1: false });
+```
 
-httpClient.get('/api/endpoint', {
-    cancelToken: source.token,
-});
+After:
+
+```javascript
+httpClient.get('/api/endpoint');
+httpClient.request({ method: 'get', url: '/api/endpoint' });
+```
+
+An unknown property in a request configuration is ignored, so a leftover `useAxiosV1` does not throw. It silently stops selecting a transport, which is why code that relied on `useAxiosV1: false` must be migrated rather than left in place.
+
+### Migrate code that relied on axios 0.x behaviour
+
+Request cancellation is the most common case. Axios 0.x used `CancelToken`, axios 1.x uses `AbortController`:
+
+```javascript
+// Before
+const source = httpClient.CancelToken.source();
+httpClient.get('/api/endpoint', { cancelToken: source.token, useAxiosV1: false });
 source.cancel('Operation cancelled');
 
-// Axios 1.x (modern AbortController)
+// After
 const controller = new AbortController();
-
-httpClient.get('/api/endpoint', {
-    signal: controller.signal,
-    useAxiosV1: true,
-});
+httpClient.get('/api/endpoint', { signal: controller.signal });
 controller.abort();
 ```
 
-**Error Detection:**
-```javascript
-// Works for both versions
-if (httpClient.isCancel(error)) {
-    // Handle cancellation
-}
+`httpClient.isCancel(error)` keeps working and is the recommended way to detect a cancelled request. Axios 1.x additionally reports `error.name === 'CanceledError'` and `error.code === 'ERR_CANCELED'`.
 
-// Axios 1.x specific
-if (error.name === 'CanceledError' || error.code === 'ERR_CANCELED') {
-    // Handle cancellation
-}
+`httpClient.CancelToken` and the `cancelToken` request option still exist, because axios 1.x still supports them. Both are deprecated by axios itself; use `AbortController` in new code.
+
+### Import `axios` instead of `axios-v1`
+
+Axios 1.x is installed under its own name again:
+
+```javascript
+// Before
+import type { AxiosResponse } from 'axios-v1';
+
+// After
+import type { AxiosResponse } from 'axios';
 ```
 
-**Interceptors and Defaults:**
+New Administration code should not import axios types at all. Use Shopware's own contract instead:
 
-The Administration HTTP client is a Shopware-owned compatibility facade. Interceptors and defaults registered through its existing public API are mirrored to both internal axios clients:
+```typescript
+import type { HttpClient, HttpRequestConfig, HttpResponse } from 'src/core/factory/http-client.types';
+```
+
+### Interceptors and defaults
+
+Registering interceptors and defaults is unchanged:
 
 ```javascript
 const interceptorId = httpClient.interceptors.request.use(myRequestHandler);
 httpClient.defaults.headers.common['my-header'] = 'value';
 
-// Removes the interceptor from both internal clients
 httpClient.interceptors.request.eject(interceptorId);
 ```
 
-Extensions do not need to know which axios version handles a request. The underlying axios instances and their version-specific types are no longer part of the public HTTP-client contract. During the transition, the facade remains structurally compatible with `AxiosInstance`, `AxiosRequestConfig.useAxiosV1`, and `axios-mock-adapter` to avoid unnecessary source changes.
+With a single transport there is nothing left to mirror, so a handler is registered exactly once. Code that registered a handler on `interceptorsV0` or `interceptorsV1` to avoid the previous mirroring must move to `httpClient.interceptors`.
 
-### Migration guide
-
-Most code will work without changes.
-However, if you use request cancellation or depend on specific axios behavior:
-
-1. **Update cancellation logic** to use `AbortController` instead of `CancelToken`
-2. **Test your plugin** with axios v1 before the 6.8 release
-3. **Review error handling** for version-specific error codes
-
-**If a direct HTTP request needs axios 0.30.2 temporarily:**
-```javascript
-// Explicitly opt-out to use axios 0.30.2
-httpClient.request({
-    method: 'get',
-    url: '/api/endpoint',
-    useAxiosV1: false, // Force axios 0.30.2
-});
-```
-
-### Future removal
-
-Axios 0.30.2 support will be completely removed in a future major release.
-The `useAxiosV1` flag will be deprecated once axios v1 becomes the sole version.
-Plan to migrate all code to axios v1 as soon as possible.
-
-For detailed migration instructions, see the migration guide at `src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md`.
-The architectural rationale is documented in [Keep Administration HTTP transports behind a compatibility facade](adr/2026-07-23-administration-http-client-compatibility-facade.md).
+The architectural rationale for the facade is documented in [Keep Administration HTTP transports behind a compatibility facade](adr/2026-07-23-administration-http-client-compatibility-facade.md).
 
 ## Removal of "sw-empty-state"
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1564,6 +1564,8 @@ Axios ignores an unknown property in a request configuration, so a leftover `use
 | The `axios-v1` package alias | `axios`, which now resolves to 1.x |
 | `src/core/factory/http-client-adapter` with `HttpClientAdapter`, `createAxiosV0Adapter` and `createAxiosV1Adapter` | Nothing. Call the HTTP client directly. |
 
+`httpClient.interceptors` gains behaviour in the exchange. During 6.7 its `handlers` array was a copy that the facade mirrored onto both transports, so mutating a handler object in place had no effect on requests. It is now the axios interceptor manager itself, and `handlers` is the list axios runs.
+
 ### Import `axios` instead of `axios-v1`
 
 Axios 1.x is installed under its own name again:

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1465,20 +1465,20 @@ Please use the `dataSource` prop instead to align with the parent `sw-data-grid`
 
 ## Axios 1.x is the only HTTP client of the Administration
 
-Until Shopware 6.7 the Administration performed its HTTP requests with axios 0.30.2. It now uses axios 1.x, and axios 0.x is gone. This resolves CVE-2023-45857 and eleven further advisories that only affect the axios 0.x line.
+Until Shopware 6.7 the Administration performed its HTTP requests with legacy axios 0.x. It now uses axios 1.x, and axios 0.x is gone. This resolves twelve npm audit advisories that only affect the axios 0.x line and had to be suppressed while that line was still shipped: proxy bypasses, proxy authorization leaks, prototype pollution gadgets, form serializer denial of service and a ReDoS.
 
 Most code keeps working untouched. `httpClient.get`, `.post`, interceptors, defaults and the `error.response` properties behave the same. The differences below matter if your code cancels requests, inspects axios internals, or imports axios types directly.
 
 The removal was announced with Shopware 6.7.15.0.
 
-### Key differences between axios 0.30.2 and axios 1.x
+### Key differences between legacy axios 0.x and axios 1.x
 
 **Request cancellation**
 
 Axios 0.x used `CancelToken`. Axios 1.x uses the standard `AbortController`:
 
 ```javascript
-// Axios 0.30.2
+// Legacy axios 0.x
 const source = httpClient.CancelToken.source();
 
 httpClient.get('/api/endpoint', {
@@ -1537,7 +1537,7 @@ this.httpClient.get('/api/endpoint', {
 });
 ```
 
-If you never set the flag, your direct requests ran on axios 0.30.2, which is the starting point this section is written for. Repository calls are unaffected either way; they already used axios 1.x during 6.7.
+If you never set the flag, your direct requests ran on legacy axios 0.x, which is the starting point this section is written for. Repository calls are unaffected either way; they already used axios 1.x during 6.7.
 
 The flag is a transitional aid, deprecated with 6.7.15.0 and removed together with axios 0.x:
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1551,7 +1551,7 @@ httpClient.interceptors.request.eject(interceptorId);
 
 With a single transport there is nothing left to mirror, so a handler is registered exactly once. Code that registered a handler on `interceptorsV0` or `interceptorsV1` to avoid the previous mirroring must move to `httpClient.interceptors`.
 
-The architectural rationale for the facade is documented in [Keep Administration HTTP transports behind a compatibility facade](adr/2026-07-23-administration-http-client-compatibility-facade.md).
+The architectural rationale for the facade is documented in [One Axios transport behind the Administration HTTP client facade](adr/2026-09-08-administration-single-axios-transport.md).
 
 ## Removal of "sw-empty-state"
 

--- a/adr/2026-07-23-administration-http-client-compatibility-facade.md
+++ b/adr/2026-07-23-administration-http-client-compatibility-facade.md
@@ -19,6 +19,18 @@ During the transition, direct HTTP requests can select the legacy or new transpo
 
 Repository requests always use Axios v1 internally. Repository options cannot select the transport. Any repository incompatibility is fixed centrally in Shopware rather than worked around by each extension.
 
+## Version 6.8 Major Checklist
+
+The transitional half of this decision ends with Shopware 6.8. The facade stays, the second transport does not.
+
+- Remove the axios 0.x dependency and rename the `axios-v1` alias back to `axios`.
+- Remove the `useAxiosV1` request flag and the version dispatcher in `src/core/factory/http.factory.js`.
+- Remove the mirrored interceptor manager and mirrored defaults; a single transport needs no mirroring.
+- Remove `src/core/factory/http-client-adapter.ts` and the `axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0` and `defaultsV1` escape hatches.
+- Drop the axios 0.x advisory suppressions from `scripts/runNpmAudit.ts`.
+
+Structural `AxiosInstance` compatibility stops being a goal at that point. `HttpClient`, `HttpRequestConfig` and `HttpResponse` are the contract.
+
 ## Consequences
 
 Extensions can adopt Axios v1 incrementally: repository calls migrate without source changes, while transport-sensitive direct requests retain a temporary fallback. Existing interceptor setup and common test infrastructure continue to work across both transports.

--- a/adr/2026-09-08-administration-single-axios-transport.md
+++ b/adr/2026-09-08-administration-single-axios-transport.md
@@ -1,0 +1,58 @@
+---
+title: One Axios transport behind the Administration HTTP client facade
+date: 2026-09-08
+area: administration
+tags: [administration, axios, deprecation, extensions]
+status: accepted
+---
+
+## Context
+
+[Keep Administration HTTP transports behind a compatibility facade](_superseded/2026-07-23-administration-http-client-compatibility-facade.md) decided to run Axios 0.x and Axios 1.x side by side behind a Shopware-owned facade, so extensions could migrate at their own pace. Direct HTTP requests selected a transport with `useAxiosV1`, repository requests always used 1.x, and the facade mirrored interceptors and defaults onto both clients.
+
+The incremental path worked. Repository calls moved to Axios 1.x without a single source change in an extension, and Axios 1.x became the default for direct requests once the `V6_8_0_0` feature flag is active. No requirement to stay on Axios 0.x has come up since.
+
+Coexistence has a standing price:
+
+- Twelve npm audit advisories stay suppressed because they only affect the Axios 0.x line, CVE-2023-45857 among them.
+- `httpClient.interceptors` and `httpClient.defaults` are hand-written proxies that clone every handler and mirror every property write into both clients, rather than the Axios ones.
+- The request methods (`get`, `post`, `postForm`, `getUri` and the rest) are re-implemented on a dispatcher function, because the facade is not an Axios instance.
+- Six undocumented escape hatches (`axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0`, `defaultsV1`) let extensions reach past the facade to tell the two transports apart.
+
+The superseded ADR left the end of the transition open. It promised an announcement through the release information and the applicable major upgrade guide, without naming a release, so extension authors had no date to plan against.
+
+## Decision
+
+Axios 1.x is the only HTTP transport of the Administration. The second transport and the transitional compatibility surface are removed with Shopware 6.8, announced as deprecated with `@deprecated tag:v6.8.0` in 6.7.
+
+The durable half of the superseded decision is unchanged:
+
+- The Administration exposes a Shopware-owned HTTP client facade. The concrete Axios instance stays private and is not part of the public contract.
+- `HttpClient`, `HttpRequestConfig` and `HttpResponse` are the contract extensions depend on.
+- Axios is not part of the repository contract. A repository incompatibility is fixed centrally in Shopware rather than worked around by each extension.
+
+The transitional half ends:
+
+- The Axios 0.x dependency is removed. Axios 1.x is installed as `axios` instead of behind the `axios-v1` alias.
+- The `useAxiosV1` request flag and the version dispatcher are removed.
+- The mirrored interceptor manager and mirrored defaults are removed. `createHTTPClient` returns a configured Axios 1.x instance, with `isCancel` and `CancelToken` assigned onto it because the `HttpClient` contract declares them.
+- The version adapter module and the six escape hatches are removed.
+- Structural `AxiosInstance` compatibility stops being a goal.
+
+`CancelToken` and the `cancelToken` request option are kept. Axios 1.x still supports both, so removing them would be a separate breaking change. `AbortController` is the recommended mechanism.
+
+## Consequences
+
+Extensions that never selected a transport need no change. An extension pinned to `useAxiosV1: false` must migrate before 6.8; afterwards the flag is an unknown configuration key that Axios ignores, so the opt-out fails silently rather than throwing. This is why the removal is announced a minor ahead and the flag carries a deprecation annotation.
+
+The facade shrinks to the Axios instance itself. Interceptors and defaults registered through it are the Axios ones, so a handler is registered once instead of cloned into two stacks, and behaviour no longer depends on which transport served a request.
+
+The twelve suppressed advisories are resolved by the removal rather than by an exception in the audit configuration.
+
+The facade remains the boundary for the next HTTP-library upgrade. Keeping it while dropping the second transport preserves what the superseded ADR was for and drops what it cost.
+
+## References
+
+- Superseded ADR: `adr/_superseded/2026-07-23-administration-http-client-compatibility-facade.md`
+- [The Administration HTTP client](../src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md)
+- `UPGRADE-6.8.md`, section "Axios 1.x is the only HTTP client of the Administration"

--- a/adr/2026-09-08-administration-single-axios-transport.md
+++ b/adr/2026-09-08-administration-single-axios-transport.md
@@ -17,7 +17,6 @@ Coexistence has a standing price:
 - Twelve npm audit advisories stay suppressed because they only affect the Axios 0.x line: proxy bypasses, proxy authorization leaks, prototype pollution gadgets, form serializer denial of service and a ReDoS. They are listed with that reason in the Administration's `scripts/runNpmAudit.ts`.
 - `httpClient.interceptors` and `httpClient.defaults` are hand-written proxies that clone every handler and mirror every property write into both clients, rather than the Axios ones.
 - The request methods (`get`, `post`, `postForm`, `getUri` and the rest) are re-implemented on a dispatcher function, because the facade is not an Axios instance.
-- Six undocumented escape hatches (`axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0`, `defaultsV1`) let extensions reach past the facade to tell the two transports apart.
 
 The superseded ADR left the end of the transition open. It promised an announcement through the release information and the applicable major upgrade guide, without naming a release, so extension authors had no date to plan against.
 
@@ -35,21 +34,20 @@ The transitional half ends:
 
 - The Axios 0.x dependency is removed. Axios 1.x is installed as `axios` instead of behind the `axios-v1` alias.
 - The `useAxiosV1` request flag and the version dispatcher are removed.
-- The mirrored interceptor manager and mirrored defaults are removed. `createHTTPClient` returns a configured Axios 1.x instance, with `isCancel` and `CancelToken` assigned onto it because the `HttpClient` contract declares them.
+- The mirrored interceptor manager and mirrored defaults are removed. `httpClient.interceptors` and `httpClient.defaults` forward to a single private Axios 1.x instance instead of being mirrored onto two.
+- Shopware does not modify the Axios instance. The facade stays a distinct object that delegates to it, and members the `HttpClient` contract declares but an instance does not carry — `isCancel` and `CancelToken`, which `axios.create()` leaves off — live on the facade and are imported by name from Axios.
 - The version adapter module and the six escape hatches are removed.
 - Structural `AxiosInstance` compatibility stops being a goal.
-
-`CancelToken` and the `cancelToken` request option are kept. Axios 1.x still supports both, so removing them would be a separate breaking change. `AbortController` is the recommended mechanism.
 
 ## Consequences
 
 Extensions that never selected a transport need no change. An extension pinned to `useAxiosV1: false` must migrate before 6.8; afterwards the flag is an unknown configuration key that Axios ignores, so the opt-out fails silently rather than throwing. This is why the removal is announced a minor ahead and the flag carries a deprecation annotation.
 
-The facade shrinks to the Axios instance itself. Interceptors and defaults registered through it are the Axios ones, so a handler is registered once instead of cloned into two stacks, and behaviour no longer depends on which transport served a request.
+The facade shrinks to a thin delegate. Interceptors and defaults registered through it are the Axios ones, so a handler is registered once instead of cloned into two stacks, and behaviour no longer depends on which transport served a request. Because the instance stays unmodified, an Axios upgrade changes what the facade delegates to rather than a set of Shopware-owned patches on it.
 
 The twelve suppressed advisories are resolved by the removal rather than by an exception in the audit configuration.
 
-The facade remains the boundary for the next HTTP-library upgrade. Keeping it while dropping the second transport preserves what the superseded ADR was for and drops what it cost.
+The superseded ADR's boundary is preserved; its compatibility guarantee is not. It promised to normalize cancellation, errors, configuration and test compatibility in one place. The first three still hold. The fourth ends with structural `AxiosInstance` compatibility: extensions that hold the client in an Axios-typed variable, or attach `axios-mock-adapter` to it, have to change. So do Shopware's own specs, which mock through the escape hatches this removal deletes. The replacement for that mocking path is decided with the removal.
 
 ## References
 

--- a/adr/2026-09-08-administration-single-axios-transport.md
+++ b/adr/2026-09-08-administration-single-axios-transport.md
@@ -14,7 +14,7 @@ The incremental path worked. Repository calls moved to Axios 1.x without a singl
 
 Coexistence has a standing price:
 
-- Twelve npm audit advisories stay suppressed because they only affect the Axios 0.x line, CVE-2023-45857 among them.
+- Twelve npm audit advisories stay suppressed because they only affect the Axios 0.x line: proxy bypasses, proxy authorization leaks, prototype pollution gadgets, form serializer denial of service and a ReDoS. They are listed with that reason in the Administration's `scripts/runNpmAudit.ts`.
 - `httpClient.interceptors` and `httpClient.defaults` are hand-written proxies that clone every handler and mirror every property write into both clients, rather than the Axios ones.
 - The request methods (`get`, `post`, `postForm`, `getUri` and the rest) are re-implemented on a dispatcher function, because the facade is not an Axios instance.
 - Six undocumented escape hatches (`axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0`, `defaultsV1`) let extensions reach past the facade to tell the two transports apart.

--- a/adr/_superseded/2026-07-23-administration-http-client-compatibility-facade.md
+++ b/adr/_superseded/2026-07-23-administration-http-client-compatibility-facade.md
@@ -31,4 +31,4 @@ The facade also provides a stable boundary for future HTTP-library upgrades. Ver
 
 Maintaining two transports and transitional Axios compatibility adds temporary complexity. Code that directly depends on Axios-specific behavior must still migrate before the legacy transport and compatibility surface can be removed.
 
-See the [Axios migration guide](../src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md) for the supported migration path.
+See the [Axios migration guide](../../src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md) for the supported migration path.

--- a/adr/_superseded/2026-07-23-administration-http-client-compatibility-facade.md
+++ b/adr/_superseded/2026-07-23-administration-http-client-compatibility-facade.md
@@ -5,6 +5,10 @@ area: administration
 tags: [administration, axios, compatibility, extensions]
 ---
 
+> **Status:** Superseded on 2026-09-08
+> This ADR has been replaced by [2026-09-08-administration-single-axios-transport.md](../2026-09-08-administration-single-axios-transport.md).
+> The new ADR keeps the facade and ends the second transport: axios 1.x becomes the only transport with Shopware 6.8.
+
 ## Context
 
 The Administration HTTP client has historically exposed Axios behavior to extensions. Replacing Axios 0.x with Axios 1.x directly would therefore affect interceptor and default configuration, request cancellation, TypeScript types, and test mocks across the extension ecosystem.
@@ -18,18 +22,6 @@ The Administration exposes a Shopware-owned HTTP client facade while keeping the
 During the transition, direct HTTP requests can select the legacy or new transport with `useAxiosV1`. Interceptors and defaults registered through the facade are applied to both transports, and the facade retains the compatibility needed by existing Axios-based types and test tooling. New code should use Shopware's HTTP client types instead of depending on an Axios instance.
 
 Repository requests always use Axios v1 internally. Repository options cannot select the transport. Any repository incompatibility is fixed centrally in Shopware rather than worked around by each extension.
-
-## Version 6.8 Major Checklist
-
-The transitional half of this decision ends with Shopware 6.8. The facade stays, the second transport does not.
-
-- Remove the axios 0.x dependency and rename the `axios-v1` alias back to `axios`.
-- Remove the `useAxiosV1` request flag and the version dispatcher in `src/core/factory/http.factory.js`.
-- Remove the mirrored interceptor manager and mirrored defaults; a single transport needs no mirroring.
-- Remove `src/core/factory/http-client-adapter.ts` and the `axiosV0`, `axiosV1`, `interceptorsV0`, `interceptorsV1`, `defaultsV0` and `defaultsV1` escape hatches.
-- Drop the axios 0.x advisory suppressions from `scripts/runNpmAudit.ts`.
-
-Structural `AxiosInstance` compatibility stops being a goal at that point. `HttpClient`, `HttpRequestConfig` and `HttpResponse` are the contract.
 
 ## Consequences
 

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -655,6 +655,7 @@ export default class Repository<EntityName extends keyof EntitySchema.EntityKeys
         );
         const url = `/_action/version/${versionId}/${this.entityName.replace(/_/g, '-')}/${entityId}`;
 
+        // @deprecated tag:v6.8.0 - Drop `useAxiosV1`, axios 1.x is the only transport.
         return fetch(this.httpClient.getUri({ url, useAxiosV1: true }), {
             method: 'POST',
             headers,
@@ -809,6 +810,7 @@ export default class Repository<EntityName extends keyof EntitySchema.EntityKeys
     private buildRequestConfig(headers: ReturnType<Repository<EntityName>['buildHeaders']>) {
         return {
             headers,
+            // @deprecated tag:v6.8.0 - Drop `useAxiosV1`, axios 1.x is the only transport.
             useAxiosV1: true,
         };
     }

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -655,8 +655,13 @@ export default class Repository<EntityName extends keyof EntitySchema.EntityKeys
         );
         const url = `/_action/version/${versionId}/${this.entityName.replace(/_/g, '-')}/${entityId}`;
 
-        // @deprecated tag:v6.8.0 - Drop `useAxiosV1`, axios 1.x is the only transport.
-        return fetch(this.httpClient.getUri({ url, useAxiosV1: true }), {
+        const uri = this.httpClient.getUri({
+            url,
+            // @deprecated tag:v6.8.0 - Remove this option, axios 1.x is the only transport.
+            useAxiosV1: true,
+        });
+
+        return fetch(uri, {
             method: 'POST',
             headers,
             body: JSON.stringify({}),
@@ -810,7 +815,7 @@ export default class Repository<EntityName extends keyof EntitySchema.EntityKeys
     private buildRequestConfig(headers: ReturnType<Repository<EntityName>['buildHeaders']>) {
         return {
             headers,
-            // @deprecated tag:v6.8.0 - Drop `useAxiosV1`, axios 1.x is the only transport.
+            // @deprecated tag:v6.8.0 - Remove this option, axios 1.x is the only transport.
             useAxiosV1: true,
         };
     }

--- a/src/Administration/Resources/app/administration/src/core/factory/http-client-adapter.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/http-client-adapter.ts
@@ -2,6 +2,9 @@
  * @sw-package framework
  *
  * @module core/factory/http-client-adapter
+ *
+ * @deprecated tag:v6.8.0 - The whole module will be removed. It only exists to normalise the
+ * differences between axios 0.x and axios 1.x while both transports are available.
  */
 
 import Axios from 'axios';
@@ -23,6 +26,9 @@ type ResponseForConfig<TRequestConfig, TData = unknown> = TRequestConfig extends
       : AxiosResponseV0<TData> | AxiosResponseV1<TData>;
 /**
  * Adapter interface for handling axios version-specific differences
+ *
+ * @deprecated tag:v6.8.0 - Will be removed. Axios 1.x is the only transport, so no version
+ * abstraction is needed.
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export interface HttpClientAdapter<TRequestConfig = AxiosRequestConfigV0 | AxiosRequestConfigV1> {
@@ -40,6 +46,8 @@ export interface HttpClientAdapter<TRequestConfig = AxiosRequestConfigV0 | Axios
 /**
  * Creates an adapter for axios v1.x
  * Uses AbortController for request cancellation
+ *
+ * @deprecated tag:v6.8.0 - Will be removed. Call `client.request()` and `Axios.isCancel()` directly.
  *
  * @param client - The axios v1 instance
  * @returns HttpClientAdapter for axios v1
@@ -64,6 +72,8 @@ export function createAxiosV1Adapter(client: AxiosInstanceV1): HttpClientAdapter
 /**
  * Creates an adapter for axios v0.x
  * Uses CancelToken for request cancellation
+ *
+ * @deprecated tag:v6.8.0 - Will be removed with axios 0.x support.
  *
  * @param client - The axios v0 instance
  * @returns HttpClientAdapter for axios v0

--- a/src/Administration/Resources/app/administration/src/core/factory/http-client.types.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/http-client.types.ts
@@ -24,6 +24,10 @@ export interface HttpRequestConfig<Data = HttpClientValue> {
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
     adapter?: HttpClientValue;
     version?: number;
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed. Axios 1.x is the only transport, so the request
+     * no longer selects a version. Remove the flag from the request configuration.
+     */
     useAxiosV1?: boolean;
 }
 

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -6,6 +6,7 @@
 import Axios from 'axios';
 import AxiosV1 from 'axios-v1';
 import cacheAdapterFactory from 'src/core/factory/cache-adapter.factory';
+// @deprecated tag:v6.8.0 - Remove this import together with the `http-client-adapter` module.
 import { createAxiosV0Adapter, createAxiosV1Adapter } from 'src/core/factory/http-client-adapter';
 
 /**
@@ -46,7 +47,7 @@ function createClient() {
         timeout: 30000, // 30 second timeout
     };
 
-    // @deprecated tag:v6.8.0 - Remove this instance, axios 1.x is the only transport.
+    // @deprecated tag:v6.8.0 - Remove the axios 0.x instance below; `axiosV1` is the only remaining transport.
     const axiosV0 = Axios.create(baseConfig);
     const axiosV1 = AxiosV1.create(baseConfig);
 
@@ -79,15 +80,13 @@ function createClient() {
         requestCacheAdapterInterceptorV1(axiosV1);
     }
 
-    // Create adapters for both versions
+    // @deprecated tag:v6.8.0 - Remove both adapters together with the version routing below.
     const adapterV0 = createAxiosV0Adapter(axiosV0);
     const adapterV1 = createAxiosV1Adapter(axiosV1);
 
     /**
      * Dispatcher function that routes requests to the appropriate axios version
      * based on the useAxiosV1 flag in the request config
-     *
-     * @deprecated tag:v6.8.0 - Version routing will be removed. Every request will be handled by axios 1.x.
      *
      * @param {Object|string} configOrUrl - Axios request config or URL
      * @param {Object} config - Axios request config when a URL is passed
@@ -100,6 +99,8 @@ function createClient() {
         // 1. If useAxiosV1 is explicitly set (true/false), use that
         // 2. Otherwise, check V6_8_0_0 feature flag (defaults to v1 when active)
         // 3. Fall back to v0 for backward compatibility
+        //
+        // @deprecated tag:v6.8.0 - Remove the two lines below and return `axiosV1.request(requestConfig)`.
         const shouldUseV1 = requestConfig?.useAxiosV1 ?? isV68 ?? false;
         const targetAdapter = shouldUseV1 ? adapterV1 : adapterV0;
 
@@ -119,16 +120,19 @@ function createClient() {
     dispatcher.putForm = (url, data, config = {}) => dispatcher(createFormConfig('put', url, data, config));
     dispatcher.patchForm = (url, data, config = {}) => dispatcher(createFormConfig('patch', url, data, config));
     dispatcher.getUri = (config = {}) => {
+        // @deprecated tag:v6.8.0 - Remove the version routing and return `axiosV1.getUri(config)`.
         const shouldUseV1 = config?.useAxiosV1 ?? isV68 ?? false;
         return shouldUseV1 ? axiosV1.getUri(config) : axiosV0.getUri(config);
     };
 
-    // Add isCancel method that checks both adapters
+    // @deprecated tag:v6.8.0 - Probing both adapters goes away. Assign `AxiosV1.isCancel` instead, which the
+    // `HttpClient` contract requires but `AxiosV1.create()` does not put on the instance.
     dispatcher.isCancel = (value) => {
         return adapterV0.isCancel(value) || adapterV1.isCancel(value);
     };
 
-    // Keep CancelToken for backward compatibility with axios v0
+    // Survives the axios 0.x removal (the `HttpClient` contract declares it, axios 1.x still supports it), but
+    // must then be re-sourced: `Axios` here is the 0.x package.
     dispatcher.CancelToken = CancelToken;
 
     // Keep the public configuration surface independent of the selected axios version.
@@ -142,8 +146,9 @@ function createClient() {
      * Runtime escape hatches to the concrete axios instances. They intentionally stay out of the
      * TypeScript contract so new code uses the version-agnostic facade.
      *
-     * @deprecated tag:v6.8.0 - All six properties will be removed. Register interceptors through
-     * `httpClient.interceptors` and defaults through `httpClient.defaults` instead.
+     * @deprecated tag:v6.8.0 - All six properties will be removed. Use `httpClient` itself instead of
+     * `axiosV0`/`axiosV1`, `httpClient.interceptors` instead of `interceptorsV0`/`interceptorsV1`, and
+     * `httpClient.defaults` instead of `defaultsV0`/`defaultsV1`.
      */
     dispatcher.axiosV0 = axiosV0;
     dispatcher.axiosV1 = axiosV1;

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -2,8 +2,6 @@
  * @sw-package framework
  *
  * @module core/factory/http
- *
- * @deprecated tag:v6.8.0 - The version dispatcher will be removed. Axios 1.x becomes the only transport.
  */
 import Axios from 'axios';
 import AxiosV1 from 'axios-v1';
@@ -48,7 +46,7 @@ function createClient() {
         timeout: 30000, // 30 second timeout
     };
 
-    // @deprecated tag:v6.8.0 - Only the axios 1.x instance will remain.
+    // @deprecated tag:v6.8.0 - Remove this instance, axios 1.x is the only transport.
     const axiosV0 = Axios.create(baseConfig);
     const axiosV1 = AxiosV1.create(baseConfig);
 
@@ -308,6 +306,9 @@ function createMirroredObject(primary, secondary, originalAdapters = null) {
     });
 }
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed together with the second transport.
+ */
 function isObject(value) {
     return value !== null && typeof value === 'object';
 }

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -2,6 +2,8 @@
  * @sw-package framework
  *
  * @module core/factory/http
+ *
+ * @deprecated tag:v6.8.0 - The version dispatcher will be removed. Axios 1.x becomes the only transport.
  */
 import Axios from 'axios';
 import AxiosV1 from 'axios-v1';
@@ -46,7 +48,7 @@ function createClient() {
         timeout: 30000, // 30 second timeout
     };
 
-    // Create both axios v0 and v1 instances
+    // @deprecated tag:v6.8.0 - Only the axios 1.x instance will remain.
     const axiosV0 = Axios.create(baseConfig);
     const axiosV1 = AxiosV1.create(baseConfig);
 
@@ -86,6 +88,8 @@ function createClient() {
     /**
      * Dispatcher function that routes requests to the appropriate axios version
      * based on the useAxiosV1 flag in the request config
+     *
+     * @deprecated tag:v6.8.0 - Version routing will be removed. Every request will be handled by axios 1.x.
      *
      * @param {Object|string} configOrUrl - Axios request config or URL
      * @param {Object} config - Axios request config when a URL is passed
@@ -136,8 +140,13 @@ function createClient() {
     };
     dispatcher.defaults = createMirroredDefaults(axiosV0.defaults, axiosV1.defaults, isV68);
 
-    // Keep the former runtime escape hatches for extensions that already use them.
-    // They intentionally stay out of the TypeScript contract so new code uses the version-agnostic facade.
+    /**
+     * Runtime escape hatches to the concrete axios instances. They intentionally stay out of the
+     * TypeScript contract so new code uses the version-agnostic facade.
+     *
+     * @deprecated tag:v6.8.0 - All six properties will be removed. Register interceptors through
+     * `httpClient.interceptors` and defaults through `httpClient.defaults` instead.
+     */
     dispatcher.axiosV0 = axiosV0;
     dispatcher.axiosV1 = axiosV1;
     dispatcher.interceptorsV0 = axiosV0.interceptors;
@@ -161,6 +170,10 @@ function createFormConfig(method, url, data, config) {
     };
 }
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed. With a single transport the facade exposes the axios
+ * interceptor managers directly, so nothing has to be mirrored.
+ */
 function createMirroredInterceptorManager(axiosV0Interceptors, axiosV1Interceptors) {
     // Keep the public facade separate from Axios' internal interceptor stacks. The
     // initial handlers contain version-specific closures (notably the cache
@@ -242,10 +255,16 @@ function createMirroredInterceptorManager(axiosV0Interceptors, axiosV1Intercepto
     };
 }
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed together with the second transport.
+ */
 function cloneInterceptorHandler(handler) {
     return handler === null || handler === undefined ? handler : { ...handler };
 }
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed together with the second transport.
+ */
 function createMirroredDefaults(axiosV0Defaults, axiosV1Defaults, isV68) {
     const primaryDefaults = isV68 ? axiosV1Defaults : axiosV0Defaults;
     const secondaryDefaults = isV68 ? axiosV0Defaults : axiosV1Defaults;
@@ -257,6 +276,9 @@ function createMirroredDefaults(axiosV0Defaults, axiosV1Defaults, isV68) {
     return createMirroredObject(primaryDefaults, secondaryDefaults, originalAdapters);
 }
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed together with the second transport.
+ */
 function createMirroredObject(primary, secondary, originalAdapters = null) {
     return new Proxy(primary, {
         get(target, property) {
@@ -293,6 +315,8 @@ function isObject(value) {
 /**
  * Sets up an interceptor to handle automatic cache of same requests in short time amount
  * for Axios v0.x
+ *
+ * @deprecated tag:v6.8.0 - Will be removed with axios 0.x. Use `requestCacheAdapterInterceptorV1`.
  *
  * @param {AxiosInstance} client
  * @returns {AxiosInstance}

--- a/src/Administration/Resources/app/administration/src/core/service/api/media-presigned-upload.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media-presigned-upload.api.service.js
@@ -8,7 +8,11 @@ import ApiService from '../api.service';
 
 /**
  * Standalone client for the direct-to-S3 PUT. It bypasses the Administration HTTP client so no API
- * interceptor, base URL or auth header is applied to a presigned upload.
+ * interceptor, base URL or auth header is applied to a presigned upload. Because of that it carries its own
+ * axios 0.x dependency: `axios` resolves to 0.x today and to 1.x once the alias is dropped.
+ *
+ * @deprecated tag:v6.8.0 - Verify this client against axios 1.x, starting with the `Content-Type` constraint
+ * below.
  */
 const s3Client = Axios.create();
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/media-presigned-upload.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media-presigned-upload.api.service.js
@@ -6,6 +6,10 @@ import { fileReader } from 'src/core/service/util.service';
 import { UploadEvents } from './media.api.service';
 import ApiService from '../api.service';
 
+/**
+ * Standalone client for the direct-to-S3 PUT. It bypasses the Administration HTTP client so no API
+ * interceptor, base URL or auth header is applied to a presigned upload.
+ */
 const s3Client = Axios.create();
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-worker.js
@@ -13,6 +13,13 @@ import Axios from 'axios';
 self.onmessage = onMessage;
 self.onconnect = onconnect;
 
+/**
+ * The worker has its own axios 0.x dependency, outside the Administration HTTP client: `axios` resolves to
+ * 0.x today and to 1.x once the alias is dropped.
+ *
+ * @deprecated tag:v6.8.0 - Verify this client against axios 1.x and move the cancellation to
+ * `AbortController`, which axios 1.x prefers over `CancelToken`.
+ */
 const { CancelToken } = Axios;
 let isRunning = false;
 let loginService;

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -618,16 +618,27 @@ declare module 'axios' {
     interface AxiosRequestConfig {
         // adds the shopware API version to the RequestConfig
         version?: number;
-        // Opt-in flag to use axios v1 instead of v0 for this request
+        /**
+         * Opt-in flag to use axios v1 instead of v0 for this request
+         *
+         * @deprecated tag:v6.8.0 - Will be removed together with axios 0.x support.
+         */
         useAxiosV1?: boolean;
     }
 }
 
+/**
+ * @deprecated tag:v6.8.0 - The `axios-v1` package alias will be removed; axios 1.x is installed as `axios`.
+ */
 declare module 'axios-v1' {
     interface AxiosRequestConfig {
         // adds the shopware API version to the RequestConfig
         version?: number;
-        // Opt-in flag to use axios v1 instead of v0 for this request
+        /**
+         * Opt-in flag to use axios v1 instead of v0 for this request
+         *
+         * @deprecated tag:v6.8.0 - Will be removed together with axios 0.x support.
+         */
         useAxiosV1?: boolean;
     }
 }

--- a/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
+++ b/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
@@ -28,6 +28,10 @@ The resulting behavior is:
 
 Repository requests use Axios v1 before the global switch because repositories are the standard Administration data-access path. Axios is not part of the repository contract, so extensions do not select its transport or need to change repository calls.
 
+If your extension never sets `useAxiosV1`, its direct requests run on legacy Axios today and move to Axios v1 with 6.8. That is the starting point this guide assumes.
+
+`useAxiosV1` is a migration aid, not a permanent option. It lets you move one request at a time onto Axios v1 while still running 6.7. It is deprecated with 6.7.15.0 and removed with 6.8, so delete it again once the migration is done.
+
 ## Migrating direct HTTP requests
 
 Opt in while running Shopware 6.7 by setting `useAxiosV1: true`:

--- a/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
+++ b/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
@@ -216,7 +216,7 @@ Checklist before upgrading to 6.8:
 
 The removal is documented in `UPGRADE-6.8.md`, section "Axios 1.x is the only HTTP client of the Administration".
 
-The architectural rationale for keeping both transports behind a Shopware-owned boundary is documented in [Keep Administration HTTP transports behind a compatibility facade](../../../../../../../adr/2026-07-23-administration-http-client-compatibility-facade.md).
+The architectural rationale for the facade, and the decision to end the second transport, is documented in [One Axios transport behind the Administration HTTP client facade](../../../../../../../adr/2026-09-08-administration-single-axios-transport.md).
 
 ## Troubleshooting
 

--- a/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
+++ b/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
@@ -6,6 +6,8 @@ The Shopware Administration is moving from its legacy Axios 0.x client to Axios 
 
 To keep existing extensions working during the migration, the Administration temporarily contains both Axios versions behind a Shopware-owned HTTP client facade. Extension code continues to use the injected `httpClient`; it must not select or access an underlying Axios instance.
 
+Legacy Axios 0.x, the `useAxiosV1` switch and the `axios-v1` package alias are deprecated and are removed with Shopware 6.8. Complete the steps in this guide before upgrading to 6.8.
+
 The exact installed patch versions are implementation details and may change while the migration is in progress. This guide therefore refers to the clients as legacy Axios 0.x and Axios v1.
 
 ## Version selection
@@ -52,7 +54,7 @@ this.httpClient.get(url, {
 });
 ```
 
-Keep the explicit opt-in while validating Axios v1 on Shopware 6.7. Remove it after upgrading to a version where `V6_8_0_0` is active, because Axios v1 is then the default.
+Keep the explicit opt-in while validating Axios v1 on Shopware 6.7. Remove it after upgrading to a version where `V6_8_0_0` is active, because Axios v1 is then the default and the flag is removed with 6.8.
 
 ## Repository requests
 
@@ -194,7 +196,25 @@ httpClient.request({
 
 Avoid spreading this override across an extension. A widespread opt-out hides migration problems and makes later removal harder.
 
-Axios 0.x, the `useAxiosV1` switch, and structural `AxiosInstance` compatibility are transitional. Their removal will be announced through the release information and the applicable major upgrade guide. No specific removal release is promised by this guide.
+## Removal with Shopware 6.8
+
+Legacy Axios 0.x and the transitional compatibility surface are removed with Shopware 6.8:
+
+- The `useAxiosV1` request flag, in both directions
+- `httpClient.axiosV0`, `httpClient.axiosV1`, `httpClient.interceptorsV0`, `httpClient.interceptorsV1`, `httpClient.defaultsV0` and `httpClient.defaultsV1`
+- The `axios-v1` package alias; Axios 1.x is installed as `axios`
+- The `src/core/factory/http-client-adapter` module
+
+Structural `AxiosInstance` compatibility is no longer a goal after the removal. Depend on `HttpClient`, `HttpRequestConfig` and `HttpResponse` from `src/core/factory/http-client.types`.
+
+Checklist before upgrading to 6.8:
+
+1. Remove every `useAxiosV1: true`; Axios v1 is the default.
+2. Replace every `useAxiosV1: false` with Axios v1 compatible code, most often `AbortController` instead of `CancelToken`.
+3. Replace `axios-v1` imports with `axios`, or better, with Shopware's HTTP types.
+4. Replace access to `axiosV0`, `axiosV1`, `interceptorsV*` and `defaults*V*` with `httpClient.interceptors` and `httpClient.defaults`.
+
+The removal is documented in `UPGRADE-6.8.md`, section "Axios 1.x is the only HTTP client of the Administration".
 
 The architectural rationale for keeping both transports behind a Shopware-owned boundary is documented in [Keep Administration HTTP transports behind a compatibility facade](../../../../../../../adr/2026-07-23-administration-http-client-compatibility-facade.md).
 

--- a/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
+++ b/src/Administration/Resources/app/administration/technical-docs/09-security/axios-migration-guide.md
@@ -216,7 +216,19 @@ Checklist before upgrading to 6.8:
 1. Remove every `useAxiosV1: true`; Axios v1 is the default.
 2. Replace every `useAxiosV1: false` with Axios v1 compatible code, most often `AbortController` instead of `CancelToken`.
 3. Replace `axios-v1` imports with `axios`, or better, with Shopware's HTTP types.
-4. Replace access to `axiosV0`, `axiosV1`, `interceptorsV*` and `defaults*V*` with `httpClient.interceptors` and `httpClient.defaults`.
+4. Replace access to `axiosV0` and `axiosV1` with `httpClient` itself, and access to `interceptorsV*` and `defaults*V*` with `httpClient.interceptors` and `httpClient.defaults`.
+
+While both transports exist, `httpClient.interceptors.<request|response>.handlers` is a copy of the handler list rather than the array Axios runs, because the facade has to keep two handler stacks in sync. `use()`, `eject()`, `clear()` and assigning a whole element are mirrored onto both transports and behave as expected. Mutating a handler object in place does not:
+
+```javascript
+// Has no effect during 6.7: only the facade's copy is changed
+httpClient.interceptors.response.handlers[0].fulfilled = myWrapper;
+
+// Works in both versions
+const id = httpClient.interceptors.response.use(myWrapper);
+```
+
+From 6.8 on, `httpClient.interceptors` is the Axios interceptor manager itself and `handlers` is the list Axios runs.
 
 The removal is documented in `UPGRADE-6.8.md`, section "Axios 1.x is the only HTTP client of the Administration".
 


### PR DESCRIPTION
### 1. Why is this change necessary?

- Currently, Axios 0.x and 1.x are supported.
- Research showed that nearly no plugin is affected by a break migrating to 1.x
- the auto switch from 0.x to 1.x already breaks plugins
- 0.x has a lot of security issues
- Code needs to maintain 0.x and 1.x paths in parallel

### 2. What does this change do, exactly?

- Deprecates 0.x to be removed in 6.8 in upgrade.md and release_info
- adds deprecation markers all over the place
- Supersedes the previous ADR
- Also the `useAxiosV1` config gets deprecated

### 3. Describe each step to reproduce the issue or behaviour.

Nothing observable at runtime. In an editor, `useAxiosV1` and the escape hatches now render struck through:

```javascript
this.httpClient.get('/api/endpoint', { useAxiosV1: true });
//                                     ^^^^^^^^^^ deprecated tag:v6.8.0
```

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/shopware/issues/14041

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
  - Annotations and release documentation only. Existing HTTP client specs pass unchanged.
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

