### PR TITLE
feat: Allow crawling of thumbnails in `robots.txt`

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -435,6 +435,10 @@ The `assetFilter` computed of both components is deprecated for removal in v6.9.
 
 ## Storefront
 
+### `robots.txt` allows crawling thumbnails
+
+The default storefront `robots.txt` now contains `Allow: /thumbnail/*?ts=` alongside the existing rules `Disallow: /*?` and `Allow: /media/*?ts=` to allow crawling thumbnails by bots.
+
 ### Passive privacy notices without a checkbox
 
 Storefront privacy notices now use passive wording when `core.loginRegistration.requireDataProtectionCheckbox` is disabled. Contact and newsletter forms use the privacy-only snippet keys `contact.privacyNoticeTextModal` and `contact.privacyNoticeInformation`, while forms that include the terms of service use `general.privacyNoticeTextModal` and `general.privacyNoticeInformation`. Themes and custom snippet sets can override the new `*.privacyNoticeInformation` keys to adjust the non-blocking notice.

--- a/src/Storefront/Resources/views/storefront/page/robots/robots.txt.twig
+++ b/src/Storefront/Resources/views/storefront/page/robots/robots.txt.twig
@@ -27,6 +27,9 @@
 
                     {# Allow all media files to be indexed, including the GET requests with the cache buster #}
                     Allow: /media/*?ts=
+
+                    {# Allow all thumbnail files to be indexed, including the GET requests with the cache buster #}
+                    Allow: /thumbnail/*?ts=
                 {% endif %}
             {% endblock %}
 

--- a/tests/integration/Storefront/Controller/RobotsControllerTest.php
+++ b/tests/integration/Storefront/Controller/RobotsControllerTest.php
@@ -123,6 +123,8 @@ class RobotsControllerTest extends TestCase
 
         Allow: /media/*?ts=
 
+        Allow: /thumbnail/*?ts=
+
         Disallow: {$domainPath}/account/
         Disallow: {$domainPath}/checkout/
         Disallow: {$domainPath}/widgets/


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the crawling of thumbnails is not allowed, although they are referenced on the page, due to the cache buster get parameter.

### 2. What does this change do, exactly?
Allow crawling of thumbnails with cache buster.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
