### PR TITLE
fix(ci): remove duplicate permissions in npm-audit-check workflow

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -141,9 +141,6 @@ jobs:
           if-no-files-found: error
 
   report-scheduled-audit-failures:
-    permissions:
-      contents: read
-      issues: write
     name: Report scheduled audit failures
     if: ${{ always() && github.event_name == 'schedule' && needs.audit-packages.result == 'failure' }}
     needs: audit-packages


### PR DESCRIPTION
### 1. Why is this change necessary?

GitHub rejects `.github/workflows/npm-audit-check.yml` as invalid: the `report-scheduled-audit-failures` job defines `permissions` twice (`'permissions' is already defined`).

### 2. What does this change do, exactly?

Removes the first duplicate `permissions` block (`contents: read`, `issues: write`) and keeps the single merged block with `contents: read`, `id-token: write` (octo-sts project board write) and `issues: write`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open `.github/workflows/npm-audit-check.yml` on `trunk` and observe two `permissions` keys in the `report-scheduled-audit-failures` job.
2. GitHub reports `Invalid workflow file: .github/workflows/npm-audit-check.yml#L1 ('permissions' is already defined)`.
3. After the fix, `composer lint:actions` passes (yamlfmt, actionlint, zizmor with no findings).

### 4. Please link to the relevant issues (if any).

No related issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
