### PR TITLE
test(administration): expect deprecated Jest tests to fail under the major flag

### DIFF
--- a/adr/2026-08-06-administration-jest-feature-flag-helpers.md
+++ b/adr/2026-08-06-administration-jest-feature-flag-helpers.md
@@ -74,12 +74,16 @@ Three rules follow from this:
    ordinary `it()` carrying an `@deprecated` comment, not an `it.deprecated()`. The registered test
    name gains a `(removed in <version>)` suffix so legacy/v6.8 pairs do not share a title.
 
-   Two failure modes stay outside the inversion, because Jest can only invert what the test
-   callback itself throws:
+   Jest can only invert what the test callback itself throws, so the console guard cooperates: the
+   environment marks such a test, and `prepare_environment.js` stops asserting on console output and
+   unhandled rejections for it. A removed code path warning on its way out is part of the expected
+   failure, not a failure of its own — and the guard raises its own in `afterEach`, where the
+   inversion can no longer reach it.
 
-   - A failure raised from a hook — including the `console.warn`/`console.error` guard, which
-     asserts in `afterEach` — is reported as a plain failure. A deprecation warning that only
-     appears before the major therefore has to be silenced through `global.allowedErrors`.
+   Two things stay outside the inversion:
+
+   - A failure raised from a spec's own hook, and an error Vue throws asynchronously from its
+     scheduler — a crash on re-render rather than on mount. Both are reported as plain failures.
    - The test now runs where it used to be skipped, so state it leaves behind (a half-mounted
      component, a global) reaches its neighbours.
 

--- a/adr/2026-08-06-administration-jest-feature-flag-helpers.md
+++ b/adr/2026-08-06-administration-jest-feature-flag-helpers.md
@@ -47,7 +47,7 @@ Feature flags in Administration tests are declared on the test, not assigned ins
 // Runs with the flag active, in the default suite and the major suite alike.
 it.activeFeatureFlags(['v6.8.0.0'])('renders the meteor tabs', async () => { /* ... */ });
 
-// Skipped once the flag is active, because the behaviour it covers is gone by then.
+// Expected to fail once the flag is active, because the behaviour it covers is gone by then.
 // @deprecated tag:v6.8.0.0 - The test will be removed with the legacy sw-tabs branch.
 it.deprecated('v6.8.0.0')('renders the deprecated tabs', async () => { /* ... */ });
 
@@ -66,9 +66,22 @@ Three rules follow from this:
    that. Mounting a component with `provide.feature` inside a test that used
    `it.activeFeatureFlags()` now throws, because such a test can only pass for the wrong reason.
 
-3. **`it.deprecated()` means "this disappears with that version"**, not "this currently fails". It
-   marks a test whose subject is being removed, and the registered test name gains a
-   `(removed in <version>)` suffix so a skipped test explains itself in the reporter output.
+3. **`it.deprecated()` means "the flag removes the behaviour this asserts".** Once the flag is
+   active the test is registered through `it.failing`, so its failure is the expected result and a
+   test that still passes fails the suite instead. That is the point: a passing deprecated test
+   means the removal is not behind that version, so either the `removedIn` version names the wrong
+   flag or the assertion does not discriminate between the two worlds — in which case it is an
+   ordinary `it()` carrying an `@deprecated` comment, not an `it.deprecated()`. The registered test
+   name gains a `(removed in <version>)` suffix so legacy/v6.8 pairs do not share a title.
+
+   Two failure modes stay outside the inversion, because Jest can only invert what the test
+   callback itself throws:
+
+   - A failure raised from a hook — including the `console.warn`/`console.error` guard, which
+     asserts in `afterEach` — is reported as a plain failure. A deprecation warning that only
+     appears before the major therefore has to be silenced through `global.allowedErrors`.
+   - The test now runs where it used to be skipped, so state it leaves behind (a half-mounted
+     component, a global) reaches its neighbours.
 
 ## Consequences
 
@@ -77,6 +90,9 @@ belongs to, and both suites can be green at the same time.
 
 Deprecated tests become greppable. `@deprecated tag:v6.8.0` next to `it.deprecated('v6.8.0.0')`
 means the major cleanup is a search, not an audit.
+
+The major suite also audits the tags themselves: a deprecated test that keeps passing with the flag
+on is reported, rather than silently skipped until someone reads the file at cleanup time.
 
 The trade is that a test's flag context is no longer visible in its body — you have to read the `it`
 line. In exchange it is visible *everywhere*, including in hooks that run before the callback, which

--- a/src/Administration/Resources/app/administration/test/_setup/feature-flag-test-environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/feature-flag-test-environment.js
@@ -1,7 +1,7 @@
 /**
  * @sw-package framework
  *
- * Jest environment backing `it.activeFeatureFlags()`.
+ * Jest environment backing `it.activeFeatureFlags()` and `it.deprecated()`.
  *
  * Feature flags live in the mutable `global.activeFeatureFlags` array that the feature service mock
  * reads on every `isActive()` call. Activating them from inside a test callback is too late: setup
@@ -11,9 +11,10 @@
  *
  * The flow across three events:
  *
- * 1. `add_test`   — remember which flags a test was registered with (the helper leaves them in a
- *                   global slot for the duration of the synchronous `it()` call).
- * 2. `test_start` — merge them over the runner's baseline flags and publish, before any hook runs.
+ * 1. `add_test`   — remember what a test was registered with (the helper leaves it in a global slot
+ *                   for the duration of the synchronous `it()` call).
+ * 2. `test_start` — publish it before any hook runs: the flags merged over the runner's baseline,
+ *                   and whether the test is expected to fail.
  * 3. `test_done`  — restore the baseline, so the next test is unaffected.
  *
  * `test/_setup/jest-extensions.ts` is the author-facing half; this file is the plumbing.
@@ -23,65 +24,97 @@ const { TestEnvironment } = require('jest-environment-jsdom');
 
 const pendingFeatureFlagsSymbol = Symbol.for('shopware.pendingActiveFeatureFlags');
 const defaultActiveFeatureFlagsSymbol = Symbol.for('shopware.defaultActiveFeatureFlags');
+const pendingExpectedFailureSymbol = Symbol.for('shopware.pendingTestExpectsFailure');
+const expectedFailureSymbol = Symbol.for('shopware.currentTestExpectsFailure');
+
+const testFinishedEvents = [
+    'test_done',
+    'test_skip',
+    'test_todo',
+];
 
 class FeatureFlagTestEnvironment extends TestEnvironment {
     activeFeatureFlagsByTest = new WeakMap();
 
+    expectedFailureTests = new WeakSet();
+
     handleTestEvent(event, state) {
         if (event.name === 'add_test') {
-            // Read from the slot rather than the callback: it.each() hands its own wrapper to it(),
-            // so a property on the callback would not reach us for table-driven tests.
-            const featureFlags = this.global[pendingFeatureFlagsSymbol];
-            const registeredTest = state.currentDescribeBlock.tests.at(-1);
-
-            if (featureFlags && registeredTest) {
-                this.activeFeatureFlagsByTest.set(registeredTest, featureFlags);
-            }
+            this.rememberTestRegistration(state);
 
             return;
         }
 
         if (event.name === 'test_start') {
-            const featureFlags = this.activeFeatureFlagsByTest.get(event.test);
-
-            if (!featureFlags) {
-                return;
-            }
-
-            const defaultActiveFeatureFlags = this.global[defaultActiveFeatureFlagsSymbol] ?? [];
-            const activeFeatureFlags = [
-                ...new Set([
-                    ...defaultActiveFeatureFlags,
-                    ...featureFlags,
-                ]),
-            ];
-
-            // `activeFeatureFlags` is what the feature service mock reads. The extra
-            // `activeFeatureFlagsForCurrentTest` marker exists because prepare_environment.js resets
-            // `activeFeatureFlags` to the baseline in its own global `beforeEach`, which runs *after*
-            // this event — without the marker that reset would immediately undo the line below. It
-            // doubles as the "a helper is driving this test" signal for the feature mock shadowing
-            // check in the same file.
-            this.global.activeFeatureFlagsForCurrentTest = activeFeatureFlags;
-            this.global.activeFeatureFlags = activeFeatureFlags;
+            this.publishForTest(event.test);
 
             return;
         }
 
-        if (
-            ![
-                'test_done',
-                'test_skip',
-                'test_todo',
-            ].includes(event.name)
-        ) {
+        if (testFinishedEvents.includes(event.name)) {
+            this.restoreAfterTest(event.test);
+        }
+    }
+
+    /**
+     * Reads what the helper left in its global slots and attaches it to the test Jest just added.
+     *
+     * Reading the slots rather than the callback: `it.each()` hands its own wrapper to `it()`, so a
+     * property on the callback would not reach us for table-driven tests.
+     */
+    rememberTestRegistration(state) {
+        const registeredTest = state.currentDescribeBlock.tests.at(-1);
+
+        if (!registeredTest) {
             return;
         }
 
-        // Past this point the event is one of test_done / test_skip / test_todo, i.e. the test is
-        // finished. Only tests the helper registered flags for need restoring; everything else never
-        // had them changed.
-        if (!this.activeFeatureFlagsByTest.has(event.test)) {
+        const featureFlags = this.global[pendingFeatureFlagsSymbol];
+
+        if (featureFlags) {
+            this.activeFeatureFlagsByTest.set(registeredTest, featureFlags);
+        }
+
+        if (this.global[pendingExpectedFailureSymbol]) {
+            this.expectedFailureTests.add(registeredTest);
+        }
+    }
+
+    /** Publishes a test's flags and its expected-failure marker, before its first hook runs. */
+    publishForTest(test) {
+        if (this.expectedFailureTests.has(test)) {
+            this.global[expectedFailureSymbol] = true;
+        }
+
+        const featureFlags = this.activeFeatureFlagsByTest.get(test);
+
+        if (!featureFlags) {
+            return;
+        }
+
+        const defaultActiveFeatureFlags = this.global[defaultActiveFeatureFlagsSymbol] ?? [];
+        const activeFeatureFlags = [
+            ...new Set([
+                ...defaultActiveFeatureFlags,
+                ...featureFlags,
+            ]),
+        ];
+
+        // `activeFeatureFlags` is what the feature service mock reads. The extra
+        // `activeFeatureFlagsForCurrentTest` marker exists because prepare_environment.js resets
+        // `activeFeatureFlags` to the baseline in its own global `beforeEach`, which runs *after*
+        // this event — without the marker that reset would immediately undo the line below. It
+        // doubles as the "a helper is driving this test" signal for the feature mock shadowing
+        // check in the same file.
+        this.global.activeFeatureFlagsForCurrentTest = activeFeatureFlags;
+        this.global.activeFeatureFlags = activeFeatureFlags;
+    }
+
+    /** Undoes `publishForTest`. Only tests a helper drove were changed; everything else is left alone. */
+    restoreAfterTest(test) {
+        delete this.global[expectedFailureSymbol];
+
+        if (!this.activeFeatureFlagsByTest.has(test)) {
             return;
         }
 

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions-major-baseline.spec.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions-major-baseline.spec.ts
@@ -20,6 +20,7 @@ globalThis.activeFeatureFlags = [...majorFeatureFlags];
 
 describe('Jest feature flag extensions with a major baseline', () => {
     let deprecatedTestRan = false;
+    let noisyDeprecatedTestRan = false;
     let featureFlagsInSetup: string[] = [];
 
     beforeEach(() => {
@@ -32,6 +33,9 @@ describe('Jest feature flag extensions with a major baseline', () => {
 
         // eslint-disable-next-line jest/no-standalone-expect -- The inverted test runs, unlike a skipped one.
         expect(deprecatedTestRan).toBeTruthy();
+
+        // eslint-disable-next-line jest/no-standalone-expect -- Same, for the one that also writes to the console.
+        expect(noisyDeprecatedTestRan).toBeTruthy();
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the v6.8 major-baseline fixture.
@@ -40,6 +44,22 @@ describe('Jest feature flag extensions with a major baseline', () => {
 
         // Registered through `it.failing` because the flag is on, so this failure is the pass.
         expect(Shopware.Feature.isActive('v6.8.0.0')).toBeFalsy();
+    });
+
+    // @deprecated tag:v6.8.0 - The test will be removed with the v6.8 major-baseline fixture.
+    it.deprecated('v6.8.0.0')('counts console output during an expected failure as part of it', () => {
+        noisyDeprecatedTestRan = true;
+
+        // Removed code paths warn on their way out. Without the expected-failure marker the console
+        // guard turns this into a failure of its own, thrown from an `afterEach` where `it.failing`
+        // can no longer invert it.
+        console.warn('expected console.warn from a deprecated test that is expected to fail');
+
+        expect(Shopware.Feature.isActive('v6.8.0.0')).toBeFalsy();
+    });
+
+    it('clears the expected-failure marker once a deprecated test is done', () => {
+        expect(Reflect.get(globalThis, Symbol.for('shopware.currentTestExpectsFailure'))).toBeUndefined();
     });
 
     it.activeFeatureFlags(['EXPERIMENTAL_FEATURE'])('adds per-test flags without replacing the major baseline', () => {

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions-major-baseline.spec.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions-major-baseline.spec.ts
@@ -30,13 +30,16 @@ describe('Jest feature flag extensions with a major baseline', () => {
         // eslint-disable-next-line jest/no-standalone-expect -- Verifies the environment restores the baseline after teardown.
         expect(globalThis.activeFeatureFlags).toEqual(majorFeatureFlags);
 
-        // eslint-disable-next-line jest/no-standalone-expect -- Verifies the normalized major flag skipped the test.
-        expect(deprecatedTestRan).toBeFalsy();
+        // eslint-disable-next-line jest/no-standalone-expect -- The inverted test runs, unlike a skipped one.
+        expect(deprecatedTestRan).toBeTruthy();
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the v6.8 major-baseline fixture.
-    it.deprecated('v6.8.0.0')('skips a deprecated test for the normalized major flag', () => {
+    it.deprecated('v6.8.0.0')('inverts a deprecated test for the normalized major flag', () => {
         deprecatedTestRan = true;
+
+        // Registered through `it.failing` because the flag is on, so this failure is the pass.
+        expect(Shopware.Feature.isActive('v6.8.0.0')).toBeFalsy();
     });
 
     it.activeFeatureFlags(['EXPERIMENTAL_FEATURE'])('adds per-test flags without replacing the major baseline', () => {

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions.spec.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions.spec.ts
@@ -19,9 +19,9 @@ function readPendingFeatureFlags(): string[] {
 }
 
 function createTestFunctionSpy() {
-    // `it.skip` carries `each` in real Jest, so the spy has to as well.
+    // `it.failing` carries `each` in real Jest, so the spy has to as well.
     return Object.assign(jest.fn(), {
-        skip: Object.assign(jest.fn(), { each: jest.fn(() => jest.fn()) }),
+        failing: Object.assign(jest.fn(), { each: jest.fn(() => jest.fn()) }),
         each: jest.fn(() => jest.fn()),
     }) as unknown as jest.It;
 }
@@ -33,16 +33,16 @@ describe('Jest feature flag extensions', () => {
         createDeprecatedTest(testFunction)('v99.0.0.0')('deprecated test', jest.fn());
 
         expect(testFunction).toHaveBeenCalledWith('deprecated test (removed in v99.0.0.0)', expect.any(Function), undefined);
-        expect(testFunction.skip).not.toHaveBeenCalled();
+        expect(testFunction.failing).not.toHaveBeenCalled();
     });
 
-    it.activeFeatureFlags(['v6.8.0.0'])('skips a deprecated test when its major feature flag is active', () => {
+    it.activeFeatureFlags(['v6.8.0.0'])('expects a deprecated test to fail when its major feature flag is active', () => {
         const testFunction = createTestFunctionSpy();
 
         createDeprecatedTest(testFunction)('v6.8.0.0')('deprecated test', jest.fn());
 
         expect(testFunction).not.toHaveBeenCalled();
-        expect(testFunction.skip).toHaveBeenCalledWith(
+        expect(testFunction.failing).toHaveBeenCalledWith(
             'deprecated test (removed in v6.8.0.0)',
             expect.any(Function),
             undefined,
@@ -93,12 +93,12 @@ describe('Jest feature flag extensions', () => {
         );
     });
 
-    it.activeFeatureFlags(['v6.8.0.0'])('forwards each() to skip when the major feature flag is active', () => {
+    it.activeFeatureFlags(['v6.8.0.0'])('forwards each() to failing when the major feature flag is active', () => {
         const testFunction = createTestFunctionSpy();
 
         createDeprecatedTest(testFunction)('v6.8.0.0').each([['first']])('handles %s', jest.fn());
 
-        expect(testFunction.skip.each).toHaveBeenCalledWith([['first']]);
+        expect(testFunction.failing.each).toHaveBeenCalledWith([['first']]);
         expect(testFunction.each).not.toHaveBeenCalled();
     });
 
@@ -195,7 +195,7 @@ describe('Jest feature flag extensions', () => {
             expect(Shopware.Feature.isActive('v6.8.0.0')).toBe(true);
         });
 
-        // @deprecated tag:v6.8.0 - Asserts the pre-major baseline, so it cannot run once v6.8 is the default.
+        // @deprecated tag:v6.8.0 - Asserts the pre-major baseline, so it has to fail once v6.8 is the default.
         it.deprecated('v6.8.0.0')('is not visible to Shopware.Feature without the helper', () => {
             expect(Shopware.Feature.isActive('v6.8.0.0')).toBe(false);
         });

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions.spec.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions.spec.ts
@@ -6,6 +6,7 @@ import { mount } from '@vue/test-utils';
 import { createActiveFeatureFlagsTest, createDeprecatedTest } from './jest-extensions';
 
 const pendingFeatureFlagsSymbol = Symbol.for('shopware.pendingActiveFeatureFlags');
+const pendingExpectedFailureSymbol = Symbol.for('shopware.pendingTestExpectsFailure');
 
 const defaultActiveFeatureFlags =
     (Reflect.get(globalThis, Symbol.for('shopware.defaultActiveFeatureFlags')) as string[] | undefined) ?? [];
@@ -47,6 +48,34 @@ describe('Jest feature flag extensions', () => {
             expect.any(Function),
             undefined,
         );
+    });
+
+    it.activeFeatureFlags(['v6.8.0.0'])('marks a deprecated test as expected to fail while it registers', () => {
+        const testFunction = createTestFunctionSpy();
+        let markedAtRegistration: unknown;
+        (testFunction.failing as unknown as jest.Mock).mockImplementation(() => {
+            markedAtRegistration = Reflect.get(globalThis, pendingExpectedFailureSymbol);
+        });
+
+        createDeprecatedTest(testFunction)('v6.8.0.0')('deprecated test', jest.fn());
+
+        // The console guard reads this through the environment, so it has to be set while Jest adds
+        // the test, not while the test runs.
+        expect(markedAtRegistration).toBe(true);
+        // The slot must not outlive the registration, or the next plain it() would inherit it.
+        expect(Reflect.has(globalThis, pendingExpectedFailureSymbol)).toBeFalsy();
+    });
+
+    it('does not mark a deprecated test whose removal flag is inactive', () => {
+        const testFunction = createTestFunctionSpy();
+        let markedAtRegistration: unknown;
+        (testFunction as unknown as jest.Mock).mockImplementation(() => {
+            markedAtRegistration = Reflect.get(globalThis, pendingExpectedFailureSymbol);
+        });
+
+        createDeprecatedTest(testFunction)('v99.0.0.0')('deprecated test', jest.fn());
+
+        expect(markedAtRegistration).toBeUndefined();
     });
 
     it('keeps the removal version unshortened in the suffix', () => {

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions.ts
@@ -13,6 +13,7 @@ type EachRegister = (name: string, callback: jest.ProvidesCallback, timeout?: nu
 // invokes as (strings, ...values). Forward every argument so interpolated values are not dropped.
 type EachArgs = [table: EachTable] | [strings: TemplateStringsArray, ...values: unknown[]];
 const pendingFeatureFlagsSymbol = Symbol.for('shopware.pendingActiveFeatureFlags');
+const pendingExpectedFailureSymbol = Symbol.for('shopware.pendingTestExpectsFailure');
 
 function getActiveFeatureFlags(): string[] {
     return globalThis.activeFeatureFlags ?? [];
@@ -35,6 +36,24 @@ function withPendingFeatureFlags<T>(featureFlags: readonly string[], register: (
     }
 }
 
+/**
+ * Marks the tests registered by `register` as expected to fail.
+ *
+ * The environment picks this up on `add_test` and republishes it for the running test, which is what
+ * lets `prepare_environment.js` keep its console guard quiet for a test whose failure is the point.
+ * Same slot mechanism as `withPendingFeatureFlags`, for the same reason: `it.each` hands its own
+ * wrapper to `it()`, so a property on the callback would not survive a table.
+ */
+function withPendingExpectedFailure<T>(register: () => T): T {
+    Reflect.set(globalThis, pendingExpectedFailureSymbol, true);
+
+    try {
+        return register();
+    } finally {
+        Reflect.deleteProperty(globalThis, pendingExpectedFailureSymbol);
+    }
+}
+
 /** @private */
 export function createDeprecatedTest(testFunction: jest.It): jest.It['deprecated'] {
     return (removedIn: string) => {
@@ -43,24 +62,23 @@ export function createDeprecatedTest(testFunction: jest.It): jest.It['deprecated
             return normalizeFeatureFlag(featureFlag) === normalizedRemovedIn;
         });
         // Inverted instead of skipped: with the removal flag on, the behaviour the test asserts is
-        // gone, so the test still passing means `removedIn` names the wrong version. Jest cannot
-        // invert a failure that happens in `beforeEach`, so setup that breaks under the flag still
-        // reports as a plain failure.
+        // gone, so the test still passing means `removedIn` names the wrong version. Jest only
+        // inverts what the callback itself throws, so a throw from a spec's own `beforeEach` still
+        // reports as a plain failure; the console guard is covered by the marker below.
         const register = isRemoved ? testFunction.failing : testFunction;
+        const publish = isRemoved ? withPendingExpectedFailure : <T>(registerTest: () => T) => registerTest();
 
         // Applied before Jest interpolates `%s` and friends, so the suffix trails the whole title.
         const withSuffix = (name: string) => `${name} (removed in ${removedIn})`;
 
         const run = ((name: string, callback?: TestCallback, timeout?: number) => {
-            register(withSuffix(name), callback as jest.ProvidesCallback, timeout);
+            publish(() => register(withSuffix(name), callback as jest.ProvidesCallback, timeout));
         }) as jest.FeatureFlagTest;
 
         run.each = ((...eachArgs: EachArgs) =>
             (name: string, callback: jest.ProvidesCallback, timeout?: number) =>
-                (register.each as (...args: EachArgs) => EachRegister)(...eachArgs)(
-                    withSuffix(name),
-                    callback,
-                    timeout,
+                publish(() =>
+                    (register.each as (...args: EachArgs) => EachRegister)(...eachArgs)(withSuffix(name), callback, timeout),
                 )) as jest.It['each'];
 
         return run;

--- a/src/Administration/Resources/app/administration/test/_setup/jest-extensions.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/jest-extensions.ts
@@ -42,7 +42,11 @@ export function createDeprecatedTest(testFunction: jest.It): jest.It['deprecated
         const isRemoved = getActiveFeatureFlags().some((featureFlag) => {
             return normalizeFeatureFlag(featureFlag) === normalizedRemovedIn;
         });
-        const register = isRemoved ? testFunction.skip : testFunction;
+        // Inverted instead of skipped: with the removal flag on, the behaviour the test asserts is
+        // gone, so the test still passing means `removedIn` names the wrong version. Jest cannot
+        // invert a failure that happens in `beforeEach`, so setup that breaks under the flag still
+        // reports as a plain failure.
+        const register = isRemoved ? testFunction.failing : testFunction;
 
         // Applied before Jest interpolates `%s` and friends, so the suffix trails the whole title.
         const withSuffix = (name: string) => `${name} (removed in ${removedIn})`;

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -70,6 +70,7 @@ import findByPlaceholder from '../_helper_/find-by-placeholder';
 import CacheService from '../../src/app/service/cache.service';
 
 const defaultActiveFeatureFlagsSymbol = Symbol.for('shopware.defaultActiveFeatureFlags');
+const expectedFailureSymbol = Symbol.for('shopware.currentTestExpectsFailure');
 global[defaultActiveFeatureFlagsSymbol] = [...global.activeFeatureFlags];
 
 // initialize the Stores
@@ -726,6 +727,14 @@ beforeEach(() => {
 // eslint-disable-next-line jest/require-top-level-describe
 afterEach(() => {
     hasActiveTest = false;
+
+    // A test registered through `it.deprecated()` under its removal flag is expected to fail, so its
+    // console output and rejections belong to that failure. Jest inverts only what the callback
+    // throws, and this hook runs too late to be inverted. The `beforeEach` above resets every flag
+    // read below, so leaving them set cannot reach the next test.
+    if (global[expectedFailureSymbol]) {
+        return;
+    }
 
     if (unhandledRejectionError) {
         const rejectionError = unhandledRejectionError;

--- a/src/Administration/Resources/app/administration/test/_setup/test-utils.d.ts
+++ b/src/Administration/Resources/app/administration/test/_setup/test-utils.d.ts
@@ -29,9 +29,10 @@ declare global {
 
         interface It {
             /**
-             * Skip this test when the given major feature flag is active. The registered test name
-             * gains a ` (removed in <removedIn>)` suffix, so a skip explains itself in the reporter
-             * output and legacy/v6.8 pairs do not share a title.
+             * Expect this test to fail when the given major feature flag is active — the behaviour
+             * it asserts is gone by then, so a test that still passes means `removedIn` names the
+             * wrong version. The registered test name gains a ` (removed in <removedIn>)` suffix,
+             * so legacy/v6.8 pairs do not share a title.
              */
             deprecated(removedIn: string): FeatureFlagTest;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

This is Administration Jest test infrastructure, and it carries two problems around one helper.

**A skipped test never checks its own tag.**

`it.deprecated('v6.8.0.0')` marks a test whose subject the next major removes. It skipped the test once that major flag was active.

A skipped test proves nothing. Nothing verifies that the version on the tag is the version that actually removes what the test asserts. A wrong tag stays hidden until someone reads the file during the major cleanup.

**The console guard decided the verdict instead of the test.**

`prepare_environment.js` records console output during a test and asserts on it in an `afterEach`. Jest can only invert what a test callback throws. So a deprecation warning on the way out of a removed code path failed the test from that hook, with a message that says nothing about the tag:

```
● should pass the "resizeWidth" prop to sw-popover-deprecated when feature flag is disabled and deprecated resizeWidth is set (removed in v6.8.0.0)

  Error: Unexpected console.warn: [sw-popover] The "resizeWidth" prop is deprecated and will be removed in v6.8.0. Please use "match-reference-width" instead.
      at Object.global.console.warn (test/_setup/prepare_environment.js:689:19)
      at Proxy.warn (src/app/component/utils/sw-popover/index.ts:58:34)
```

That test's own assertions do fail under the flag, which is the result the tag asks for. The warning hid it and pointed at an `allowedErrors` entry instead.

### 2. What does this change do, exactly?

- `it.deprecated()` registers through `it.failing` instead of `it.skip` once the removal flag is active. The failure becomes the expected result, and a deprecated test that still passes fails the suite.
- The Jest environment publishes an expected-failure marker for such a test, next to the feature flags it already publishes for it.
- `prepare_environment.js` returns early from its console guard while that marker is set. This covers all three of its assertions: unhandled rejection, `console.error`, `console.warn`. The output still prints.
- ADR rule 3 now states the contract. `it.deprecated()` means the flag removes the behaviour the test asserts. A test whose assertions hold in both worlds is an ordinary `it()` carrying an `@deprecated` comment.

Two things stay outside the inversion, both recorded in the ADR: a throw from a spec's own hook, and an error Vue throws asynchronously from its scheduler.

**to be followed up** the major suite is red on 15 tests with this PR. That is the audit output of the change, and #20254 stacks on top to clear it:

- 4 name a version that does not remove them. `sw-loader` and `sw-skeleton-bar` switch on `ENABLE_METEOR_COMPONENTS`, the `sw-cms` text config pair on `METEOR_TEXT_EDITOR`.
- 11 assert something that holds with the flag on and off alike.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
composer admin:unit:major
```

Before, every deprecated test is skipped. After, a deprecated test that still passes reports:

```
● src/app/component/meteor/sw-meteor-card › should render the tabs (removed in v6.8.0.0)

  Error: Failing test passed even though it was supposed to fail. Remove `.failing` to remove error.
```

`composer admin:unit` is unaffected. Nothing marks a test as expected to fail while the removal flag is off.

### 4. Please link to the relevant issues (if any).

Follow-up: #20254

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes stay untouched: this is test infrastructure, with no surface an extension author can reach.

