### PR TITLE
test(administration): retag deprecated Jest tests the major flag does not remove

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -89,7 +89,7 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it.deprecated('v6.8.0.0')('should not render tabs in card section', async () => {
+    it('should not render the deprecated tabs in card section', async () => {
         Shopware.Store.get('extensionComponentSections').addSection({
             component: 'card',
             positionId: 'test-position',

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -88,23 +88,6 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
         Shopware.Store.get('extensionComponentSections').identifier = {};
     });
 
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it('should not render the deprecated tabs in card section', async () => {
-        Shopware.Store.get('extensionComponentSections').addSection({
-            component: 'card',
-            positionId: 'test-position',
-            props: {
-                title: 'test-card',
-                subtitle: 'test-card-description',
-            },
-        });
-
-        wrapper = await createWrapper();
-        await flushPromises();
-
-        expect(wrapper.find('.sw-tabs').exists()).toBe(false);
-    });
-
     it.activeFeatureFlags(['v6.8.0.0'])('should not render tabs in card section', async () => {
         Shopware.Store.get('extensionComponentSections').addSection({
             component: 'card',

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/sw-many-to-many-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/sw-many-to-many-select.spec.js
@@ -65,7 +65,6 @@ const createSelect = async (
 };
 
 describe('components/sw-entity-many-to-many-select', () => {
-    // @deprecated tag:v6.8.0 - The test will be removed with sw-entity-many-to-many-select.
     it('should use the provided associations in the criteria', async () => {
         const criteria = new Criteria(1, 25);
         criteria.addAssociation('testAssociation');

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/sw-many-to-many-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/sw-many-to-many-select.spec.js
@@ -66,7 +66,7 @@ const createSelect = async (
 
 describe('components/sw-entity-many-to-many-select', () => {
     // @deprecated tag:v6.8.0 - The test will be removed with sw-entity-many-to-many-select.
-    it.deprecated('v6.8.0.0')('should use the provided associations in the criteria', async () => {
+    it('should use the provided associations in the criteria', async () => {
         const criteria = new Criteria(1, 25);
         criteria.addAssociation('testAssociation');
         const entityCollection = getCollection();

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
@@ -1726,7 +1726,7 @@ describe('src/app/component/form/sw-custom-field-set-renderer', () => {
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it.deprecated('v6.8.0.0')('should load custom fields for the initial deprecated tab', async () => {
+    it('should load custom fields for the initial deprecated tab', async () => {
         const sportsId = uuid.get('custom_sports');
 
         wrapper = await createWrapper({

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
@@ -1725,8 +1725,7 @@ describe('src/app/component/form/sw-custom-field-set-renderer', () => {
         expect(wrapper.find('.sw-tab--name-custom_clothing').text()).toContain('Clothing');
     });
 
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it('should load custom fields for the initial deprecated tab', async () => {
+    it('should load custom fields for the initial tab', async () => {
         const sportsId = uuid.get('custom_sports');
 
         wrapper = await createWrapper({

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
@@ -302,7 +302,6 @@ describe('components/form/sw-text-editor/sw-text-editor-link-menu', () => {
         },
     );
 
-    // @deprecated tag:v6.8.0 - The test will be removed with sw-text-editor-link-menu.
     it('parses product detail links and reacts to changes correctly', async () => {
         const wrapper = await createWrapper({
             value: `${seoDomainPrefix}/detail/aaaaaaa524604ccbad6042edce3ac799#`,

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
@@ -303,7 +303,7 @@ describe('components/form/sw-text-editor/sw-text-editor-link-menu', () => {
     );
 
     // @deprecated tag:v6.8.0 - The test will be removed with sw-text-editor-link-menu.
-    it.deprecated('v6.8.0.0')('parses product detail links and reacts to changes correctly', async () => {
+    it('parses product detail links and reacts to changes correctly', async () => {
         const wrapper = await createWrapper({
             value: `${seoDomainPrefix}/detail/aaaaaaa524604ccbad6042edce3ac799#`,
             type: 'detail',

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.spec.js
@@ -240,9 +240,6 @@ describe('src/app/component/meteor/sw-meteor-card', () => {
                         'sw-extension-component-section': true,
                         'router-link': true,
                     },
-                    provide: {
-                        feature: createFeatureMock(),
-                    },
                 },
             },
         );

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
@@ -312,14 +312,6 @@ describe('src/app/component/meteor/sw-meteor-page', () => {
         },
     );
 
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it('should not render the deprecated tabs when slot is empty', async () => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-
-        expect(wrapper.find('.sw-tabs__content').exists()).toBe(false);
-    });
-
     it.activeFeatureFlags(['v6.8.0.0'])('should not render the tabs when slot is empty', async () => {
         const wrapper = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
@@ -313,7 +313,7 @@ describe('src/app/component/meteor/sw-meteor-page', () => {
     );
 
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-tabs branch.
-    it.deprecated('v6.8.0.0')('should not render the tabs when slot is empty', async () => {
+    it('should not render the deprecated tabs when slot is empty', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader/sw-loader.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader/sw-loader.spec.js
@@ -19,7 +19,8 @@ async function createWrapper(additionalOptions = {}) {
 
 describe('src/app/component/base/sw-loader', () => {
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-loader implementation.
-    it.deprecated('v6.8.0.0')('should render the deprecated sw-loader', async () => {
+    // The switch to mt-loader is ENABLE_METEOR_COMPONENTS, which v6.8 does not set.
+    it('should render the deprecated sw-loader', async () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.html()).toContain('sw-loader-deprecated');

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader/sw-loader.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader/sw-loader.spec.js
@@ -18,7 +18,6 @@ async function createWrapper(additionalOptions = {}) {
 }
 
 describe('src/app/component/base/sw-loader', () => {
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-loader implementation.
     // The switch to mt-loader is ENABLE_METEOR_COMPONENTS, which v6.8 does not set.
     it('should render the deprecated sw-loader', async () => {
         const wrapper = await createWrapper();

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar/sw-skeleton-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar/sw-skeleton-bar.spec.js
@@ -17,7 +17,6 @@ async function createWrapper(additionalOptions = {}) {
 }
 
 describe('src/app/component/base/sw-skeleton-bar', () => {
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-skeleton-bar implementation.
     // The switch to mt-skeleton-bar is ENABLE_METEOR_COMPONENTS, which v6.8 does not set.
     it('should render the deprecated skeleton-bar', async () => {
         const wrapper = await createWrapper();

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar/sw-skeleton-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar/sw-skeleton-bar.spec.js
@@ -18,7 +18,8 @@ async function createWrapper(additionalOptions = {}) {
 
 describe('src/app/component/base/sw-skeleton-bar', () => {
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-skeleton-bar implementation.
-    it.deprecated('v6.8.0.0')('should render the deprecated skeleton-bar', async () => {
+    // The switch to mt-skeleton-bar is ENABLE_METEOR_COMPONENTS, which v6.8 does not set.
+    it('should render the deprecated skeleton-bar', async () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.html()).toContain('sw-skeleton-bar-deprecated');

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
@@ -256,12 +256,18 @@ describe('core/factory/http.factory.js', () => {
     });
 
     // @deprecated tag:v6.8.0 - Axios v1 becomes the default client.
-    it('should opt in to axios v1 per request', async () => {
+    it.deprecated('v6.8.0.0')('should opt in to axios v1 per request before v6.8', async () => {
         const { client, axiosV0, axiosV1: axiosV1Client } = createHTTPClientWithSpies();
         const axiosV0Request = jest.spyOn(axiosV0, 'request');
         const axiosV1Request = jest.spyOn(axiosV1Client, 'request');
         const clientMock = new MockAdapter(client);
+        clientMock.onPost('/test-without-flag').reply(200, { success: true });
         clientMock.onPost('/test-with-flag').reply(200, { success: true });
+
+        await client.post('/test-without-flag', { data: 'test' });
+
+        // Opting in is the only way to reach v1 before the major, so v0 has to answer the default.
+        expect(axiosV0Request).toHaveBeenCalledTimes(1);
 
         const response = await client.post(
             '/test-with-flag',
@@ -272,7 +278,6 @@ describe('core/factory/http.factory.js', () => {
         );
 
         expect(response.data).toEqual({ success: true });
-        expect(axiosV0Request).not.toHaveBeenCalled();
         expect(axiosV1Request).toHaveBeenCalledTimes(1);
     });
 

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
@@ -256,7 +256,7 @@ describe('core/factory/http.factory.js', () => {
     });
 
     // @deprecated tag:v6.8.0 - Axios v1 becomes the default client.
-    it.deprecated('v6.8.0.0')('should opt in to axios v1 per request before v6.8', async () => {
+    it('should opt in to axios v1 per request', async () => {
         const { client, axiosV0, axiosV1: axiosV1Client } = createHTTPClientWithSpies();
         const axiosV0Request = jest.spyOn(axiosV0, 'request');
         const axiosV1Request = jest.spyOn(axiosV1Client, 'request');
@@ -277,7 +277,7 @@ describe('core/factory/http.factory.js', () => {
     });
 
     // @deprecated tag:v6.8.0 - Axios v1 becomes the default client.
-    it.deprecated('v6.8.0.0')('should support the axios URL and config call form', async () => {
+    it('should support the axios URL and config call form', async () => {
         const { client, axiosV0, axiosV1: axiosV1Client } = createHTTPClientWithSpies();
         const axiosV0Request = jest.spyOn(axiosV0, 'request');
         const axiosV1Request = jest.spyOn(axiosV1Client, 'request').mockResolvedValue({ data: { success: true } });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
@@ -147,7 +147,7 @@ describe('src/module/sw-cms/elements/text/config', () => {
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy CMS text editor.
-    it.deprecated('v6.8.0.0')('should emits element-update when trigger @input event', async () => {
+    it('should emit element-update on @input from the legacy editor', async () => {
         const wrapper = await createWrapper();
 
         const updatedContent = 'Updated content';
@@ -212,7 +212,7 @@ describe('src/module/sw-cms/elements/text/config', () => {
     );
 
     // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-text-editor blur integration.
-    it.deprecated('v6.8.0.0')('should emits element-update when trigger @blur event', async () => {
+    it('should emit element-update on @blur from the legacy editor', async () => {
         const wrapper = await createWrapper();
 
         const updatedContent = 'Updated content';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
@@ -146,25 +146,6 @@ describe('src/module/sw-cms/elements/text/config', () => {
         expect(wrapper.find('.sw-cms-el-config-text__tab-settings').exists()).toBe(true);
     });
 
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy CMS text editor.
-    it('should emit element-update on @input from the legacy editor', async () => {
-        const wrapper = await createWrapper();
-
-        const updatedContent = 'Updated content';
-
-        const input = wrapper.find('input[type="text"]');
-        await input.setValue(updatedContent);
-
-        expect(input.element.value).toBe(updatedContent);
-
-        await input.trigger('input');
-        await wrapper.vm.$nextTick();
-
-        expect(wrapper.vm.element.config.content.value).toBe(updatedContent);
-        expect(wrapper.emitted('element-update')).toBeTruthy();
-        expect(wrapper.emitted()['element-update'][0][0]).toEqual(wrapper.vm.element);
-    });
-
     it.activeFeatureFlags([
         'v6.8.0.0',
         'METEOR_TEXT_EDITOR',
@@ -210,25 +191,6 @@ describe('src/module/sw-cms/elements/text/config', () => {
             expect(wrapper.emitted()['element-update'][0][0]).toEqual(wrapper.vm.element);
         },
     );
-
-    // @deprecated tag:v6.8.0 - The test will be removed with the legacy sw-text-editor blur integration.
-    it('should emit element-update on @blur from the legacy editor', async () => {
-        const wrapper = await createWrapper();
-
-        const updatedContent = 'Updated content';
-
-        const input = wrapper.find('input[type="text"]');
-        await input.setValue(updatedContent);
-
-        expect(input.element.value).toBe(updatedContent);
-
-        await input.trigger('blur');
-        await wrapper.vm.$nextTick();
-
-        expect(wrapper.vm.element.config.content.value).toBe(updatedContent);
-        expect(wrapper.emitted('element-update')).toBeTruthy();
-        expect(wrapper.emitted()['element-update'][0][0]).toEqual(wrapper.vm.element);
-    });
 
     // Covers the default major-suite combination (v6.8 tabs + legacy editor, METEOR_TEXT_EDITOR off).
     // Remove with sw-text-editor.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.spec.js
@@ -13,6 +13,10 @@ const logEntryMock = {
     context: {
         additionalData: {
             recipients: [],
+            contents: {
+                'text/html': '<p>Mail content</p>',
+                'text/plain': 'Mail content',
+            },
         },
     },
 };
@@ -104,15 +108,6 @@ describe('src/module/sw-settings-logging/page/sw-settings-logging-list', () => {
             displayedLog: {
                 ...logEntryMock,
                 message: 'mail.sent',
-                context: {
-                    additionalData: {
-                        recipients: [],
-                        contents: {
-                            'text/html': '<p>Mail content</p>',
-                            'text/plain': 'Mail content',
-                        },
-                    },
-                },
             },
         });
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
@@ -421,11 +421,11 @@ describe('module/sw-settings/page/sw-settings-index', () => {
      * @deprecated tag:v6.8.0 - Will be removed
      */
     // @deprecated tag:v6.8.0 - The test will be removed with the settings rename banner.
-    it('should toggle banner visibility and save config', async () => {
+    it.deprecated('v6.8.0.0')('should toggle banner visibility and save config', async () => {
         Shopware.Service('userConfigService').search.mockResolvedValueOnce({
             data: {
                 'settings.hideRenameBanner': {
-                    value: true,
+                    value: false,
                 },
             },
         });
@@ -433,7 +433,7 @@ describe('module/sw-settings/page/sw-settings-index', () => {
 
         await flushPromises();
 
-        expect(wrapper.vm.hideSettingRenameBanner).toBe(true);
+        expect(wrapper.vm.hideSettingRenameBanner).toBe(false);
 
         await wrapper.vm.onCloseSettingRenameBanner();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
@@ -394,6 +394,7 @@ describe('module/sw-settings/page/sw-settings-index', () => {
 
         await flushPromises();
 
+        expect(Shopware.Service('userConfigService').search).toHaveBeenCalledWith(['settings.hideRenameBanner']);
         expect(wrapper.vm.hideSettingRenameBanner).toBe(true);
     });
 
@@ -420,7 +421,7 @@ describe('module/sw-settings/page/sw-settings-index', () => {
      * @deprecated tag:v6.8.0 - Will be removed
      */
     // @deprecated tag:v6.8.0 - The test will be removed with the settings rename banner.
-    it.deprecated('v6.8.0.0')('should toggle banner visibility and save config', async () => {
+    it('should toggle banner visibility and save config', async () => {
         Shopware.Service('userConfigService').search.mockResolvedValueOnce({
             data: {
                 'settings.hideRenameBanner': {
@@ -445,7 +446,7 @@ describe('module/sw-settings/page/sw-settings-index', () => {
     });
 
     // @deprecated tag:v6.8.0 - The test will be removed with the settings rename notice.
-    it.deprecated('v6.8.0.0')('provides the change notices with the version they can be removed with', async () => {
+    it('provides the change notices with the version they can be removed with', async () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.changeNotices).toEqual([


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow-up to #20253, which registers a deprecated Administration test through `it.failing` once its removal flag is active. That left 15 tests red in the major suite:

```
● src/app/component/meteor/sw-meteor-card › should render the tabs (removed in v6.8.0.0)

  Error: Failing test passed even though it was supposed to fail. Remove `.failing` to remove error.
```

All 15 pass with v6.8 as the default. Their tag claims a removal that the flag does not perform.

**Three hid a defect in the test itself.**

- `sw-meteor-card` "should render the tabs" mounts with `provide: { feature: createFeatureMock() }`. The local mock shadows the global feature service, so the card renders its legacy tabs whatever the suite has active.
- `sw-settings-index` "should hide banner when config is set to true" asserts `hideSettingRenameBanner` is `true`, which is also the component's `data` default. v6.8 skips reading the user config, and the assertion holds anyway.
- `sw-settings-logging-list` "should load dynamic modal component" sets a log entry without `context.additionalData.contents`. The v6.8 mail modal renders those, so the test crashes during the re-render `setData` triggers instead of failing an assertion. That crash reaches Jest as an uncaught error, outside the inversion, and the next test then fails unmounting what it left behind.

**Twelve assert something both worlds satisfy.**

`sw-loader` and `sw-skeleton-bar` switch to their `mt-*` implementation on `ENABLE_METEOR_COMPONENTS`, which is not a registered feature flag, so v6.8 leaves the deprecated implementation in place. The `sw-cms` text config pair switches on `METEOR_TEXT_EDITOR`, a separate non-major flag. The rest assert an absent selector staying absent, or data with no flag branch behind it.

### 2. What does this change do, exactly?

Each of the 15 reaches one of three ends.

**Deleted (4).** The v6.8 test next to them covers the same scenario in the world that survives: the empty-slot tab assertions in `sw-meteor-page` and `sw-extension-component-section`, and the legacy editor pair in the `sw-cms` text config.

**Sharpened, tag kept (4).** The three defects above, plus `http.factory`, which now asserts that the default request lands on axios v0. That is what opting in per request is for before v1 becomes the default. `sw-settings-index` starts from a visible banner, a state v6.8 never reaches because it skips reading the user config.

**Ordinary `it()` (7).** Five also lose their `@deprecated tag:v6.8.0` comment, because v6.8 does not take the test with it: the two `ENABLE_METEOR_COMPONENTS` wrappers, the `sw-entity-many-to-many-select` and `sw-text-editor-link-menu` specs (deleted with the components they cover, which carry the annotation themselves), and `sw-custom-field-set-renderer`, which loads the initial set's custom fields in both branches and loses the word deprecated from its title too. The remaining two keep the comment: they live in spec files that survive v6.8 and hold an assertion the major invalidates.

`sw-settings-index` renders `changeNotices` through `sw-dismissible-notices` without a flag branch, so with v6.8 active the settings page does show a notice that is obsolete by then. Filtering the list in the component would fix that and break the tripwire test one line below it, which is red exactly while an arrived notice is still in the list. That guard is the mechanism that gets the entry deleted before v6.8 ships, so the component keeps its list as is.

**nit:** `sw-loader` and `sw-skeleton-bar` warn that they are removed in v6.8:

```
The old usage of "sw-loader" is deprecated and will be removed in v6.8.0.0. Please use "mt-loader" instead.
```

Their switch is `ENABLE_METEOR_COMPONENTS`, and no such flag exists in `feature.yaml`. So both keep rendering the deprecated implementation with v6.8 active, and the warning stays wrong until someone points the switch at the major flag. Out of scope here: this PR moves no production code.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
composer admin:unit:major
```

Green on the 40 spec files that use `it.deprecated`:

```
Test Suites: 40 passed, 40 total
Tests:       3 skipped, 736 passed, 739 total
```

`composer admin:unit` is unaffected.

### 4. Please link to the relevant issues (if any).

Stacked on #20253.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Both suites were run over every spec file that uses `it.deprecated`. Release notes and docs stay untouched: the contract these tests follow is written down in #20253, and this PR only moves tests.

