### PR TITLE
docs: add adr for an optional contact person on commercial accounts

### DIFF
--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -7,24 +7,32 @@ tags: [customer, validation, documents, payment]
 
 ## Context
 
-A commercial customer often has no single contact person. Purchasing runs through a shared mailbox, orders are placed by whoever is on shift, and the company name is the identity that matters. Shopware requires `firstName` and `lastName` on every customer, so those shops type `-`, `.`, or the company name twice to get past the register form. Issue [#15321](https://github.com/shopware/shopware/issues/15321) asks for the contact person to become optional.
+Registering a commercial account always requires a first and last name. A company that buys through a shared mailbox has no single contact person to enter, so those shops type `-`, `.`, or the company name twice to get past the form. Issue [#15321](https://github.com/shopware/shopware/issues/15321) asks for the contact person to become optional.
 
-Dropping the two `NotBlank` constraints is a two line change. The reason this needs an ADR is what happens next.
-
-`firstName` and `lastName` are the de facto identity of a customer everywhere. The storefront greets with them in `sidebar.html.twig`, the Administration customer list sorts on `lastName,firstName`, mail templates stored in the shop database address them directly, and `ZugferdDocument::withBuyerInformation()` prints them as the e-invoice buyer. Around nine places in Core already branch on `accountType === 'business'`, and each of them builds a name from those two columns on its own. Nothing in the system answers "what is this customer called" in one place.
-
-Two earlier attempts made that concrete. A Core attempt and a plugin attempt both went through several review rounds that kept producing the same two failures: a form that permits what the backend rejects, and a display that goes blank because one consumer was missed. The storefront account greeting rendered as "Hello" with nothing after it for the whole life of one of those branches, invisible to sixty passing unit tests.
-
-So the work is not "make two fields optional". It is "give the system one answer for a customer's name, then make the fields optional".
+We want the shop to decide. A merchant should be able to say that commercial accounts need a contact person, may leave it empty, or do not get the fields at all, and the company name should take over as the identity when there is none. Dropping the two `NotBlank` constraints is the small part. `firstName` and `lastName` are what the storefront greets, the Administration sorts by, mail templates address and e-invoices print, and no single place in the system answers what a customer is called.
 
 ## Decision
 
-Keep both columns `NOT NULL` and both fields `Required`. Add `AllowEmptyString` beside `Required` on `firstName` and `lastName` for `customer`, `customer_address`, `order_customer` and `order_address`. `StringFieldSerializer::getConstraints()` then yields `NotNull` instead of `NotBlank`, so an empty string becomes a legal value while `null` stays rejected.
+Add two settings that make the contact person flexible for commercial accounts, and one resolved name that every consumer reads instead of concatenating the two columns.
 
-Add a runtime field to `CustomerDefinition` that resolves the name a consumer should render, filled by a subscriber on `customer.loaded`:
+```
+core.loginRegistration.showNameFieldsForCompanyAccounts
+core.loginRegistration.nameFieldsRequiredForCompanyAccounts
+```
+
+Both default to on, so nothing changes until a merchant switches one off. A hidden field is never required, so the first implies the second. The whole feature is gated on `core.loginRegistration.showAccountTypeSelection`: with that off the names stay mandatory and both switches are hidden.
+
+To achieve this we touch the following scopes.
+
+### Data model
+
+`firstName` and `lastName` on `customer`, `customer_address`, `order_customer` and `order_address` get `AllowEmptyString` beside `Required`. `StringFieldSerializer::getConstraints()` then yields `NotNull` instead of `NotBlank`, so an empty string becomes legal while `null` stays rejected. The columns stay `NOT NULL`.
+
+### Customer identity
+
+`CustomerDefinition` gets a runtime field, filled by a subscriber on `customer.loaded`:
 
 ```php
-// CustomerDefinition::defineFields()
 (new StringField('display_name', 'displayName'))->addFlags(new ApiAware(), new Runtime()),
 
 // CustomerDisplayNameSubscriber
@@ -39,20 +47,15 @@ if ($personName === '' && $customer->getAccountType() === CustomerEntity::ACCOUN
 $customer->setDisplayName($personName);
 ```
 
-The company stands in only when there is no person name, so a commercial account that has a contact person keeps showing that person. An existing shop sees no change.
+The company stands in only when there is no person name, so a commercial account that has a contact person keeps showing that person.
 
-Two settings sit in `Settings > Login & Registration` beside the account type selection, both defaulting to on:
+### Validation
 
-* `core.loginRegistration.showNameFieldsForCompanyAccounts`
-* `core.loginRegistration.nameFieldsRequiredForCompanyAccounts`
+`RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute` and `CheckoutConfirmPageLoader` resolve the effective account type from the request first and the authenticated customer second, because the profile and address forms omit it whenever the account type selection is hidden. Once the names are optional the company gains a `NotBlank` on the write paths, with a trimming normalizer guarded by `is_string()` because `HappyPathValidator` calls normalizers without checking the type. The confirm page relaxes the names but does not require a company, so an address stored before the setting was switched on cannot block checkout.
 
-A hidden field is never required, so the first implies the second. The whole feature is gated on `core.loginRegistration.showAccountTypeSelection`. With that off, the names stay mandatory and both switches are hidden.
+### Orders and documents
 
-### Scope
-
-**Validation.** `RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute` and `CheckoutConfirmPageLoader` resolve the effective account type from the request first and the authenticated customer second, because the profile and address forms omit it whenever the account type selection is hidden. Once the names are optional the company gains a `NotBlank` on the write paths, with a trimming normalizer that guards for `is_string()` because `HappyPathValidator` calls normalizers without checking the type. The confirm page relaxes the names but does not require a company, so an address stored before the setting was switched on cannot block checkout.
-
-**Orders and documents.** `CustomerTransformer` writes the company into the order snapshot when there is no person name. Both document renderers move to one shared formatter:
+`CustomerTransformer` writes the company into the order snapshot when there is no person name. `ZugferdDocument` and `TradePartyView` move to one shared formatter:
 
 ```php
 $personName = trim($firstName . ' ' . $lastName);
@@ -65,30 +68,30 @@ if ($company === '' || $company === $personName) {
 return $personName === '' ? $company : $personName . ' - ' . $company;
 ```
 
-**Mail.** A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately.
+### Mail
 
-**Storefront.** The name fields follow the account type `<select>` through a small plugin that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
+A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately. Templates live in the shop database, so they keep addressing `customer.firstName` and `customer.lastName`.
 
-**Administration.** The two name fields become optional only when both settings allow it, the account level company becomes editable rather than only copied from the address, and the customer and order lists read the resolved name.
+### Storefront
+
+The name fields follow the account type `<select>` through a small plugin that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
+
+### Administration
+
+The two name fields become optional only when both settings allow it. The account level company becomes editable rather than only copied from the address, and the customer and order lists read the resolved name.
 
 ## Consequences
 
-The data abstraction layer stops guarding against an empty contact person. That guard now lives in the store API validation definitions, which means the Admin API and direct repository writes accept an empty name for private accounts too. An entity extension sees the field definition, never the row or the configuration, so the relaxation cannot be made conditional. Extensions that relied on the layer rejecting an empty name have to validate it themselves.
+What the API accepts after this change:
 
-Sorting and searching stay on the stored columns. A runtime field cannot be sorted or searched by, and the Administration customer list column is `dataIndex: 'lastName,firstName'`, so a commercial account without a contact person displays as its company but sorts as an empty name and clusters at one end of the list. Search still finds it through `company`, which carries `SearchRanking::HIGH`. We take this over a stored column, which would need a migration, a backfill, write path logic on four entities, and would drift the moment anything writes a name outside the DAL.
+* An empty string on `firstName` and `lastName` for `customer`, `customer_address`, `order_customer` and `order_address`, on every write path. That includes the Admin API, the Sync API and direct repository writes, and it applies to private accounts too. An entity extension sees the field definition, never the row or the configuration, so the relaxation cannot be conditional. `null` is still rejected.
+* `customer.displayName` in store API and Admin API responses, resolved per account type. It is a runtime field, so it cannot be sorted or searched by. The Administration customer list keeps sorting on `lastName,firstName`, which means a commercial account without a contact person displays as its company but sorts as an empty name. Search still finds it through `company`.
+* Two new system config keys, both defaulting to on.
+* The Administration needs [#20173](https://github.com/shopware/shopware/pull/20173) before it can save an empty name at all.
 
-The feature needs [#20173](https://github.com/shopware/shopware/pull/20173) to work in the Administration at all. The changeset generator rewrites an empty string to `null` for every field, so a field that is both `Required` and `AllowEmptyString` cannot be saved from the Administration until that lands.
+What the checkout domain should be aware of:
 
-The gate has a known hole. `hasSelectedBusiness` comes from the customer group setting `registrationOnlyCompanyRegistration`, which is independent of the global account type selection. A shop with the selection off and a company only registration group produces commercial accounts the feature does not reach. Those shops have to enable the account type selection. Widening the gate later is a change to one condition.
+* An empty given name can now reach a payment provider. `AbstractPaymentHandler::pay()` receives only a `PaymentTransactionStruct` and a `Context`, and handlers load the order themselves to build the payload from `orderCustomer` and `addresses`. Core's own payment code never reads a name, so every case lives in an integration outside this repository. `payer.name.given_name` in PayPal is the one we would check first. If a provider rejects the payload the customer has already clicked pay, and Core cannot recover from that.
+* `order_customer` has no `accountType` column, so it cannot resolve a display name the way `customer` does. Copying the company into `firstName` keeps documents and the order list working, at the cost of a column named `firstName` holding a company name.
 
-### Risks we want the checkout domain to weigh in on
-
-Payment integrations are the part we are least able to judge. `AbstractPaymentHandler::pay()` receives a `PaymentTransactionStruct` and a `Context`, and handlers load the order themselves to build the provider payload from `orderCustomer` and `addresses`. Core's own payment code never reads a name, so every case lives in an integration outside this repository. Several provider APIs carry a payer object with a given and family name, and some reject an empty value or use it for name matching in 3-D Secure and fraud scoring. PayPal's `payer.name.given_name` is the case we would check first.
-
-If a provider rejects the payload, the customer has already clicked pay. Core cannot recover from that, so the answer changes the design rather than adding a patch:
-
-* Providers accept an empty name. The order snapshot can then stay honest and `order_customer` gets its own runtime display name.
-* Providers reject it. The snapshot has to carry a non-empty name, so the company keeps being copied into `firstName` and the shared document formatter is mandatory.
-* Mixed. Payment handlers need a shared way to resolve a fallback name before building the payload, which is a Core API addition nobody has scoped.
-
-The second risk is smaller and related. `order_customer` has no `accountType` column, so it cannot answer the same question the runtime field answers for `customer`. Copying the company into `firstName` keeps documents and the order list working, at the cost of a column named `firstName` holding a company name, which reads oddly to anything inspecting an order directly.
+Those two decide each other. If providers accept an empty name, the snapshot can stay honest and `order_customer` gets its own runtime field. If they reject it, the company copy stays and the shared formatter is mandatory.

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -194,10 +194,3 @@ What the API accepts after this change:
 * `customer.displayName` in store API and Admin API responses, resolved per account type. It is a runtime field, so it cannot be sorted or searched by. The Administration customer list keeps sorting on `lastName,firstName`, which means a commercial account without a contact person displays as its company but sorts as an empty name. Search still finds it through `company`.
 * Two new system config keys, both defaulting to on.
 * The Administration needs [#20173](https://github.com/shopware/shopware/pull/20173) before it can save an empty name at all.
-
-What the checkout domain should be aware of:
-
-* An empty given name can now reach a payment provider. `AbstractPaymentHandler::pay()` receives only a `PaymentTransactionStruct` and a `Context`, and handlers load the order themselves to build the payload from `orderCustomer` and `addresses`. Core's own payment code never reads a name, so every case lives in an integration outside this repository. `payer.name.given_name` in PayPal is the one we would check first. If a provider rejects the payload the customer has already clicked pay, and Core cannot recover from that.
-* `order_customer` has no `accountType` column, so it cannot resolve a display name the way `customer` does. Copying the company into `firstName` keeps documents and the order list working, at the cost of a column named `firstName` holding a company name.
-
-Those two decide each other. If providers accept an empty name, the snapshot can stay honest and `order_customer` gets its own runtime field. If they reject it, the company copy stays and the shared formatter is mandatory.

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -9,94 +9,50 @@ tags: [customer, validation, documents, payment]
 
 A commercial customer often has no single contact person. Purchasing runs through a shared mailbox, orders are placed by whoever is on shift, and the company name is the identity that matters. Shopware requires `firstName` and `lastName` on every customer, so those shops type `-`, `.`, or the company name twice to get past the register form. Issue [#15321](https://github.com/shopware/shopware/issues/15321) asks for the contact person to become optional.
 
-The awkward part isn't the validation. It's that `firstName` and `lastName` are the de facto identity of a customer across the whole system. Roughly nine places in Core branch on `accountType === 'business'` already, and every one of them renders, sorts, mails, or prints a name built from those two columns. Relaxing the validation without deciding what takes their place produces blank greetings, blank invoice buyers, and blank rows in the Administration.
+Dropping the two `NotBlank` constraints is a two line change. The reason this needs an ADR is what happens next.
 
-Two settings drive the feature, both in `Settings > Login & Registration` next to the existing account type selection:
+`firstName` and `lastName` are the de facto identity of a customer everywhere. The storefront greets with them in `sidebar.html.twig`, the Administration customer list sorts on `lastName,firstName`, mail templates stored in the shop database address them directly, and `ZugferdDocument::withBuyerInformation()` prints them as the e-invoice buyer. Around nine places in Core already branch on `accountType === 'business'`, and each of them builds a name from those two columns on its own. Nothing in the system answers "what is this customer called" in one place.
 
-- `core.loginRegistration.showNameFieldsForCompanyAccounts`
-- `core.loginRegistration.nameFieldsRequiredForCompanyAccounts`
+Two earlier attempts made that concrete. A Core attempt and a plugin attempt both went through several review rounds that kept producing the same two failures: a form that permits what the backend rejects, and a display that goes blank because one consumer was missed. The storefront account greeting rendered as "Hello" with nothing after it for the whole life of one of those branches, invisible to sixty passing unit tests.
 
-Both default to on, so nothing changes for an existing shop until one is switched off. A hidden field is never required, so `showNameFieldsForCompanyAccounts = false` implies the second one is off too.
+So the work is not "make two fields optional". It is "give the system one answer for a customer's name, then make the fields optional".
 
-## Customer data model
+## Decision
 
-The four entities that store a contact person are `customer`, `customer_address`, `order_customer`, and `order_address`. All four keep `firstName` and `lastName` as `Required` with `NOT NULL` columns.
+Keep both columns `NOT NULL` and both fields `Required`. Add `AllowEmptyString` beside `Required` on `firstName` and `lastName` for `customer`, `customer_address`, `order_customer` and `order_address`. `StringFieldSerializer::getConstraints()` then yields `NotNull` instead of `NotBlank`, so an empty string becomes a legal value while `null` stays rejected.
 
-**Problems:**
-
-* `StringFieldSerializer` turns an empty string into `null` for a `Required` string field, and the column rejects `null`. An empty name cannot be written at all.
-* Nothing in the system answers "what is this customer called" in one place. Each consumer concatenates the two columns itself.
-
-**Solution:**
-
-Add `AllowEmptyString` next to `Required` on all four name fields. `StringFieldSerializer::getConstraints()` then produces `NotNull` instead of `NotBlank`, so an empty string is a legal value and `null` still isn't. The columns stay `NOT NULL`.
-
-Add a runtime field to `CustomerDefinition` that resolves the name a consumer should render:
+Add a runtime field to `CustomerDefinition` that resolves the name a consumer should render, filled by a subscriber on `customer.loaded`:
 
 ```php
 // CustomerDefinition::defineFields()
 (new StringField('display_name', 'displayName'))->addFlags(new ApiAware(), new Runtime()),
-```
 
-A subscriber on `customer.loaded` fills it:
+// CustomerDisplayNameSubscriber
+$personName = trim($customer->getFirstName() . ' ' . $customer->getLastName());
 
-```php
-public function onCustomerLoaded(EntityLoadedEvent $event): void
-{
-    foreach ($event->getEntities() as $customer) {
-        $personName = trim($customer->getFirstName() . ' ' . $customer->getLastName());
+if ($personName === '' && $customer->getAccountType() === CustomerEntity::ACCOUNT_TYPE_BUSINESS) {
+    $customer->setDisplayName(trim($customer->getCompany() ?? ''));
 
-        if ($personName === '' && $customer->getAccountType() === CustomerEntity::ACCOUNT_TYPE_BUSINESS) {
-            $customer->setDisplayName(trim($customer->getCompany() ?? ''));
-
-            continue;
-        }
-
-        $customer->setDisplayName($personName);
-    }
+    continue;
 }
+
+$customer->setDisplayName($personName);
 ```
 
-The company stands in only when there is no person name. A commercial account that does have a contact person keeps showing that person, which is why an existing shop sees no change.
+The company stands in only when there is no person name, so a commercial account that has a contact person keeps showing that person. An existing shop sees no change.
 
-The field is deliberately runtime rather than a stored column. A stored column would be sortable and searchable, but it needs a migration, a backfill, and write-path logic on four entities, and it drifts the moment anything writes a name outside the DAL. The cost of the runtime choice is stated under Consequences.
+Two settings sit in `Settings > Login & Registration` beside the account type selection, both defaulting to on:
 
-## Validation and the account type gate
+* `core.loginRegistration.showNameFieldsForCompanyAccounts`
+* `core.loginRegistration.nameFieldsRequiredForCompanyAccounts`
 
-Validation lives in `RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute`, and the confirm page, all of which build their definitions from `AddressValidationFactory` and `CustomerProfileValidationFactory`.
+A hidden field is never required, so the first implies the second. The whole feature is gated on `core.loginRegistration.showAccountTypeSelection`. With that off, the names stay mandatory and both switches are hidden.
 
-**Problems:**
+### Scope
 
-* The relaxation depends on the account type of the request, which the profile and address forms omit whenever the account type selection is hidden. Reading the submitted value alone puts a commercial customer on the private branch, where `ChangeCustomerProfileRoute` rejects an empty contact person and clears the stored company and VAT ids.
-* `UpsertAddressRoute` writes both names from the request every time. A form that hides them submits neither, so the write either fails on `null` or replaces a stored contact person with an empty string.
-* Core treats every `accountType` value that is not `business` as the private branch and adds no `Choice` constraint, so an unknown value must count as private too.
+**Validation.** `RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute` and `CheckoutConfirmPageLoader` resolve the effective account type from the request first and the authenticated customer second, because the profile and address forms omit it whenever the account type selection is hidden. Once the names are optional the company gains a `NotBlank` on the write paths, with a trimming normalizer that guards for `is_string()` because `HappyPathValidator` calls normalizers without checking the type. The confirm page relaxes the names but does not require a company, so an address stored before the setting was switched on cannot block checkout.
 
-**Solution:**
-
-Resolve the effective account type from the request first and from the authenticated customer second. When the request omits the company on the profile route, read it back from the customer so the save neither fails nor wipes it. When it omits a name on an address update, read it back from the stored address.
-
-Once the names are optional the company becomes the identity, so it gains a `NotBlank` with a trimming normalizer on the write paths. The normalizer needs an `is_string()` guard, because `HappyPathValidator` calls normalizers without checking the type.
-
-The confirm page validates addresses that already exist, so it relaxes the names but does not require a company. Adding that requirement there would block checkout for any commercial customer whose address predates the setting being switched on.
-
-The whole feature is gated on `core.loginRegistration.showAccountTypeSelection`. With the selection off, both switches are hidden in the Administration and the names stay mandatory. One boolean decides it, which keeps the number of states a reader has to hold in their head down to something workable.
-
-That gate has a known hole. `hasSelectedBusiness` comes from the customer group setting `registrationOnlyCompanyRegistration`, which is independent of the global account type selection. A shop with the selection off and a company-only registration group produces commercial accounts that the feature does not reach. Those shops have to enable the account type selection to use it. Widening the gate later is a change to one condition.
-
-## Orders, documents and payments
-
-This is the domain we would most like feedback on, and the one where the blast radius is hardest to see from the customer side.
-
-An order keeps its own copy of the customer in `order_customer`. That copy has no `accountType` column, so it cannot answer the same question the runtime field answers for `customer`.
-
-**Problems:**
-
-* `ZugferdDocument::withBuyerInformation()` and `TradePartyView::buyerFromOrder()` each build the buyer name inline as `firstName lastName` and then append `- company`. Neither trims, and neither checks whether the company already equals the person name. `TradePartyView` raises a violation when the result is empty, so a nameless commercial buyer fails e-invoice generation outright.
-* Payment integrations read `firstName` and `lastName` from the order customer or the billing address and send them on. An empty given name may be rejected by the provider rather than by Shopware.
-
-**Solution:**
-
-`CustomerTransformer` writes the company into the snapshot when the person name is empty, so the order carries a buyer name that documents and mails can read. Both document renderers then go through one shared formatter that trims and de-duplicates:
+**Orders and documents.** `CustomerTransformer` writes the company into the order snapshot when there is no person name. Both document renderers move to one shared formatter:
 
 ```php
 $personName = trim($firstName . ' ' . $lastName);
@@ -109,51 +65,30 @@ if ($company === '' || $company === $personName) {
 return $personName === '' ? $company : $personName . ' - ' . $company;
 ```
 
-Two open questions for the checkout domain:
+**Mail.** A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately.
 
-1. Should `order_customer` get its own runtime display name instead of the snapshot copy? A twin field keeps the snapshot columns honest, at the cost of a second subscriber and a second definition of the same rule. The snapshot copy is simpler but puts the company in a column named `firstName`, which reads oddly to anything inspecting the order directly.
-2. Which payment integrations forward the customer name to a provider, and which of those providers reject an empty given name? PayPal's payer object is the case we are most unsure about. The answer decides whether an empty name is acceptable at all on a paid order, or whether the company has to be substituted before the payment call.
+**Storefront.** The name fields follow the account type `<select>` through a small plugin that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
 
-## Storefront and Administration
-
-The forms and the identity displays are separate problems, and the second one is easy to miss.
-
-**Problems:**
-
-* `address-personal.html.twig` marks both names required from configuration alone, with no knowledge of the account type the visitor picked. The account type is a runtime `<select>`, so a server-rendered flag cannot answer per type.
-* The account sidebar greeting and the account overview render `context.customer.firstName` and `lastName` directly. For a nameless commercial account the greeting reads as though the shop forgot the customer.
-* The Administration customer form marks both names required unconditionally, and `sw-customer-create` validates the company on the address without copying it to the account.
-
-**Solution:**
-
-The storefront template reads the resolved settings through a Twig function backed by the same service the routes use, so the form and the backend cannot disagree about what an unsaved setting means. A small storefront plugin follows the account type `<select>` and toggles the required rule through `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`, which handle `data-validation`, `aria-required`, and the required label together. `FormFieldTogglePlugin` is not reused, because it disables what it hides and the values would drop out of the payload.
-
-Identity displays use the runtime field: `{{ context.customer.displayName }}` in the sidebar and the account overview, and the same value in the Administration customer and order lists.
-
-The Administration name fields become optional only when both settings allow it, and default to required until the settings resolve, so a slow request leaves the form strict rather than permissive.
-
-## Extendability
-
-`customer.displayName` is `ApiAware`, so it appears in `/store-api/account/customer` and in Admin API responses without any extra work. Headless clients get the resolved name instead of reimplementing the rule.
-
-An app or plugin that wants a different rule subscribes to `customer.loaded` at a later priority and overwrites the field. A B2B extension could show the organisation unit instead of the company, or prefix the company with a customer number, without touching any consumer.
-
-The two settings are ordinary system config, so a plugin can read them through `SystemConfigService` and follow the same states in its own forms.
+**Administration.** The two name fields become optional only when both settings allow it, the account level company becomes editable rather than only copied from the address, and the customer and order lists read the resolved name.
 
 ## Consequences
 
-### For the platform
+The data abstraction layer stops guarding against an empty contact person. That guard now lives in the store API validation definitions, which means the Admin API and direct repository writes accept an empty name for private accounts too. An entity extension sees the field definition, never the row or the configuration, so the relaxation cannot be made conditional. Extensions that relied on the layer rejecting an empty name have to validate it themselves.
 
-The data abstraction layer stops being the guard for an empty contact person. Any write path that has to reject one now says so itself, through the store API validation definitions. That includes the Admin API and direct repository writes, which accept an empty name for private accounts too.
+Sorting and searching stay on the stored columns. A runtime field cannot be sorted or searched by, and the Administration customer list column is `dataIndex: 'lastName,firstName'`, so a commercial account without a contact person displays as its company but sorts as an empty name and clusters at one end of the list. Search still finds it through `company`, which carries `SearchRanking::HIGH`. We take this over a stored column, which would need a migration, a backfill, write path logic on four entities, and would drift the moment anything writes a name outside the DAL.
 
-Sorting and searching keep working on the stored columns. The Administration customer list column is `dataIndex: 'lastName,firstName'`, and a runtime field cannot be sorted or searched by, so a nameless commercial account displays as its company but sorts as an empty name and clusters at one end of the list. Search still finds those customers through `company`, which carries `SearchRanking::HIGH`. We accept this rather than pay for a stored column.
+The feature needs [#20173](https://github.com/shopware/shopware/pull/20173) to work in the Administration at all. The changeset generator rewrites an empty string to `null` for every field, so a field that is both `Required` and `AllowEmptyString` cannot be saved from the Administration until that lands.
 
-The Administration changeset generator needs a matching change, tracked in [#20173](https://github.com/shopware/shopware/pull/20173). It rewrites an empty string to `null` for every field, so a field that is `Required` and `AllowEmptyString` cannot be saved from the Administration at all until that lands.
+The gate has a known hole. `hasSelectedBusiness` comes from the customer group setting `registrationOnlyCompanyRegistration`, which is independent of the global account type selection. A shop with the selection off and a company only registration group produces commercial accounts the feature does not reach. Those shops have to enable the account type selection. Widening the gate later is a change to one condition.
 
-### For third-party developers
+### Risks we want the checkout domain to weigh in on
 
-Extensions that relied on the data abstraction layer rejecting an empty name have to validate it themselves. Nothing else changes for them while both settings stay on.
+Payment integrations are the part we are least able to judge. `AbstractPaymentHandler::pay()` receives a `PaymentTransactionStruct` and a `Context`, and handlers load the order themselves to build the provider payload from `orderCustomer` and `addresses`. Core's own payment code never reads a name, so every case lives in an integration outside this repository. Several provider APIs carry a payer object with a given and family name, and some reject an empty value or use it for name matching in 3-D Secure and fraud scoring. PayPal's `payer.name.given_name` is the case we would check first.
 
-Anything that renders a customer name should move to `customer.displayName`. Concatenating `firstName` and `lastName` still compiles and still works for private accounts, but it produces an empty string for a commercial account without a contact person.
+If a provider rejects the payload, the customer has already clicked pay. Core cannot recover from that, so the answer changes the design rather than adding a patch:
 
-Mail templates live in the shop database, so existing templates keep addressing `customer.firstName` and `customer.lastName`. A subscriber on `MailBeforeValidateEvent` swaps in a rendered copy of the customer carrying the company, and patches the recipient name in `getData()` as well, because `MailService::send()` reads that separately from the template data.
+* Providers accept an empty name. The order snapshot can then stay honest and `order_customer` gets its own runtime display name.
+* Providers reject it. The snapshot has to carry a non-empty name, so the company keeps being copied into `firstName` and the shared document formatter is mandatory.
+* Mixed. Payment handlers need a shared way to resolve a fallback name before building the payload, which is a Core API addition nobody has scoped.
+
+The second risk is smaller and related. `order_customer` has no `accountType` column, so it cannot answer the same question the runtime field answers for `customer`. Copying the company into `firstName` keeps documents and the order list working, at the cost of a column named `firstName` holding a company name, which reads oddly to anything inspecting an order directly.

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -9,7 +9,7 @@ tags: [customer, validation, documents, payment]
 
 Registering a commercial account always requires a first and last name, and `Settings > Login & Registration` offers no way to turn that off. Issue [#15321](https://github.com/shopware/shopware/issues/15321) states the case: a legal transaction with a GmbH or an AG is a transaction with a legal entity, and a legal entity has no first and last name. The same issue asks for the company name to become an account level field for commercial customers in the Administration, where today it exists only on the address.
 
-We want the shop to decide. A merchant should be able to set the contact person to required, optional or hidden, and the company name should take over as the identity when there is none. Dropping the two `NotBlank` constraints is the small part. `firstName` and `lastName` are what the storefront greets, the Administration sorts by, mail templates address and e-invoices print, and no single place in the system answers what a customer is called.
+We want the shop to decide. A merchant should be able to set the contact person to required, optional or hidden, and the company name should take over as the identity when there is none.
 
 ## Decision
 

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -136,15 +136,6 @@ public function getMailStruct(): MailRecipientStruct
 }
 ```
 
-`MailStorer` builds the same name twice when it restores a flow, without even a
-space between the two parts, and reads the resolved name too.
-
-Order events keep their own join. `OrderStateMachineStateChangeEvent`,
-`OrderPaymentMethodChangedEvent` and `CheckoutOrderPlacedEvent` read
-`orderCustomer`, which already carries the company through the snapshot. The two
-newsletter events and `UserRecoveryRequestEvent` address a recipient that is not
-a customer at all.
-
 There is no runtime patching of the customer for the render. A shop that customised a mail template keeps addressing `customer.firstName` and `customer.lastName`, and gets an empty greeting for an account with no contact person. That is the trade we accept: the shop owns that template, and hiding the change behind a subscriber would mean every mail renders a customer that does not match the one in the database.
 
 ### Storefront

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -7,9 +7,9 @@ tags: [customer, validation, documents, payment]
 
 ## Context
 
-Registering a commercial account always requires a first and last name. A company that buys through a shared mailbox has no single contact person to enter, so those shops type `-`, `.`, or the company name twice to get past the form. Issue [#15321](https://github.com/shopware/shopware/issues/15321) asks for the contact person to become optional.
+Registering a commercial account always requires a first and last name, and `Settings > Login & Registration` offers no way to turn that off. Issue [#15321](https://github.com/shopware/shopware/issues/15321) states the case: a legal transaction with a GmbH or an AG is a transaction with a legal entity, and a legal entity has no first and last name. The same issue asks for the company name to become an account level field for commercial customers in the Administration, where today it exists only on the address.
 
-We want the shop to decide. A merchant should be able to say that commercial accounts need a contact person, may leave it empty, or do not get the fields at all, and the company name should take over as the identity when there is none. Dropping the two `NotBlank` constraints is the small part. `firstName` and `lastName` are what the storefront greets, the Administration sorts by, mail templates address and e-invoices print, and no single place in the system answers what a customer is called.
+We want the shop to decide. A merchant should be able to set the contact person to required, optional or hidden, and the company name should take over as the identity when there is none. Dropping the two `NotBlank` constraints is the small part. `firstName` and `lastName` are what the storefront greets, the Administration sorts by, mail templates address and e-invoices print, and no single place in the system answers what a customer is called.
 
 ## Decision
 
@@ -78,7 +78,7 @@ The name fields follow the account type `<select>` through a small plugin that t
 
 ### Administration
 
-The two name fields become optional only when both settings allow it. The account level company becomes editable rather than only copied from the address, and the customer and order lists read the resolved name.
+The two name fields become optional only when both settings allow it. `Customers > New customer` gains a company field in the account section for the commercial type, so the company is persisted on the customer and not only on the address. This is a requirement of its own in the issue, not a side effect of the name change. The customer and order lists read the resolved name.
 
 ## Consequences
 

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -1,0 +1,159 @@
+---
+title: Optional contact person for commercial customer accounts
+date: 2026-09-09
+area: checkout
+tags: [customer, validation, documents, payment]
+---
+
+## Context
+
+A commercial customer often has no single contact person. Purchasing runs through a shared mailbox, orders are placed by whoever is on shift, and the company name is the identity that matters. Shopware requires `firstName` and `lastName` on every customer, so those shops type `-`, `.`, or the company name twice to get past the register form. Issue [#15321](https://github.com/shopware/shopware/issues/15321) asks for the contact person to become optional.
+
+The awkward part isn't the validation. It's that `firstName` and `lastName` are the de facto identity of a customer across the whole system. Roughly nine places in Core branch on `accountType === 'business'` already, and every one of them renders, sorts, mails, or prints a name built from those two columns. Relaxing the validation without deciding what takes their place produces blank greetings, blank invoice buyers, and blank rows in the Administration.
+
+Two settings drive the feature, both in `Settings > Login & Registration` next to the existing account type selection:
+
+- `core.loginRegistration.showNameFieldsForCompanyAccounts`
+- `core.loginRegistration.nameFieldsRequiredForCompanyAccounts`
+
+Both default to on, so nothing changes for an existing shop until one is switched off. A hidden field is never required, so `showNameFieldsForCompanyAccounts = false` implies the second one is off too.
+
+## Customer data model
+
+The four entities that store a contact person are `customer`, `customer_address`, `order_customer`, and `order_address`. All four keep `firstName` and `lastName` as `Required` with `NOT NULL` columns.
+
+**Problems:**
+
+* `StringFieldSerializer` turns an empty string into `null` for a `Required` string field, and the column rejects `null`. An empty name cannot be written at all.
+* Nothing in the system answers "what is this customer called" in one place. Each consumer concatenates the two columns itself.
+
+**Solution:**
+
+Add `AllowEmptyString` next to `Required` on all four name fields. `StringFieldSerializer::getConstraints()` then produces `NotNull` instead of `NotBlank`, so an empty string is a legal value and `null` still isn't. The columns stay `NOT NULL`.
+
+Add a runtime field to `CustomerDefinition` that resolves the name a consumer should render:
+
+```php
+// CustomerDefinition::defineFields()
+(new StringField('display_name', 'displayName'))->addFlags(new ApiAware(), new Runtime()),
+```
+
+A subscriber on `customer.loaded` fills it:
+
+```php
+public function onCustomerLoaded(EntityLoadedEvent $event): void
+{
+    foreach ($event->getEntities() as $customer) {
+        $personName = trim($customer->getFirstName() . ' ' . $customer->getLastName());
+
+        if ($personName === '' && $customer->getAccountType() === CustomerEntity::ACCOUNT_TYPE_BUSINESS) {
+            $customer->setDisplayName(trim($customer->getCompany() ?? ''));
+
+            continue;
+        }
+
+        $customer->setDisplayName($personName);
+    }
+}
+```
+
+The company stands in only when there is no person name. A commercial account that does have a contact person keeps showing that person, which is why an existing shop sees no change.
+
+The field is deliberately runtime rather than a stored column. A stored column would be sortable and searchable, but it needs a migration, a backfill, and write-path logic on four entities, and it drifts the moment anything writes a name outside the DAL. The cost of the runtime choice is stated under Consequences.
+
+## Validation and the account type gate
+
+Validation lives in `RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute`, and the confirm page, all of which build their definitions from `AddressValidationFactory` and `CustomerProfileValidationFactory`.
+
+**Problems:**
+
+* The relaxation depends on the account type of the request, which the profile and address forms omit whenever the account type selection is hidden. Reading the submitted value alone puts a commercial customer on the private branch, where `ChangeCustomerProfileRoute` rejects an empty contact person and clears the stored company and VAT ids.
+* `UpsertAddressRoute` writes both names from the request every time. A form that hides them submits neither, so the write either fails on `null` or replaces a stored contact person with an empty string.
+* Core treats every `accountType` value that is not `business` as the private branch and adds no `Choice` constraint, so an unknown value must count as private too.
+
+**Solution:**
+
+Resolve the effective account type from the request first and from the authenticated customer second. When the request omits the company on the profile route, read it back from the customer so the save neither fails nor wipes it. When it omits a name on an address update, read it back from the stored address.
+
+Once the names are optional the company becomes the identity, so it gains a `NotBlank` with a trimming normalizer on the write paths. The normalizer needs an `is_string()` guard, because `HappyPathValidator` calls normalizers without checking the type.
+
+The confirm page validates addresses that already exist, so it relaxes the names but does not require a company. Adding that requirement there would block checkout for any commercial customer whose address predates the setting being switched on.
+
+The whole feature is gated on `core.loginRegistration.showAccountTypeSelection`. With the selection off, both switches are hidden in the Administration and the names stay mandatory. One boolean decides it, which keeps the number of states a reader has to hold in their head down to something workable.
+
+That gate has a known hole. `hasSelectedBusiness` comes from the customer group setting `registrationOnlyCompanyRegistration`, which is independent of the global account type selection. A shop with the selection off and a company-only registration group produces commercial accounts that the feature does not reach. Those shops have to enable the account type selection to use it. Widening the gate later is a change to one condition.
+
+## Orders, documents and payments
+
+This is the domain we would most like feedback on, and the one where the blast radius is hardest to see from the customer side.
+
+An order keeps its own copy of the customer in `order_customer`. That copy has no `accountType` column, so it cannot answer the same question the runtime field answers for `customer`.
+
+**Problems:**
+
+* `ZugferdDocument::withBuyerInformation()` and `TradePartyView::buyerFromOrder()` each build the buyer name inline as `firstName lastName` and then append `- company`. Neither trims, and neither checks whether the company already equals the person name. `TradePartyView` raises a violation when the result is empty, so a nameless commercial buyer fails e-invoice generation outright.
+* Payment integrations read `firstName` and `lastName` from the order customer or the billing address and send them on. An empty given name may be rejected by the provider rather than by Shopware.
+
+**Solution:**
+
+`CustomerTransformer` writes the company into the snapshot when the person name is empty, so the order carries a buyer name that documents and mails can read. Both document renderers then go through one shared formatter that trims and de-duplicates:
+
+```php
+$personName = trim($firstName . ' ' . $lastName);
+$company = trim($company ?? '');
+
+if ($company === '' || $company === $personName) {
+    return $personName;
+}
+
+return $personName === '' ? $company : $personName . ' - ' . $company;
+```
+
+Two open questions for the checkout domain:
+
+1. Should `order_customer` get its own runtime display name instead of the snapshot copy? A twin field keeps the snapshot columns honest, at the cost of a second subscriber and a second definition of the same rule. The snapshot copy is simpler but puts the company in a column named `firstName`, which reads oddly to anything inspecting the order directly.
+2. Which payment integrations forward the customer name to a provider, and which of those providers reject an empty given name? PayPal's payer object is the case we are most unsure about. The answer decides whether an empty name is acceptable at all on a paid order, or whether the company has to be substituted before the payment call.
+
+## Storefront and Administration
+
+The forms and the identity displays are separate problems, and the second one is easy to miss.
+
+**Problems:**
+
+* `address-personal.html.twig` marks both names required from configuration alone, with no knowledge of the account type the visitor picked. The account type is a runtime `<select>`, so a server-rendered flag cannot answer per type.
+* The account sidebar greeting and the account overview render `context.customer.firstName` and `lastName` directly. For a nameless commercial account the greeting reads as though the shop forgot the customer.
+* The Administration customer form marks both names required unconditionally, and `sw-customer-create` validates the company on the address without copying it to the account.
+
+**Solution:**
+
+The storefront template reads the resolved settings through a Twig function backed by the same service the routes use, so the form and the backend cannot disagree about what an unsaved setting means. A small storefront plugin follows the account type `<select>` and toggles the required rule through `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`, which handle `data-validation`, `aria-required`, and the required label together. `FormFieldTogglePlugin` is not reused, because it disables what it hides and the values would drop out of the payload.
+
+Identity displays use the runtime field: `{{ context.customer.displayName }}` in the sidebar and the account overview, and the same value in the Administration customer and order lists.
+
+The Administration name fields become optional only when both settings allow it, and default to required until the settings resolve, so a slow request leaves the form strict rather than permissive.
+
+## Extendability
+
+`customer.displayName` is `ApiAware`, so it appears in `/store-api/account/customer` and in Admin API responses without any extra work. Headless clients get the resolved name instead of reimplementing the rule.
+
+An app or plugin that wants a different rule subscribes to `customer.loaded` at a later priority and overwrites the field. A B2B extension could show the organisation unit instead of the company, or prefix the company with a customer number, without touching any consumer.
+
+The two settings are ordinary system config, so a plugin can read them through `SystemConfigService` and follow the same states in its own forms.
+
+## Consequences
+
+### For the platform
+
+The data abstraction layer stops being the guard for an empty contact person. Any write path that has to reject one now says so itself, through the store API validation definitions. That includes the Admin API and direct repository writes, which accept an empty name for private accounts too.
+
+Sorting and searching keep working on the stored columns. The Administration customer list column is `dataIndex: 'lastName,firstName'`, and a runtime field cannot be sorted or searched by, so a nameless commercial account displays as its company but sorts as an empty name and clusters at one end of the list. Search still finds those customers through `company`, which carries `SearchRanking::HIGH`. We accept this rather than pay for a stored column.
+
+The Administration changeset generator needs a matching change, tracked in [#20173](https://github.com/shopware/shopware/pull/20173). It rewrites an empty string to `null` for every field, so a field that is `Required` and `AllowEmptyString` cannot be saved from the Administration at all until that lands.
+
+### For third-party developers
+
+Extensions that relied on the data abstraction layer rejecting an empty name have to validate it themselves. Nothing else changes for them while both settings stay on.
+
+Anything that renders a customer name should move to `customer.displayName`. Concatenating `firstName` and `lastName` still compiles and still works for private accounts, but it produces an empty string for a commercial account without a contact person.
+
+Mail templates live in the shop database, so existing templates keep addressing `customer.firstName` and `customer.lastName`. A subscriber on `MailBeforeValidateEvent` swaps in a rendered copy of the customer carrying the company, and patches the recipient name in `getData()` as well, because `MailService::send()` reads that separately from the template data.

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -88,11 +88,13 @@ return $personName === '' ? $company : $personName . ' - ' . $company;
 
 A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately. Templates live in the shop database, so they keep addressing `customer.firstName` and `customer.lastName`.
 
+The company goes into `lastName`, not `firstName`. Most shipped templates greet with `{{ customer.salutation.translated.letterName }} {{ customer.lastName }}` and never read `firstName`, so a company placed there would not appear in the mail at all. Templates that render both parts produce a double space, which HTML collapses. Plain text mails keep it.
+
 ```php
 // the stored customer is never touched, only the copy the template renders
 $rendered = clone $customer;
-$rendered->setFirstName($customer->getCompany());
-$rendered->setLastName('');
+$rendered->setFirstName('');
+$rendered->setLastName($customer->getCompany());
 
 $event->setTemplateData([...$templateData, 'customer' => $rendered]);
 $event->setData([...$data, 'recipients' => [$customer->getEmail() => $customer->getCompany()]]);

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -86,10 +86,10 @@ return $personName === '' ? $company : $personName . ' - ' . $company;
 
 ### Mail
 
-The shipped templates move to the resolved name, and a migration carries that to installations that never edited them. `MailUpdate` only rewrites a template while `updated_at IS NULL` on both the template and its translation, so a shop that customised its mails keeps what it has.
+The shipped templates move to the resolved name, and a migration carries that to installations that never edited them. `MailUpdate` only rewrites a template while `updated_at IS NULL` on both the template and its translation, so a shop that customised its mails keeps its own text. Twenty fixture files across five templates read the customer name today, in two shapes, one of which never reads `firstName`.
 
 ```twig
-{# fixtures today, in two shapes, one of which never reads firstName #}
+{# before #}
 Hello {{ customer.firstName }} {{ customer.lastName }},
 Hello {{ customer.salutation.translated.letterName }} {{ customer.lastName }},
 
@@ -98,19 +98,16 @@ Hello {{ customer.displayName }},
 Hello {{ customer.salutation.translated.letterName }} {{ customer.displayName }},
 ```
 
-Customised templates still address `customer.firstName` and `customer.lastName`, so a subscriber on `MailBeforeValidateEvent` covers them. It swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately.
-
-The copy puts the company in `lastName`, not `firstName`, because the shape that greets with `letterName` never reads `firstName` and the company would not appear at all. A customised template that renders both parts gets a double space, which HTML collapses and plain text keeps. That is the residue we accept, and it reaches only shops that edited their own mails.
+The recipient name is built in the events, not the template, so the ten `MailAware` customer events read the resolved name instead of joining the two columns. Otherwise the `To:` header of a nameless company account is a single space.
 
 ```php
-// the stored customer is never touched, only the copy the template renders
-$rendered = clone $customer;
-$rendered->setFirstName('');
-$rendered->setLastName($customer->getCompany());
-
-$event->setTemplateData([...$templateData, 'customer' => $rendered]);
-$event->setData([...$data, 'recipients' => [$customer->getEmail() => $customer->getCompany()]]);
+// CustomerRegisterEvent::getMailStruct() and its nine siblings
+new MailRecipientStruct([$this->customer->getEmail() => $this->customer->getDisplayName()]);
 ```
+
+Order mails need nothing. They read `order.orderCustomer.firstName`, which already carries the company through the snapshot.
+
+There is no runtime patching of the customer for the render. A shop that customised a mail template keeps addressing `customer.firstName` and `customer.lastName`, and gets an empty greeting for an account with no contact person. That is the trade we accept: the shop owns that template, and hiding the change behind a subscriber would mean every mail renders a customer that does not match the one in the database.
 
 ### Storefront
 

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -2,7 +2,7 @@
 title: Optional contact person for commercial customer accounts
 date: 2026-09-09
 area: checkout
-tags: [customer, validation, documents, payment]
+tags: [customer, b2b]
 ---
 
 ## Context

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -86,9 +86,21 @@ return $personName === '' ? $company : $personName . ' - ' . $company;
 
 ### Mail
 
-A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately. Templates live in the shop database, so they keep addressing `customer.firstName` and `customer.lastName`.
+The shipped templates move to the resolved name, and a migration carries that to installations that never edited them. `MailUpdate` only rewrites a template while `updated_at IS NULL` on both the template and its translation, so a shop that customised its mails keeps what it has.
 
-The company goes into `lastName`, not `firstName`. Most shipped templates greet with `{{ customer.salutation.translated.letterName }} {{ customer.lastName }}` and never read `firstName`, so a company placed there would not appear in the mail at all. Templates that render both parts produce a double space, which HTML collapses. Plain text mails keep it.
+```twig
+{# fixtures today, in two shapes, one of which never reads firstName #}
+Hello {{ customer.firstName }} {{ customer.lastName }},
+Hello {{ customer.salutation.translated.letterName }} {{ customer.lastName }},
+
+{# after #}
+Hello {{ customer.displayName }},
+Hello {{ customer.salutation.translated.letterName }} {{ customer.displayName }},
+```
+
+Customised templates still address `customer.firstName` and `customer.lastName`, so a subscriber on `MailBeforeValidateEvent` covers them. It swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately.
+
+The copy puts the company in `lastName`, not `firstName`, because the shape that greets with `letterName` never reads `firstName` and the company would not appear at all. A customised template that renders both parts gets a double space, which HTML collapses and plain text keeps. That is the residue we accept, and it reaches only shops that edited their own mails.
 
 ```php
 // the stored customer is never touched, only the copy the template renders

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -28,6 +28,12 @@ To achieve this we touch the following scopes.
 
 `firstName` and `lastName` on `customer`, `customer_address`, `order_customer` and `order_address` get `AllowEmptyString` beside `Required`. `StringFieldSerializer::getConstraints()` then yields `NotNull` instead of `NotBlank`, so an empty string becomes legal while `null` stays rejected. The columns stay `NOT NULL`.
 
+```php
+// the same change in all four definitions
+(new StringField('first_name', 'firstName'))
+    ->addFlags(new Required(), new AllowEmptyString());
+```
+
 ### Customer identity
 
 `CustomerDefinition` gets a runtime field, filled by a subscriber on `customer.loaded`:
@@ -53,6 +59,16 @@ The company stands in only when there is no person name, so a commercial account
 
 `RegisterRoute`, `ChangeCustomerProfileRoute`, `UpsertAddressRoute` and `CheckoutConfirmPageLoader` resolve the effective account type from the request first and the authenticated customer second, because the profile and address forms omit it whenever the account type selection is hidden. Once the names are optional the company gains a `NotBlank` on the write paths, with a trimming normalizer guarded by `is_string()` because `HappyPathValidator` calls normalizers without checking the type. The confirm page relaxes the names but does not require a company, so an address stored before the setting was switched on cannot block checkout.
 
+```php
+$accountType = $data->get('accountType') ?: $customer->getAccountType();
+
+if ($accountType === CustomerEntity::ACCOUNT_TYPE_BUSINESS && !$config->areNamesRequired($salesChannelId)) {
+    // keep every constraint on the names except NotBlank
+    $config->makeNamesOptional($definition);
+    $definition->add('company', new NotBlank(normalizer: $trimIfString));
+}
+```
+
 ### Orders and documents
 
 `CustomerTransformer` writes the company into the order snapshot when there is no person name. `ZugferdDocument` and `TradePartyView` move to one shared formatter:
@@ -72,13 +88,54 @@ return $personName === '' ? $company : $personName . ' - ' . $company;
 
 A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer into the template data and patches the recipient name in `getData()`, which `MailService::send()` reads separately. Templates live in the shop database, so they keep addressing `customer.firstName` and `customer.lastName`.
 
+```php
+// the stored customer is never touched, only the copy the template renders
+$rendered = clone $customer;
+$rendered->setFirstName($customer->getCompany());
+$rendered->setLastName('');
+
+$event->setTemplateData([...$templateData, 'customer' => $rendered]);
+$event->setData([...$data, 'recipients' => [$customer->getEmail() => $customer->getCompany()]]);
+```
+
 ### Storefront
 
 The name fields follow the account type `<select>` through storefront JavaScript that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
 
+```twig
+{# server rendered starting state #}
+validationRules: personNameRequired ? 'required' : ''
+
+{# identity, instead of firstName ~ ' ' ~ lastName #}
+{{ context.customer.displayName }}
+```
+
+```js
+// the visitor can switch type without a reload, so the marker has to follow
+accountTypeSelect.addEventListener('change', () => nameFields.forEach((field) => {
+    isCompanySelected() && !namesRequired
+        ? window.formValidation.setFieldNotRequired(field)
+        : window.formValidation.setFieldRequired(field);
+}));
+```
+
 ### Administration
 
 The two name fields become optional only when both settings allow it. `Customers > New customer` gains a company field in the account section for the commercial type, so the company is persisted on the customer and not only on the address. This is a requirement of its own in the issue, not a side effect of the name change. The customer and order lists read the resolved name.
+
+```js
+// sw-customer-base-form, starts strict until the settings resolve
+contactPersonRequired() {
+    return !this.isBusinessAccountType || this.companyNamesRequired;
+}
+```
+
+```twig
+<mt-text-field :required="contactPersonRequired" v-model="customer.firstName" />
+
+<mt-text-field v-if="isBusinessAccountType" v-model="customer.company"
+               :required="!contactPersonRequired" />
+```
 
 ## Consequences
 

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -86,26 +86,64 @@ return $personName === '' ? $company : $personName . ' - ' . $company;
 
 ### Mail
 
-The shipped templates move to the resolved name, and a migration carries that to installations that never edited them. `MailUpdate` only rewrites a template while `updated_at IS NULL` on both the template and its translation, so a shop that customised its mails keeps its own text. Twenty fixture files across five templates read the customer name today, in two shapes, one of which never reads `firstName`.
+The shipped templates move to the resolved name, and a migration carries that to installations that never edited them. `MailUpdate` only rewrites a template while `updated_at IS NULL` on both the template and its translation, so a shop that customised its mails keeps its own text. Twenty fixture files across five templates read the customer name today, in three shapes. Two of them never read `firstName`, so a company placed there would not appear in the mail at all.
 
 ```twig
 {# before #}
 Hello {{ customer.firstName }} {{ customer.lastName }},
 Hello {{ customer.salutation.translated.letterName }} {{ customer.lastName }},
+Hello {{ customer.salutation.translated.letterName }} {{ customer.firstName }} {{ customer.lastName }},
 
 {# after #}
 Hello {{ customer.displayName }},
 Hello {{ customer.salutation.translated.letterName }} {{ customer.displayName }},
 ```
 
-The recipient name is built in the events, not the template, so the ten `MailAware` customer events read the resolved name instead of joining the two columns. Otherwise the `To:` header of a nameless company account is a single space.
+The recipient name is built in the events, not the template. Ten `MailAware`
+customer events join the two columns in `getMailStruct()`, so without a change
+the `To:` header of a nameless company account is a single space. All ten read
+the resolved name instead:
 
-```php
-// CustomerRegisterEvent::getMailStruct() and its nine siblings
-new MailRecipientStruct([$this->customer->getEmail() => $this->customer->getDisplayName()]);
+```
+Shopware\Core\Checkout\Customer\Event\
+    CustomerRegisterEvent
+    CustomerLoginEvent
+    CustomerLogoutEvent
+    CustomerDeletedEvent
+    CustomerPasswordChangedEvent
+    CustomerAccountRecoverRequestEvent
+    CustomerDoubleOptInRegistrationEvent
+    CustomerGroupRegistrationAccepted
+    CustomerGroupRegistrationDeclined
+    DoubleOptInGuestOrderEvent
 ```
 
-Order mails need nothing. They read `order.orderCustomer.firstName`, which already carries the company through the snapshot.
+```php
+// before, in each of the ten
+public function getMailStruct(): MailRecipientStruct
+{
+    return new MailRecipientStruct([
+        $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
+    ]);
+}
+
+// after
+public function getMailStruct(): MailRecipientStruct
+{
+    return new MailRecipientStruct([
+        $this->customer->getEmail() => $this->customer->getDisplayName(),
+    ]);
+}
+```
+
+`MailStorer` builds the same name twice when it restores a flow, without even a
+space between the two parts, and reads the resolved name too.
+
+Order events keep their own join. `OrderStateMachineStateChangeEvent`,
+`OrderPaymentMethodChangedEvent` and `CheckoutOrderPlacedEvent` read
+`orderCustomer`, which already carries the company through the snapshot. The two
+newsletter events and `UserRecoveryRequestEvent` address a recipient that is not
+a customer at all.
 
 There is no runtime patching of the customer for the render. A shop that customised a mail template keeps addressing `customer.firstName` and `customer.lastName`, and gets an empty greeting for an account with no contact person. That is the trade we accept: the shop owns that template, and hiding the change behind a subscriber would mean every mail renders a customer that does not match the one in the database.
 

--- a/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
+++ b/adr/2026-09-09-optional-contact-person-for-commercial-accounts.md
@@ -74,7 +74,7 @@ A subscriber on `MailBeforeValidateEvent` swaps a rendered copy of the customer 
 
 ### Storefront
 
-The name fields follow the account type `<select>` through a small plugin that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
+The name fields follow the account type `<select>` through storefront JavaScript that toggles the required rule with `window.formValidation.setFieldRequired()` and `setFieldNotRequired()`. `FormFieldTogglePlugin` is not reused because it disables what it hides, which drops the values from the payload. The sidebar and the account overview read `customer.displayName`.
 
 ### Administration
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Issue #15321 asks for the contact person (customer's firsname and lastname) to become optional on commercial customer accounts. 

### 2. What does this change do, exactly?

Adds `adr/2026-09-09-optional-contact-person-for-commercial-accounts.md`. No code.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, documentation only.

### 4. Please link to the relevant issues (if any).

relates #15321
