### PR TITLE
fix(administration): stretch advanced pricing price fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -49,6 +49,10 @@
         align-items: center;
         margin-bottom: var(--scale-size-6);
 
+        .sw-list-price-field {
+            width: 100%;
+        }
+
         .sw-product-detail-context-prices__inherited-icon {
             margin-right: var(--scale-size-10);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

The list price fields in the product advanced pricing table do not use the full available column width, making the price inputs appear unnecessarily narrow.

### 2. What does this change do, exactly?

Sets the advanced pricing `sw-list-price-field` to `width: 100%` so its fields stretch across the available grid column.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration.
2. Navigate to Products and open a product.
3. Open the Advanced pricing tab.
4. Create or edit a pricing rule.
5. Observe that the list price fields do not stretch across the column.

### 4. Please link to the relevant issues (if any).

- closes #20257

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them