### PR TITLE
fix(checkout): allow login when a default address is missing

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -227,16 +227,6 @@ The tag association routes and a nested `tags` payload on the order or category 
 
 `Shopware\Core\Checkout\Cart\AbstractCartPersister` gained `exists()` for this. The abstract class carries a default implementation that delegates to the decorated persister, so existing implementations keep working, but the method becomes abstract with 6.8.0.0 — implement it in every cart persister of yours before upgrading.
 
-### Customers with a missing default address can log in again
-
-A customer whose `default_billing_address_id` or `default_shipping_address_id` points at a deleted `customer_address` row can log in again. `/store-api/account/login` and `/store-api/account/imitate-customer` previously answered with a `TypeError`, because those columns carry no database foreign key and the sales channel context refused to build without the address.
-
-`CustomerEntity::getActiveBillingAddress()`, `getActiveShippingAddress()`, `getDefaultBillingAddress()` and `getDefaultShippingAddress()` now return `null` for such a customer instead of aborting the request, and the context falls back to the sales channel shipping location. All four getters were already typed as nullable; code that reads them without a null check should add one.
-
-The cart of such a customer instead carries the new blocking errors `billing-address-missing` and `shipping-address-missing` (`Shopware\Core\Checkout\Cart\Address\Error\BillingAddressMissingError` and `ShippingAddressMissingError`), so the customer reaches their account and can set a valid default address, but cannot check out. The shipping error is not restricted to carts that require shipping: a digital-only cart would otherwise be ordered against the sales channel country as its tax basis.
-
-For these customers `POST /store-api/checkout/order` therefore answers `500 CHECKOUT__CART_INVALID` instead of the previous `400 CHECKOUT__CUSTOMER_ADDRESS_NOT_FOUND` or `400 CHECKOUT__DELIVERY_WITHOUT_ADDRESS`. The storefront shows the cart errors on the confirm page rather than an error page.
-
 ## API
 
 ### Store API currency headers validate sales channel availability

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -227,6 +227,16 @@ The tag association routes and a nested `tags` payload on the order or category 
 
 `Shopware\Core\Checkout\Cart\AbstractCartPersister` gained `exists()` for this. The abstract class carries a default implementation that delegates to the decorated persister, so existing implementations keep working, but the method becomes abstract with 6.8.0.0 — implement it in every cart persister of yours before upgrading.
 
+### Customers with a missing default address can log in again
+
+A customer whose `default_billing_address_id` or `default_shipping_address_id` points at a deleted `customer_address` row can log in again. `/store-api/account/login` and `/store-api/account/imitate-customer` previously answered with a `TypeError`, because those columns carry no database foreign key and the sales channel context refused to build without the address.
+
+`CustomerEntity::getActiveBillingAddress()`, `getActiveShippingAddress()`, `getDefaultBillingAddress()` and `getDefaultShippingAddress()` now return `null` for such a customer instead of aborting the request, and the context falls back to the sales channel shipping location. All four getters were already typed as nullable; code that reads them without a null check should add one.
+
+The cart of such a customer instead carries the new blocking errors `billing-address-missing` and `shipping-address-missing` (`Shopware\Core\Checkout\Cart\Address\Error\BillingAddressMissingError` and `ShippingAddressMissingError`), so the customer reaches their account and can set a valid default address, but cannot check out. The shipping error is not restricted to carts that require shipping: a digital-only cart would otherwise be ordered against the sales channel country as its tax basis.
+
+For these customers `POST /store-api/checkout/order` therefore answers `500 CHECKOUT__CART_INVALID` instead of the previous `400 CHECKOUT__CUSTOMER_ADDRESS_NOT_FOUND` or `400 CHECKOUT__DELIVERY_WITHOUT_ADDRESS`. The storefront shows the cart errors on the confirm page rather than an error page.
+
 ## API
 
 ### Store API currency headers validate sales channel availability

--- a/src/Core/Checkout/Cart/Address/AddressValidator.php
+++ b/src/Core/Checkout/Cart/Address/AddressValidator.php
@@ -87,8 +87,7 @@ class AddressValidator implements CartValidatorInterface, ResetInterface
             $errors->add(new BillingAddressMissingError());
         }
 
-        // deliberately not gated by $validateShipping: a digital-only cart would otherwise be ordered
-        // with the sales channel country as its tax basis
+        // not gated by $validateShipping: a digital-only cart would otherwise be ordered against the fallback country
         if ($activeShippingAddress === null) {
             $errors->add(new ShippingAddressMissingError());
         }

--- a/src/Core/Checkout/Cart/Address/AddressValidator.php
+++ b/src/Core/Checkout/Cart/Address/AddressValidator.php
@@ -3,9 +3,11 @@
 namespace Shopware\Core\Checkout\Cart\Address;
 
 use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressMissingError;
 use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressSalutationMissingError;
 use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressBlockedError;
 use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressMissingError;
 use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressSalutationMissingError;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartValidatorInterface;
@@ -78,30 +80,43 @@ class AddressValidator implements CartValidatorInterface, ResetInterface
             return;
         }
 
-        if ($customer->getActiveBillingAddress() === null || $customer->getActiveShippingAddress() === null) {
+        $activeBillingAddress = $customer->getActiveBillingAddress();
+        $activeShippingAddress = $customer->getActiveShippingAddress();
+
+        if ($activeBillingAddress === null) {
+            $errors->add(new BillingAddressMissingError());
+        }
+
+        // deliberately not gated by $validateShipping: a digital-only cart would otherwise be ordered
+        // with the sales channel country as its tax basis
+        if ($activeShippingAddress === null) {
+            $errors->add(new ShippingAddressMissingError());
+        }
+
+        if ($activeBillingAddress === null || $activeShippingAddress === null) {
             // No need to add salutation-specific errors in this case
             return;
         }
 
-        if (!$customer->getActiveBillingAddress()->getSalutationId()) {
-            $errors->add(new BillingAddressSalutationMissingError($customer->getActiveBillingAddress()));
+        if (!$activeBillingAddress->getSalutationId()) {
+            $errors->add(new BillingAddressSalutationMissingError($activeBillingAddress));
 
             return;
         }
 
-        if (!$customer->getActiveShippingAddress()->getSalutationId() && $validateShipping) {
-            $errors->add(new ShippingAddressSalutationMissingError($customer->getActiveShippingAddress()));
+        if (!$activeShippingAddress->getSalutationId() && $validateShipping) {
+            $errors->add(new ShippingAddressSalutationMissingError($activeShippingAddress));
         }
 
-        if ($customer->getActiveBillingAddress()->getCountry()?->getForceStateInRegistration()) {
-            if (!$customer->getActiveBillingAddress()->getCountryState()) {
-                $errors->add(new BillingAddressCountryRegionMissingError($customer->getActiveBillingAddress()));
+        if ($activeBillingAddress->getCountry()?->getForceStateInRegistration()) {
+            if (!$activeBillingAddress->getCountryState()) {
+                $errors->add(new BillingAddressCountryRegionMissingError($activeBillingAddress));
             }
         }
 
-        if ($customer->getActiveShippingAddress()->getCountry()?->getForceStateInRegistration()) {
-            if (!$customer->getActiveShippingAddress()->getCountryState()) {
-                $errors->add(new ShippingAddressCountryRegionMissingError($customer->getActiveShippingAddress()));
+        if ($activeShippingAddress->getCountry()?->getForceStateInRegistration()) {
+            if (!$activeShippingAddress->getCountryState()) {
+                $errors->add(new ShippingAddressCountryRegionMissingError($activeShippingAddress));
             }
         }
     }

--- a/src/Core/Checkout/Cart/Address/Error/AddressMissingError.php
+++ b/src/Core/Checkout/Cart/Address/Error/AddressMissingError.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Address\Error;
+
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+abstract class AddressMissingError extends Error
+{
+    public function getMessageKey(): string
+    {
+        return $this->getId();
+    }
+
+    public function getLevel(): int
+    {
+        return Error::LEVEL_ERROR;
+    }
+
+    public function blockOrder(): bool
+    {
+        return true;
+    }
+
+    /**
+     * The cart is not modified, so the error has to be re-added on every calculation until the customer adds an address.
+     */
+    public function isPersistent(): bool
+    {
+        return false;
+    }
+
+    public function getParameters(): array
+    {
+        return [];
+    }
+}

--- a/src/Core/Checkout/Cart/Address/Error/AddressMissingError.php
+++ b/src/Core/Checkout/Cart/Address/Error/AddressMissingError.php
@@ -23,9 +23,6 @@ abstract class AddressMissingError extends Error
         return true;
     }
 
-    /**
-     * The cart is not modified, so the error has to be re-added on every calculation until the customer adds an address.
-     */
     public function isPersistent(): bool
     {
         return false;

--- a/src/Core/Checkout/Cart/Address/Error/BillingAddressMissingError.php
+++ b/src/Core/Checkout/Cart/Address/Error/BillingAddressMissingError.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Address\Error;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class BillingAddressMissingError extends AddressMissingError
+{
+    private const KEY = 'billing-address-missing';
+
+    public function __construct()
+    {
+        parent::__construct('The customer has no active billing address.');
+    }
+
+    public function getId(): string
+    {
+        return self::KEY;
+    }
+}

--- a/src/Core/Checkout/Cart/Address/Error/ShippingAddressMissingError.php
+++ b/src/Core/Checkout/Cart/Address/Error/ShippingAddressMissingError.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Address\Error;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class ShippingAddressMissingError extends AddressMissingError
+{
+    private const KEY = 'shipping-address-missing';
+
+    public function __construct()
+    {
+        parent::__construct('The customer has no active shipping address.');
+    }
+
+    public function getId(): string
+    {
+        return self::KEY;
+    }
+}

--- a/src/Core/Framework/Resources/snippet/messages.de.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.de.base.json
@@ -32,7 +32,9 @@
         "salutation-missing-shipping-address": "Für die gewählte Lieferadresse wurde noch keine Anrede festgelegt, bitte wählen Sie <a href=\"%url%\">hier</a> eine aus.",
         "country-region-missing-billing-address": "Für die gewählte Rechnungsadresse wurde noch kein Bundesland festgelegt, bitte wählen Sie <a href=\"%url%\">hier</a> eine aus.",
         "country-region-missing-shipping-address": "Für die gewählte Lieferadresse wurde noch kein Bundesland festgelegt, bitte wählen Sie <a href=\"%url%\">hier</a> eine aus.",
-        "checkout-gateway-error": "%reason%"
+        "checkout-gateway-error": "%reason%",
+        "billing-address-missing": "Ihre Rechnungsadresse ist nicht mehr verfügbar. Bitte legen Sie in Ihrem Konto eine neue Rechnungsadresse an, bevor Sie mit der Bestellung fortfahren.",
+        "shipping-address-missing": "Ihre Lieferadresse ist nicht mehr verfügbar. Bitte legen Sie in Ihrem Konto eine neue Lieferadresse an, bevor Sie mit der Bestellung fortfahren."
     },
     "document": {
         "invoiceNumber": "Rechnungs-Nr. %invoiceNumber%",

--- a/src/Core/Framework/Resources/snippet/messages.en.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.en.base.json
@@ -32,7 +32,9 @@
         "salutation-missing-shipping-address": "There's no salutation configured for your active shipping address, please set one <a href=\"%url%\">here</a>.",
         "country-region-missing-billing-address": "There's no country region configured for your active billing address, please set one <a href=\"%url%\">here</a>.",
         "country-region-missing-shipping-address": "There's no country region configured for your active shipping address, please set one <a href=\"%url%\">here</a>.",
-        "checkout-gateway-error": "%reason%"
+        "checkout-gateway-error": "%reason%",
+        "billing-address-missing": "Your billing address is no longer available. Please add a new billing address to your account before you continue with the checkout.",
+        "shipping-address-missing": "Your shipping address is no longer available. Please add a new shipping address to your account before you continue with the checkout."
     },
     "document": {
         "invoiceNumber": "Invoice %invoiceNumber%",

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -74,7 +74,6 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         if ($customer !== null) {
             $activeShippingAddress = $customer->getActiveShippingAddress();
-            // the default address can be dangling, as the customer FKs have no DB constraint
             $shippingLocation = $activeShippingAddress !== null
                 ? ShippingLocation::createFromAddress($activeShippingAddress)
                 : $base->getShippingLocation();
@@ -260,7 +259,7 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         $addresses = $this->addressRepository->search($criteria, $context)->getEntities();
 
-        // the addresses stay null when a default address id points to a deleted row, the setters are not nullable yet
+        // a default address id can point to a deleted row, and the setters are not nullable yet
         $activeBillingAddress = $addresses->get($activeBillingAddressId) ?? $addresses->get($customer->getDefaultBillingAddressId());
         if ($activeBillingAddress !== null) {
             $customer->setActiveBillingAddress($activeBillingAddress);

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -74,8 +74,10 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         if ($customer !== null) {
             $activeShippingAddress = $customer->getActiveShippingAddress();
-            \assert($activeShippingAddress !== null);
-            $shippingLocation = ShippingLocation::createFromAddress($activeShippingAddress);
+            // the default address can be dangling, as the customer FKs have no DB constraint
+            $shippingLocation = $activeShippingAddress !== null
+                ? ShippingLocation::createFromAddress($activeShippingAddress)
+                : $base->getShippingLocation();
 
             $criteria = new Criteria([$customer->getGroupId()]);
             $criteria->setTitle('context-factory::customer-group');
@@ -258,18 +260,26 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         $addresses = $this->addressRepository->search($criteria, $context)->getEntities();
 
+        // the addresses stay null when a default address id points to a deleted row, the setters are not nullable yet
         $activeBillingAddress = $addresses->get($activeBillingAddressId) ?? $addresses->get($customer->getDefaultBillingAddressId());
-        \assert($activeBillingAddress !== null);
-        $customer->setActiveBillingAddress($activeBillingAddress);
+        if ($activeBillingAddress !== null) {
+            $customer->setActiveBillingAddress($activeBillingAddress);
+        }
+
         $activeShippingAddress = $addresses->get($activeShippingAddressId) ?? $addresses->get($customer->getDefaultShippingAddressId());
-        \assert($activeShippingAddress !== null);
-        $customer->setActiveShippingAddress($activeShippingAddress);
+        if ($activeShippingAddress !== null) {
+            $customer->setActiveShippingAddress($activeShippingAddress);
+        }
+
         $defaultBillingAddress = $addresses->get($customer->getDefaultBillingAddressId());
-        \assert($defaultBillingAddress !== null);
-        $customer->setDefaultBillingAddress($defaultBillingAddress);
+        if ($defaultBillingAddress !== null) {
+            $customer->setDefaultBillingAddress($defaultBillingAddress);
+        }
+
         $defaultShippingAddress = $addresses->get($customer->getDefaultShippingAddressId());
-        \assert($defaultShippingAddress !== null);
-        $customer->setDefaultShippingAddress($defaultShippingAddress);
+        if ($defaultShippingAddress !== null) {
+            $customer->setDefaultShippingAddress($defaultShippingAddress);
+        }
 
         return $customer;
     }

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/LoginWithInvalidDefaultAddressTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/LoginWithInvalidDefaultAddressTest.php
@@ -1,0 +1,275 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Customer\SalesChannel;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * @internal
+ *
+ * A customer's default_billing_address_id / default_shipping_address_id carry no DB constraint, so they can
+ * point at a deleted customer_address row.
+ *
+ * @see https://github.com/shopware/shopware/issues/20225
+ */
+#[Package('checkout')]
+#[Group('store-api')]
+class LoginWithInvalidDefaultAddressTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    private KernelBrowser $browser;
+
+    private IdsCollection $ids;
+
+    private Connection $connection;
+
+    private string $email;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->browser = $this->createCustomSalesChannelBrowser(['id' => $this->ids->create('sales-channel')]);
+        $this->assignSalesChannelContext($this->browser);
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->email = Uuid::randomHex() . '@example.com';
+    }
+
+    public function testLoginSucceedsWhenDefaultBillingAddressIsMissing(): void
+    {
+        $this->createCustomer();
+        $this->deleteAddress('billing-address');
+
+        static::assertSame(200, $this->login());
+    }
+
+    public function testLoginSucceedsWhenDefaultShippingAddressIsMissing(): void
+    {
+        $this->createCustomer();
+        $this->deleteAddress('shipping-address');
+
+        static::assertSame(200, $this->login());
+    }
+
+    public function testLoginSucceedsWhenBothDefaultAddressesAreMissing(): void
+    {
+        $this->createCustomer();
+        $this->deleteAddress('billing-address');
+        $this->deleteAddress('shipping-address');
+
+        static::assertSame(200, $this->login());
+    }
+
+    public function testCartIsBlockedAndOrderIsRefusedWhenDefaultBillingAddressIsMissing(): void
+    {
+        $this->createCustomer();
+        $this->createProduct(ProductDefinition::TYPE_PHYSICAL);
+        $this->deleteAddress('billing-address');
+        static::assertSame(200, $this->login());
+
+        $errors = $this->addProductToCart();
+
+        static::assertArrayHasKey('billing-address-missing', $errors);
+        static::assertTrue($errors['billing-address-missing']['block']);
+        static::assertNotSame(
+            'checkout.billing-address-missing',
+            $errors['billing-address-missing']['translatedMessage'],
+            'the snippet must resolve, otherwise the raw key is shown to the customer'
+        );
+
+        $this->assertOrderIsRefused();
+    }
+
+    public function testDigitalOnlyCartIsRefusedWhenDefaultShippingAddressIsMissing(): void
+    {
+        $this->createCustomer();
+        $this->createProduct(ProductDefinition::TYPE_DIGITAL);
+        $this->deleteAddress('shipping-address');
+        static::assertSame(200, $this->login());
+
+        $errors = $this->addProductToCart();
+
+        static::assertArrayHasKey('shipping-address-missing', $errors);
+        static::assertTrue($errors['shipping-address-missing']['block']);
+
+        // a digital-only cart creates no delivery, so nothing downstream would stop the order
+        $this->assertOrderIsRefused();
+    }
+
+    public function testCustomerCanRepairTheMissingDefaultAddress(): void
+    {
+        $this->createCustomer();
+        $this->createProduct(ProductDefinition::TYPE_PHYSICAL);
+        $this->deleteAddress('billing-address');
+        $this->deleteAddress('shipping-address');
+        static::assertSame(200, $this->login());
+
+        static::assertNotEmpty($this->addProductToCart());
+
+        $this->browser->request('POST', '/store-api/account/address', [
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'street' => 'Musterstraße 2',
+            'city' => 'Schöppingen',
+            'zipcode' => '12345',
+            'salutationId' => $this->getValidSalutationId(),
+            'countryId' => $this->getValidCountryId($this->ids->get('sales-channel')),
+        ]);
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
+
+        // the route mints its own id and ignores one sent in the body
+        $addressId = $this->decodeResponse()['id'] ?? null;
+        static::assertIsString($addressId);
+
+        foreach (['default-billing', 'default-shipping'] as $type) {
+            $this->browser->request('PATCH', '/store-api/account/address/' . $type . '/' . $addressId);
+            static::assertSame(204, $this->browser->getResponse()->getStatusCode());
+        }
+
+        static::assertSame([], $this->addProductToCart());
+    }
+
+    private function login(): int
+    {
+        $this->browser->request('POST', '/store-api/account/login', [
+            'email' => $this->email,
+            'password' => 'shopware',
+        ]);
+
+        $token = $this->browser->getResponse()->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
+        if (\is_string($token)) {
+            $this->browser->setServerParameter('HTTP_SW_CONTEXT_TOKEN', $token);
+        }
+
+        return $this->browser->getResponse()->getStatusCode();
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function addProductToCart(): array
+    {
+        $this->browser->request(
+            'POST',
+            '/store-api/checkout/cart/line-item',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'items' => [[
+                    'id' => $this->ids->get('product'),
+                    'referencedId' => $this->ids->get('product'),
+                    'quantity' => 1,
+                    'type' => 'product',
+                ]],
+            ], \JSON_THROW_ON_ERROR)
+        );
+
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
+
+        return $this->decodeResponse()['errors'] ?? [];
+    }
+
+    private function assertOrderIsRefused(): void
+    {
+        $before = $this->countOrders();
+
+        $this->browser->request('POST', '/store-api/checkout/order', []);
+
+        static::assertNotSame(200, $this->browser->getResponse()->getStatusCode());
+        static::assertSame($before, $this->countOrders(), 'no order may be persisted without a valid address');
+    }
+
+    private function countOrders(): int
+    {
+        return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM `order`');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(): array
+    {
+        return json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    private function deleteAddress(string $key): void
+    {
+        $affected = $this->connection->delete('customer_address', ['id' => Uuid::fromHexToBytes($this->ids->get($key))]);
+
+        static::assertSame(1, $affected);
+    }
+
+    private function createCustomer(): void
+    {
+        $repository = static::getContainer()->get('customer.repository');
+        static::assertInstanceOf(EntityRepository::class, $repository);
+
+        $address = [
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'street' => 'Musterstraße 1',
+            'city' => 'Schöppingen',
+            'zipcode' => '12345',
+            'salutationId' => $this->getValidSalutationId(),
+            'countryId' => $this->getValidCountryId($this->ids->get('sales-channel')),
+        ];
+
+        $repository->create([[
+            'id' => $this->ids->create('customer'),
+            'salesChannelId' => $this->ids->get('sales-channel'),
+            'defaultBillingAddress' => ['id' => $this->ids->create('billing-address')] + $address,
+            'defaultShippingAddress' => ['id' => $this->ids->create('shipping-address')] + $address,
+            'groupId' => TestDefaults::FALLBACK_CUSTOMER_GROUP,
+            'email' => $this->email,
+            'password' => 'shopware',
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'salutationId' => $this->getValidSalutationId(),
+            'customerNumber' => '12345',
+        ]], Context::createDefaultContext());
+    }
+
+    private function createProduct(string $type): void
+    {
+        $repository = static::getContainer()->get('product.repository');
+        static::assertInstanceOf(EntityRepository::class, $repository);
+
+        $repository->create([[
+            'id' => $this->ids->create('product'),
+            'productNumber' => Uuid::randomHex(),
+            'stock' => 100,
+            'name' => 'Test product',
+            'type' => $type,
+            'price' => [[
+                'currencyId' => Defaults::CURRENCY,
+                'gross' => 25,
+                'net' => 25,
+                'linked' => false,
+            ]],
+            'manufacturer' => ['name' => 'Test manufacturer'],
+            'tax' => ['taxRate' => 19, 'name' => 'Test tax'],
+            'active' => true,
+            'visibilities' => [[
+                'salesChannelId' => $this->ids->get('sales-channel'),
+                'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+            ]],
+        ]], Context::createDefaultContext());
+    }
+}

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/LoginWithInvalidDefaultAddressTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/LoginWithInvalidDefaultAddressTest.php
@@ -22,9 +22,6 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  *
- * A customer's default_billing_address_id / default_shipping_address_id carry no DB constraint, so they can
- * point at a deleted customer_address row.
- *
  * @see https://github.com/shopware/shopware/issues/20225
  */
 #[Package('checkout')]
@@ -108,7 +105,7 @@ class LoginWithInvalidDefaultAddressTest extends TestCase
         static::assertArrayHasKey('shipping-address-missing', $errors);
         static::assertTrue($errors['shipping-address-missing']['block']);
 
-        // a digital-only cart creates no delivery, so nothing downstream would stop the order
+        // a digital-only cart creates no delivery, so only the validator can stop the order
         $this->assertOrderIsRefused();
     }
 
@@ -133,7 +130,7 @@ class LoginWithInvalidDefaultAddressTest extends TestCase
         ]);
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
 
-        // the route mints its own id and ignores one sent in the body
+        // the route mints its own id
         $addressId = $this->decodeResponse()['id'] ?? null;
         static::assertIsString($addressId);
 

--- a/tests/unit/Core/Checkout/Cart/Address/AddressValidatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Address/AddressValidatorTest.php
@@ -7,8 +7,10 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Address\AddressValidator;
 use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressMissingError;
 use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressSalutationMissingError;
 use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressMissingError;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
@@ -66,8 +68,9 @@ class AddressValidatorTest extends TestCase
         $country->setId(Uuid::randomHex());
         $country->setActive(true);
         $country->setShippingAvailable(false);
+        $country->setForceStateInRegistration(false);
 
-        $context = Generator::generateSalesChannelContext(country: $country);
+        $context = Generator::generateSalesChannelContext(customer: $this->createCustomer($country), country: $country);
 
         $idSearchResult = new IdSearchResult(
             1,
@@ -112,8 +115,9 @@ class AddressValidatorTest extends TestCase
         $country->setId(Uuid::randomHex());
         $country->setActive(true);
         $country->setShippingAvailable(true);
+        $country->setForceStateInRegistration(false);
 
-        $context = Generator::generateSalesChannelContext(country: $country);
+        $context = Generator::generateSalesChannelContext(customer: $this->createCustomer($country), country: $country);
 
         $idSearchResult = new IdSearchResult(
             1,
@@ -145,8 +149,9 @@ class AddressValidatorTest extends TestCase
         $country->setId(Uuid::randomHex());
         $country->setActive(true);
         $country->setShippingAvailable(false);
+        $country->setForceStateInRegistration(false);
 
-        $context = Generator::generateSalesChannelContext(country: $country);
+        $context = Generator::generateSalesChannelContext(customer: $this->createCustomer($country), country: $country);
 
         $idSearchResult = new IdSearchResult(
             1,
@@ -343,5 +348,115 @@ class AddressValidatorTest extends TestCase
         $this->validator->validate($cart, $errorCollection, $context);
 
         static::assertCount(0, $errorCollection);
+    }
+
+    public function testValidateAddsBlockingErrorsWhenBothActiveAddressesAreMissing(): void
+    {
+        $errorCollection = $this->validateWithCustomer(null, null, ProductDefinition::TYPE_PHYSICAL);
+
+        static::assertCount(2, $errorCollection);
+        static::assertInstanceOf(BillingAddressMissingError::class, $errorCollection->get('billing-address-missing'));
+        static::assertInstanceOf(ShippingAddressMissingError::class, $errorCollection->get('shipping-address-missing'));
+        static::assertTrue($errorCollection->blockOrder());
+    }
+
+    public function testValidateAddsBlockingErrorWhenOnlyBillingAddressIsMissing(): void
+    {
+        $country = $this->createCountry(true);
+        $errorCollection = $this->validateWithCustomer(null, $this->createAddress($country), ProductDefinition::TYPE_PHYSICAL, $country);
+
+        static::assertCount(1, $errorCollection);
+        static::assertInstanceOf(BillingAddressMissingError::class, $errorCollection->get('billing-address-missing'));
+        static::assertTrue($errorCollection->blockOrder());
+    }
+
+    public function testValidateBlocksDigitalOnlyCartWhenShippingAddressIsMissing(): void
+    {
+        $country = $this->createCountry(false);
+        $errorCollection = $this->validateWithCustomer($this->createAddress($country), null, ProductDefinition::TYPE_DIGITAL, $country);
+
+        static::assertCount(1, $errorCollection);
+        static::assertInstanceOf(ShippingAddressMissingError::class, $errorCollection->get('shipping-address-missing'));
+        static::assertTrue($errorCollection->blockOrder());
+    }
+
+    private function validateWithCustomer(
+        ?CustomerAddressEntity $billingAddress,
+        ?CustomerAddressEntity $shippingAddress,
+        string $productType,
+        ?CountryEntity $country = null
+    ): ErrorCollection {
+        $country ??= $this->createCountry(true);
+
+        $cart = new Cart('test');
+        $lineItem = (new LineItem('a', 'test'))->setPayloadValue(LineItem::PAYLOAD_PRODUCT_TYPE, $productType);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            $lineItem->setStates([$productType === ProductDefinition::TYPE_PHYSICAL ? State::IS_PHYSICAL : State::IS_DOWNLOAD]);
+        }
+
+        $cart->add($lineItem);
+
+        $customer = new CustomerEntity();
+        $customer->setId(Uuid::randomHex());
+        $customer->setActive(true);
+
+        if ($billingAddress !== null) {
+            $customer->setActiveBillingAddress($billingAddress);
+        }
+
+        if ($shippingAddress !== null) {
+            $customer->setActiveShippingAddress($shippingAddress);
+        }
+
+        $this->repository->method('searchIds')->willReturn(new IdSearchResult(
+            1,
+            [$country->getId() => ['data' => [], 'primaryKey' => $country->getId()]],
+            new Criteria(),
+            Context::createDefaultContext()
+        ));
+
+        $errorCollection = new ErrorCollection();
+        $this->validator->validate($cart, $errorCollection, Generator::generateSalesChannelContext(customer: $customer, country: $country));
+
+        return $errorCollection;
+    }
+
+    private function createCountry(bool $shippingAvailable): CountryEntity
+    {
+        $country = new CountryEntity();
+        $country->setId(Uuid::randomHex());
+        $country->setActive(true);
+        $country->setShippingAvailable($shippingAvailable);
+        $country->setForceStateInRegistration(false);
+
+        return $country;
+    }
+
+    private function createAddress(CountryEntity $country): CustomerAddressEntity
+    {
+        $address = new CustomerAddressEntity();
+        $address->setId(Uuid::randomHex());
+        $address->setCountryId($country->getId());
+        $address->setCountry($country);
+        $address->setFirstName('John');
+        $address->setLastName('Doe');
+        $address->setCity('ExampleCity');
+        $address->setSalutationId(Uuid::randomHex());
+
+        return $address;
+    }
+
+    private function createCustomer(CountryEntity $country): CustomerEntity
+    {
+        $address = $this->createAddress($country);
+
+        $customer = new CustomerEntity();
+        $customer->setId(Uuid::randomHex());
+        $customer->setActive(true);
+        $customer->setActiveBillingAddress($address);
+        $customer->setActiveShippingAddress($address);
+
+        return $customer;
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Address/Error/BillingAddressMissingErrorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Address/Error/BillingAddressMissingErrorTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Address\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressMissingError;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(BillingAddressMissingError::class)]
+class BillingAddressMissingErrorTest extends TestCase
+{
+    public function testAPI(): void
+    {
+        $error = new BillingAddressMissingError();
+
+        static::assertSame('billing-address-missing', $error->getId());
+        static::assertSame('The customer has no active billing address.', $error->getMessage());
+        static::assertSame('billing-address-missing', $error->getMessageKey());
+        static::assertSame(20, $error->getLevel());
+        static::assertTrue($error->blockOrder());
+        static::assertFalse($error->isPersistent());
+        static::assertSame([], $error->getParameters());
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Address/Error/ShippingAddressMissingErrorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Address/Error/ShippingAddressMissingErrorTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Address\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressMissingError;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ShippingAddressMissingError::class)]
+class ShippingAddressMissingErrorTest extends TestCase
+{
+    public function testAPI(): void
+    {
+        $error = new ShippingAddressMissingError();
+
+        static::assertSame('shipping-address-missing', $error->getId());
+        static::assertSame('The customer has no active shipping address.', $error->getMessage());
+        static::assertSame('shipping-address-missing', $error->getMessageKey());
+        static::assertSame(20, $error->getLevel());
+        static::assertTrue($error->blockOrder());
+        static::assertFalse($error->isPersistent());
+        static::assertSame([], $error->getParameters());
+    }
+}

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\System\SalesChannel\Context;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Cart\Tax\TaxDetector;
@@ -375,5 +376,133 @@ class SalesChannelContextFactoryTest extends TestCase
 
         $generatedContext = $factory->create(Uuid::randomHex(), $salesChannel->getId(), $options);
         static::assertSame($customer, $generatedContext->getCustomer());
+    }
+
+    /**
+     * @param list<'billing'|'shipping'> $danglingDefaults
+     */
+    #[DataProvider('danglingDefaultAddressProvider')]
+    public function testCustomerWithDanglingDefaultAddressDoesNotThrow(array $danglingDefaults, bool $expectsBillingAddress, bool $expectsShippingAddress): void
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $customer = new CustomerEntity();
+        $customer->setId(Uuid::randomHex());
+        $customer->setActive(true);
+        $customer->setDefaultBillingAddressId(Uuid::randomHex());
+        $customer->setDefaultShippingAddressId(Uuid::randomHex());
+        $customer->setGroupId(Uuid::randomHex());
+
+        $country = new CountryEntity();
+        $country->setId(Uuid::randomHex());
+        $currency = new CurrencyEntity();
+        $currency->setId(Uuid::randomHex());
+        $currency->setFactor(1);
+
+        $addresses = new CustomerAddressCollection();
+
+        if (!\in_array('billing', $danglingDefaults, true)) {
+            $billingAddress = new CustomerAddressEntity();
+            $billingAddress->setId($customer->getDefaultBillingAddressId());
+            $billingAddress->setCountry($country);
+            $addresses->add($billingAddress);
+        }
+
+        if (!\in_array('shipping', $danglingDefaults, true)) {
+            $shippingAddress = new CustomerAddressEntity();
+            $shippingAddress->setId($customer->getDefaultShippingAddressId());
+            $shippingAddress->setCountry($country);
+            $addresses->add($shippingAddress);
+        }
+
+        $baseShippingLocation = new ShippingLocation($country, null, null);
+
+        $baseContext = new BaseSalesChannelContext(
+            Context::createDefaultContext(new SalesChannelApiSource($salesChannel->getId())),
+            $salesChannel,
+            $currency,
+            new CustomerGroupEntity(),
+            new TaxCollection(),
+            new PaymentMethodEntity(),
+            new ShippingMethodEntity(),
+            $baseShippingLocation,
+            new CashRoundingConfig(2, 0.01, true),
+            new CashRoundingConfig(2, 0.01, true),
+            Generator::createLanguageInfo(),
+            MeasurementUnits::createDefaultUnits()
+        );
+
+        $customerRepository = new StaticEntityRepository(
+            [
+                static fn (Criteria $criteria, Context $context) => new EntitySearchResult(
+                    CustomerDefinition::ENTITY_NAME,
+                    1,
+                    new CustomerCollection([$customer]),
+                    null,
+                    $criteria,
+                    $context
+                ),
+            ],
+            new CustomerDefinition(),
+        );
+
+        $addressRepository = new StaticEntityRepository(
+            [
+                static fn (Criteria $criteria, Context $context) => new EntitySearchResult(
+                    CustomerAddressDefinition::ENTITY_NAME,
+                    $addresses->count(),
+                    $addresses,
+                    null,
+                    $criteria,
+                    $context
+                ),
+            ],
+            new CustomerAddressDefinition(),
+        );
+
+        $options = [
+            SalesChannelContextService::CUSTOMER_ID => $customer->getId(),
+        ];
+
+        $baseSalesChannelContextFactory = $this->createMock(AbstractBaseSalesChannelContextFactory::class);
+        $baseSalesChannelContextFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with($salesChannel->getId(), $options)
+            ->willReturn($baseContext);
+
+        $factory = new SalesChannelContextFactory(
+            $customerRepository,
+            static::createStub(EntityRepository::class),
+            $addressRepository,
+            static::createStub(EntityRepository::class),
+            static::createStub(TaxDetector::class),
+            [],
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(EntityRepository::class),
+            $baseSalesChannelContextFactory,
+        );
+
+        $generatedContext = $factory->create(Uuid::randomHex(), $salesChannel->getId(), $options);
+
+        $generatedCustomer = $generatedContext->getCustomer();
+        static::assertNotNull($generatedCustomer);
+        static::assertSame($expectsBillingAddress, $generatedCustomer->getActiveBillingAddress() !== null);
+        static::assertSame($expectsShippingAddress, $generatedCustomer->getActiveShippingAddress() !== null);
+
+        if (!$expectsShippingAddress) {
+            static::assertSame($baseShippingLocation, $generatedContext->getShippingLocation());
+        }
+    }
+
+    /**
+     * @return iterable<string, array{list<'billing'|'shipping'>, bool, bool}>
+     */
+    public static function danglingDefaultAddressProvider(): iterable
+    {
+        yield 'dangling default billing address' => [['billing'], false, true];
+        yield 'dangling default shipping address' => [['shipping'], true, false];
+        yield 'both default addresses dangling' => [['billing', 'shipping'], false, false];
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
A customer's `default_billing_address_id` / `default_shipping_address_id` carry no database foreign key, so they can point at a deleted `customer_address` row. `SalesChannelContextFactory` then passed null into the non-nullable `CustomerEntity` address setters, which made `/store-api/account/login` and `/store-api/account/imitate-customer` fail with a `TypeError`

### 2. What does this change do, exactly?
The factory now leaves the addresses unset and falls back to the sales channel shipping location. To keep such a cart from being ordered against a substituted country, AddressValidator turns its previously silent return into the blocking errors billing-address-missing and shipping-address-missing. The shipping error is not gated by $validateShipping, because a digital-only cart creates no delivery and would otherwise be persisted

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- Closes #20225
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
