### PR TITLE
feat(core): Extend country advanced postal code pattern length to 1024

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -132,6 +132,10 @@ Deleting, editing or moving a condition now updates `product_stream_mapping` and
 
 A group left without conditions, or invalid for another reason, now loses its assignments. A product export bound to such a group fails instead of exporting what it matched before.
 
+### Longer advanced postal code patterns for countries
+
+`country.advancedPostalCodePattern` now accepts up to 1024 characters instead of 255, matching `defaultPostalCodePattern`.
+
 ### `JsonField::addPropertyMapping()` for entity extensions
 
 `Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField` now has `addPropertyMapping()`. Plugins can call it from `EntityExtension::modifyFields()` to extend an existing JSON schema, for example to add another entity key to a structured `hitCount` map. The field collection passed to `modifyFields()` is keyed by property name, so `$collection->get('hitCount')` returns the field.

--- a/src/Core/Migration/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern.php
+++ b/src/Core/Migration/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1788950275;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            ALTER TABLE `country`
+            MODIFY COLUMN `advanced_postal_code_pattern` VARCHAR(1024) NULL
+        ');
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern.php
+++ b/src/Core/Migration/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Util\Database\TableHelper;
 
 /**
  * @internal
@@ -19,6 +21,16 @@ class Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern extends 
 
     public function update(Connection $connection): void
     {
+        $column = TableHelper::getColumnOfTable(
+            $connection,
+            'country',
+            'advanced_postal_code_pattern'
+        );
+
+        if ($column->type !== Types::STRING || $column->length === null || $column->length >= 1024) {
+            return;
+        }
+
         $connection->executeStatement('
             ALTER TABLE `country`
             MODIFY COLUMN `advanced_postal_code_pattern` VARCHAR(1024) NULL

--- a/src/Core/System/Country/CountryDefinition.php
+++ b/src/Core/System/Country/CountryDefinition.php
@@ -111,7 +111,7 @@ class CountryDefinition extends EntityDefinition
             (new BoolField('postal_code_required', 'postalCodeRequired'))->addFlags(new ApiAware())->setDescription('The postal code is made mandatory specification in the address, when boolean value is `true`.'),
             (new BoolField('check_postal_code_pattern', 'checkPostalCodePattern'))->addFlags(new ApiAware())->setDescription('Verify for valid postal code pattern.'),
             (new BoolField('check_advanced_postal_code_pattern', 'checkAdvancedPostalCodePattern'))->addFlags(new ApiAware())->setDescription('Verify for advanced postal code pattern.'),
-            (new StringField('advanced_postal_code_pattern', 'advancedPostalCodePattern'))->addFlags(new ApiAware())->setDescription('Wildcard formatted zip codes to allow easy searching in the frontend based on initial constants, for example - 24****, 1856**.'),
+            (new StringField('advanced_postal_code_pattern', 'advancedPostalCodePattern', 1024))->addFlags(new ApiAware())->setDescription('Wildcard formatted zip codes to allow easy searching in the frontend based on initial constants, for example - 24****, 1856**.'),
             (new TranslatedField('addressFormat'))->addFlags(new ApiAware()),
             (new StringField('default_postal_code_pattern', 'defaultPostalCodePattern', 1024))->addFlags(new ApiAware())->setDescription('Default pattern of postal or zip code.'),
             (new BoolField('is_eu', 'isEu'))->addFlags(new ApiAware(), new Required()),

--- a/tests/migration/Core/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest.php
+++ b/tests/migration/Core/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest.php
@@ -59,4 +59,26 @@ class Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest exte
         static::assertSame(1024, $column->length);
         static::assertFalse($column->isNotNull);
     }
+
+    public function testMigrationDoesNotChangeAlreadyCustomizedColumnLength(): void
+    {
+        $migration = new Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern();
+
+        $this->connection->executeStatement('
+            ALTER TABLE `country`
+            MODIFY COLUMN `advanced_postal_code_pattern` VARCHAR(2048) NULL
+        ');
+
+        $migration->update($this->connection);
+
+        $column = TableHelper::getColumnOfTable($this->connection, 'country', 'advanced_postal_code_pattern');
+        static::assertSame(Types::STRING, $column->type);
+        static::assertSame(2048, $column->length);
+        static::assertFalse($column->isNotNull);
+
+        $this->connection->executeStatement('
+            ALTER TABLE `country`
+            MODIFY COLUMN `advanced_postal_code_pattern` VARCHAR(1024) NULL
+        ');
+    }
 }

--- a/tests/migration/Core/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest.php
+++ b/tests/migration/Core/V6_7/Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern::class)]
+class Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePatternTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        $migration = new Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern();
+        static::assertSame(1788950275, $migration->getCreationTimestamp());
+    }
+
+    public function testMigrationChangesColumnLengthAndIsIdempotent(): void
+    {
+        $migration = new Migration1788950275ExtendLengthOfCountryAdvancedPostalCodePattern();
+
+        // Set column to original size to test the migration properly, as test DB may already have VARCHAR(1024)
+        $this->connection->executeStatement('
+            ALTER TABLE `country`
+            MODIFY COLUMN `advanced_postal_code_pattern` VARCHAR(255) NULL
+        ');
+
+        $column = TableHelper::getColumnOfTable($this->connection, 'country', 'advanced_postal_code_pattern');
+        static::assertSame(Types::STRING, $column->type);
+        static::assertSame(255, $column->length);
+
+        $migration->update($this->connection);
+
+        $column = TableHelper::getColumnOfTable($this->connection, 'country', 'advanced_postal_code_pattern');
+        static::assertSame(Types::STRING, $column->type);
+        static::assertSame(1024, $column->length);
+        static::assertFalse($column->isNotNull);
+
+        $migration->update($this->connection);
+
+        $column = TableHelper::getColumnOfTable($this->connection, 'country', 'advanced_postal_code_pattern');
+        static::assertSame(Types::STRING, $column->type);
+        static::assertSame(1024, $column->length);
+        static::assertFalse($column->isNotNull);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Try to adjust the ZIP code pattern for UK: https://github.com/shopware/shopware/blob/745ffb47f2af5208f0e68ac4156921b49272c5cd/src/Core/Migration/V6_4/Migration1649858046UpdateConfigurableFormatAndValidationForAddressCountry.php#L70

### 2. What does this change do, exactly?
Match the default length of the field.

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
