### PR TITLE
fix(content-system): type-check the tree a lifecycle listener hands back

### DIFF
--- a/src/Core/Framework/ContentSystem/Event/ContentTreePreparationEvent.php
+++ b/src/Core/Framework/ContentSystem/Event/ContentTreePreparationEvent.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\Framework\ContentSystem\Event;
 
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredElement;
+use Shopware\Core\Framework\ContentSystem\Layout\Scaffolding\StoredTreePreparer;
 use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
 use Shopware\Core\Framework\Context;
@@ -36,6 +38,7 @@ class ContentTreePreparationEvent implements ShopwareSalesChannelEvent
         public readonly SalesChannelContext $salesChannelContext,
         public readonly RenderingCacheContext $cacheContext,
     ) {
+        $this->rejectForeignTree($tree);
     }
 
     /**
@@ -51,6 +54,8 @@ class ContentTreePreparationEvent implements ShopwareSalesChannelEvent
      */
     public function replaceTree(array $tree): void
     {
+        $this->rejectForeignTree($tree);
+
         $this->tree = $tree;
     }
 
@@ -62,5 +67,40 @@ class ContentTreePreparationEvent implements ShopwareSalesChannelEvent
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->salesChannelContext;
+    }
+
+    /**
+     * The `list<StoredElement>` the signature can only promise in a docblock. A listener that hands the
+     * rendered model back instead reaches the preparation steps: the FULL path dies on the parameter type of a
+     * closure inside {@see StoredTreePreparer}, and the SKELETON path walks on to read `contextDefinitions` off
+     * an element that declares none, so what gets reported names a core internal rather than the listener that
+     * caused it. Depth needs no walk: every {@see StoredElement} refuses a foreign slot child, so a list of
+     * stored roots is a stored forest.
+     *
+     * @param array<array-key, mixed> $tree
+     */
+    private function rejectForeignTree(array $tree): void
+    {
+        if (!array_is_list($tree)) {
+            throw ContentSystemException::invalidMapValue(
+                'Stored content tree',
+                'tree',
+                'list<StoredElement>',
+                'array with non-list keys'
+            );
+        }
+
+        foreach ($tree as $index => $element) {
+            if ($element instanceof StoredElement) {
+                continue;
+            }
+
+            throw ContentSystemException::invalidMapValue(
+                'Stored content tree',
+                (string) $index,
+                StoredElement::class,
+                get_debug_type($element)
+            );
+        }
     }
 }

--- a/src/Core/Framework/ContentSystem/Event/Listener/AGENTS.md
+++ b/src/Core/Framework/ContentSystem/Event/Listener/AGENTS.md
@@ -5,6 +5,6 @@
 ## Constraints
 
 - Placeholders resolved in single pass, on the stored tree, after `ContentTreePreparationEvent` and in FULL mode only — a listener adding new placeholders MUST resolve them in the same dispatch cycle, and MUST NOT rely on the pipeline resolving anything in SKELETON mode
-- Both events carry their forest in private storage and replace it via `replaceTree()`: `ContentTreePreparationEvent` the stored one, `RenderedTreeFinalizationEvent` the rendered one. Every other event property is readonly, and neither exposes `RenderingMode`
+- Both events carry their forest in private storage and replace it via `replaceTree()`: `ContentTreePreparationEvent` the stored one, `RenderedTreeFinalizationEvent` the rendered one. Every other event property is readonly, and neither exposes `RenderingMode`. `replaceTree()` and the constructor both reject a replacement that is not a list of that event's own element model (`INVALID_MAP_VALUE`, 500); depth is covered by the element constructors, each of which rejects a slot child of the other model
 - A finalization listener may rewrite property values, remove, reorder AND add an element; it may NOT repeat an element id. `ContentPipeline::load()` rejects a repeated id in the forest the event handed back, after the dispatch and before the result is assembled (`DUPLICATE_ELEMENT_ID`, 500, not a client defect)
 - Extension: `#[AsEventListener]` attribute with event class and priority

--- a/src/Core/Framework/ContentSystem/Event/Listener/docs/custom-listeners.md
+++ b/src/Core/Framework/ContentSystem/Event/Listener/docs/custom-listeners.md
@@ -11,7 +11,7 @@ Listeners modify elements before or after rendering: computing derived values, t
 
 `ContentPipeline::load()` calls its own preparation and finishing steps directly rather than through these events, so the tree a listener sees does not depend on its priority. A `ContentTreePreparationEvent` listener sees the raw loaded layout, before placeholder resolution, the virtual-root wrap, the partial prune, the duplicate-element-id check, the wiring validation, the redistribute derivation and the render step. A `RenderedTreeFinalizationEvent` listener sees the finished rendered tree, after the virtual-root unwrap and the partial extract, and before the pipeline's second duplicate-element-id check, which judges the tree the listener handed back.
 
-The two carry the tree in the model of their own position, and each exposes one way to put a changed tree back:
+The two carry the tree in the model of their own position, and each exposes one way to put a changed tree back, which refuses anything that is not a list of that event's own model:
 
 - `ContentTreePreparationEvent::tree()` — `list<StoredElement>`; a replacement goes back through `replaceTree()`, because a stored element is immutable and an edit produces new instances
 - `RenderedTreeFinalizationEvent::tree()` — `list<RenderedElement>`; a replacement goes back through `replaceTree()`, because a rendered element is immutable too
@@ -36,6 +36,7 @@ The tree a listener hands back through `replaceTree()` is what the response carr
 | Reorder elements or slot children | Supported |
 | Add an element with a new id | Supported |
 | Duplicate an existing element id | Fails the render, `CONTENT_SYSTEM__DUPLICATE_ELEMENT_ID` (500) |
+| Hand back the stored model, or an array that is not a list | Fails the render, `CONTENT_SYSTEM__INVALID_MAP_VALUE` (500) |
 
 Element ids are a rendered-model contract, not bookkeeping: partial extraction addresses by id, the storefront emits `data-element-id`, and the decomposed format's `assignments` are keyed by it. The pipeline rejects a repeated id twice — once over the pre-prune stored forest before the render step, and once over the forest this event hands back — so a stored forest carrying one (a raw-SQL or migration write, or a preparation listener) fails just as a listener's duplicate does. Structural validity is otherwise the listener's responsibility; nothing repairs a tree a listener hands back.
 

--- a/src/Core/Framework/ContentSystem/Event/README.md
+++ b/src/Core/Framework/ContentSystem/Event/README.md
@@ -5,6 +5,15 @@ position: the preparation event carries the stored forest, the finalization even
 elements models are immutable, so each event exposes exactly one way to put a changed tree back, and it is
 the same way: `replaceTree()`. Neither exposes `RenderingMode`.
 
+Both `replaceTree()` and both constructors refuse a replacement that is not a list of that event's own
+element model. The two models are the mistake the storage/render split invites, and the pipeline's own
+post-event check does not catch it: that check reads `id`, which both models carry. Without the guard a
+rendered element handed to the preparation event reaches the preparation steps and fails there — as a
+`TypeError` on a closure parameter in FULL mode, and in SKELETON mode not until `WiringPlanner` reads
+`contextDefinitions` off an element that declares none — so what gets reported names a core internal rather
+than the listener that caused it. Depth needs no walk at the event: a `StoredElement` refuses a rendered slot
+child and a `RenderedElement` refuses a stored one, so a list of valid roots is a valid forest.
+
 ## Key Classes
 
 - `ContentTreePreparationEvent` - Dispatched over the stored tree before every preparation step

--- a/src/Core/Framework/ContentSystem/Event/RenderedTreeFinalizationEvent.php
+++ b/src/Core/Framework/ContentSystem/Event/RenderedTreeFinalizationEvent.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\ContentSystem\Event;
 
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\Rendering\RenderedElement;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
@@ -45,6 +46,7 @@ class RenderedTreeFinalizationEvent implements ShopwareSalesChannelEvent
         public readonly SalesChannelContext $salesChannelContext,
         public readonly RenderingCacheContext $cacheContext,
     ) {
+        $this->rejectForeignTree($tree);
     }
 
     /**
@@ -60,6 +62,8 @@ class RenderedTreeFinalizationEvent implements ShopwareSalesChannelEvent
      */
     public function replaceTree(array $tree): void
     {
+        $this->rejectForeignTree($tree);
+
         $this->tree = $tree;
     }
 
@@ -71,5 +75,39 @@ class RenderedTreeFinalizationEvent implements ShopwareSalesChannelEvent
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->salesChannelContext;
+    }
+
+    /**
+     * The `list<RenderedElement>` the signature can only promise in a docblock, and the symmetric half of the
+     * guard {@see ContentTreePreparationEvent} carries. The one check the pipeline already runs on what this
+     * event hands back reads `id` and `slots`, which the stored model carries too, so it waves a forest of the
+     * wrong model through to the encoders rather than reporting it. Depth needs no walk here: every
+     * {@see RenderedElement} refuses a foreign slot child, so a list of rendered roots is a rendered forest.
+     *
+     * @param array<array-key, mixed> $tree
+     */
+    private function rejectForeignTree(array $tree): void
+    {
+        if (!array_is_list($tree)) {
+            throw ContentSystemException::invalidMapValue(
+                'Rendered content tree',
+                'tree',
+                'list<RenderedElement>',
+                'array with non-list keys'
+            );
+        }
+
+        foreach ($tree as $index => $element) {
+            if ($element instanceof RenderedElement) {
+                continue;
+            }
+
+            throw ContentSystemException::invalidMapValue(
+                'Rendered content tree',
+                (string) $index,
+                RenderedElement::class,
+                get_debug_type($element)
+            );
+        }
     }
 }

--- a/src/Core/Framework/ContentSystem/Layout/Element/StoredElement.php
+++ b/src/Core/Framework/ContentSystem/Layout/Element/StoredElement.php
@@ -41,7 +41,7 @@ final readonly class StoredElement implements \JsonSerializable
     ) {
         $this->rejectNumericKeys($properties, 'Element property map');
         $this->rejectNumericKeys($dataRequirements, 'Element data requirement map');
-        $this->rejectNumericKeys($slots, 'Element slot map');
+        $this->rejectMalformedSlots($slots);
     }
 
     /**
@@ -231,6 +231,47 @@ final readonly class StoredElement implements \JsonSerializable
         foreach (array_keys($map) as $key) {
             if (\is_int($key)) {
                 throw ContentSystemException::invalidMapKey($mapType, 'int');
+            }
+        }
+    }
+
+    /**
+     * A foreign slot child is a 500 rather than a layout rejection because no client input can produce one:
+     * {@see StoredElementCodec::decodeSlots()} already rejects a malformed slot map, a non-list child list and
+     * a non-array child as client defects, and mints every child it admits through the codec itself. So a
+     * child that is not a stored element got here from a caller holding instances — core, a plugin, or a
+     * preparation listener — and that is a producer defect. The rendered counterpart guards its own slots on
+     * the same argument.
+     *
+     * @param array<array-key, mixed> $slots
+     */
+    private function rejectMalformedSlots(array $slots): void
+    {
+        foreach ($slots as $name => $children) {
+            if (\is_int($name)) {
+                throw ContentSystemException::invalidMapKey('Element slot map', 'int');
+            }
+
+            if (!\is_array($children) || !array_is_list($children)) {
+                throw ContentSystemException::invalidMapValue(
+                    'Element slot map',
+                    $name,
+                    'list',
+                    get_debug_type($children)
+                );
+            }
+
+            foreach ($children as $child) {
+                if ($child instanceof self) {
+                    continue;
+                }
+
+                throw ContentSystemException::invalidMapValue(
+                    'Element slot child list',
+                    $name,
+                    self::class,
+                    get_debug_type($child)
+                );
             }
         }
     }

--- a/tests/unit/Core/Framework/ContentSystem/Event/RenderedTreeFinalizationEventTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Event/RenderedTreeFinalizationEventTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
-use Shopware\Core\Framework\ContentSystem\Event\ContentTreePreparationEvent;
+use Shopware\Core\Framework\ContentSystem\Event\RenderedTreeFinalizationEvent;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredElement;
 use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
@@ -22,18 +22,18 @@ use Symfony\Component\HttpFoundation\Request;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(ContentTreePreparationEvent::class)]
-class ContentTreePreparationEventTest extends TestCase
+#[CoversClass(RenderedTreeFinalizationEvent::class)]
+class RenderedTreeFinalizationEventTest extends TestCase
 {
     #[TestDox('Exposes the constructed forest through tree(), then replaces it via replaceTree()')]
     public function testReplaceTreeReplacesWhatTreeReturns(): void
     {
-        $tree = [new StoredElement('root-id', 'section')];
+        $tree = [new RenderedElement('root-id', 'section')];
         $event = $this->createEvent($tree);
 
         static::assertSame($tree, $event->tree());
 
-        $replacement = [new StoredElement('injected-id', 'text')];
+        $replacement = [new RenderedElement('injected-id', 'text')];
         $event->replaceTree($replacement);
 
         static::assertSame($replacement, $event->tree());
@@ -43,10 +43,10 @@ class ContentTreePreparationEventTest extends TestCase
      * @param array<array-key, mixed> $replacement
      */
     #[DataProvider('foreignForestProvider')]
-    #[TestDox('refuses a replacement that is not a stored forest: $_dataName')]
+    #[TestDox('refuses a replacement that is not a rendered forest: $_dataName')]
     public function testReplaceTreeRefusesAForeignForest(array $replacement, ContentSystemException $expected): void
     {
-        $event = $this->createEvent([new StoredElement('root-id', 'section')]);
+        $event = $this->createEvent([new RenderedElement('root-id', 'section')]);
 
         $this->expectExceptionObject($expected);
 
@@ -57,7 +57,7 @@ class ContentTreePreparationEventTest extends TestCase
      * @param array<array-key, mixed> $replacement
      */
     #[DataProvider('foreignForestProvider')]
-    #[TestDox('refuses a construction that is not a stored forest: $_dataName')]
+    #[TestDox('refuses a construction that is not a rendered forest: $_dataName')]
     public function testConstructorRefusesAForeignForest(array $replacement, ContentSystemException $expected): void
     {
         $this->expectExceptionObject($expected);
@@ -68,11 +68,11 @@ class ContentTreePreparationEventTest extends TestCase
     #[TestDox('keeps the forest it holds when a replacement is refused')]
     public function testRefusedReplacementLeavesTheForestInPlace(): void
     {
-        $tree = [new StoredElement('root-id', 'section')];
+        $tree = [new RenderedElement('root-id', 'section')];
         $event = $this->createEvent($tree);
 
         try {
-            $event->replaceTree([new RenderedElement('rendered-id', 'text')]); // @phpstan-ignore argument.type (the guard answers for callers static analysis does not see)
+            $event->replaceTree([new StoredElement('stored-id', 'text')]); // @phpstan-ignore argument.type (the guard answers for callers static analysis does not see)
         } catch (ContentSystemException) {
         }
 
@@ -80,47 +80,47 @@ class ContentTreePreparationEventTest extends TestCase
     }
 
     /**
-     * The rendered model is the case the guard exists for: it is what a listener holds when it confuses the two
+     * The stored model is the case the guard exists for: it is what a listener holds when it confuses the two
      * sides of the storage/render split, and it carries an `id`, so the pipeline's own post-event check waves it
-     * through. The remaining cases are the shapes the `list<StoredElement>` docblock also promises and the
+     * through. The remaining cases are the shapes the `list<RenderedElement>` docblock also promises and the
      * runtime `array` type does not.
      *
      * @return iterable<string, array{array<array-key, mixed>, ContentSystemException}>
      */
     public static function foreignForestProvider(): iterable
     {
-        yield 'a rendered element' => [
-            [new RenderedElement('rendered-id', 'text')],
-            ContentSystemException::invalidMapValue('Stored content tree', '0', StoredElement::class, RenderedElement::class),
+        yield 'a stored element' => [
+            [new StoredElement('stored-id', 'text')],
+            ContentSystemException::invalidMapValue('Rendered content tree', '0', RenderedElement::class, StoredElement::class),
         ];
 
         yield 'a stored element behind a valid one' => [
-            [new StoredElement('root-id', 'section'), new RenderedElement('rendered-id', 'text')],
-            ContentSystemException::invalidMapValue('Stored content tree', '1', StoredElement::class, RenderedElement::class),
+            [new RenderedElement('root-id', 'section'), new StoredElement('stored-id', 'text')],
+            ContentSystemException::invalidMapValue('Rendered content tree', '1', RenderedElement::class, StoredElement::class),
         ];
 
-        yield 'a decoded element still in array form' => [
+        yield 'an element still in array form' => [
             [['id' => 'root-id', 'component' => 'section']],
-            ContentSystemException::invalidMapValue('Stored content tree', '0', StoredElement::class, 'array'),
+            ContentSystemException::invalidMapValue('Rendered content tree', '0', RenderedElement::class, 'array'),
         ];
 
         yield 'a forest keyed by element id' => [
-            ['root-id' => new StoredElement('root-id', 'section')],
-            ContentSystemException::invalidMapValue('Stored content tree', 'tree', 'list<StoredElement>', 'array with non-list keys'),
+            ['root-id' => new RenderedElement('root-id', 'section')],
+            ContentSystemException::invalidMapValue('Rendered content tree', 'tree', 'list<RenderedElement>', 'array with non-list keys'),
         ];
 
         yield 'a forest with a gap left by an unset root' => [
-            [0 => new StoredElement('first-id', 'section'), 2 => new StoredElement('third-id', 'section')],
-            ContentSystemException::invalidMapValue('Stored content tree', 'tree', 'list<StoredElement>', 'array with non-list keys'),
+            [0 => new RenderedElement('first-id', 'section'), 2 => new RenderedElement('third-id', 'section')],
+            ContentSystemException::invalidMapValue('Rendered content tree', 'tree', 'list<RenderedElement>', 'array with non-list keys'),
         ];
     }
 
     /**
-     * @param list<StoredElement> $tree
+     * @param list<RenderedElement> $tree
      */
-    private function createEvent(array $tree): ContentTreePreparationEvent
+    private function createEvent(array $tree): RenderedTreeFinalizationEvent
     {
-        return new ContentTreePreparationEvent(
+        return new RenderedTreeFinalizationEvent(
             $tree,
             LayoutReference::create('layout-1', 'Test', null),
             new RenderingSpecification([], PlaceholderValues::from([]), new Request()),

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Element/StoredElementTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Element/StoredElementTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataReq
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredValue;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Style\ElementStyle;
+use Shopware\Core\Framework\ContentSystem\Rendering\RenderedElement;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Stub\ContentSystem\StoredElementBuilder;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
@@ -183,6 +184,64 @@ class StoredElementTest extends TestCase
         $this->expectExceptionObject(ContentSystemException::invalidMapKey($mapType, 'int'));
 
         $construct($key);
+    }
+
+    /**
+     * @param callable(): StoredElement $construct
+     */
+    #[DataProvider('malformedSlotProvider')]
+    #[TestDox('rejects a malformed slot: $_dataName')]
+    public function testConstructorRejectsAMalformedSlot(callable $construct, ContentSystemException $expected): void
+    {
+        $this->expectExceptionObject($expected);
+
+        $construct();
+    }
+
+    /**
+     * A slot holds the same model as its parent, which is what makes the guard on the two lifecycle events
+     * sufficient at the roots alone. Every shape here is unreachable from client input — the codec rejects it
+     * long before a constructor sees it — so each is a producer defect and none is a client-defect code.
+     *
+     * @return iterable<string, array{callable(): StoredElement, ContentSystemException}>
+     */
+    public static function malformedSlotProvider(): iterable
+    {
+        yield 'a rendered element as a child' => [
+            static fn (): StoredElement => new StoredElement(
+                'element-1',
+                'core:section',
+                slots: ['main' => [new RenderedElement('child-1', 'core:text')]], // @phpstan-ignore argument.type (intentionally passing the rendered model to test the guard branch)
+            ),
+            ContentSystemException::invalidMapValue('Element slot child list', 'main', StoredElement::class, RenderedElement::class),
+        ];
+
+        yield 'a child still in array form' => [
+            static fn (): StoredElement => new StoredElement(
+                'element-1',
+                'core:section',
+                slots: ['main' => [['id' => 'child-1', 'component' => 'core:text']]], // @phpstan-ignore argument.type (intentionally passing an undecoded child to test the guard branch)
+            ),
+            ContentSystemException::invalidMapValue('Element slot child list', 'main', StoredElement::class, 'array'),
+        ];
+
+        yield 'a child list keyed by element id' => [
+            static fn (): StoredElement => new StoredElement(
+                'element-1',
+                'core:section',
+                slots: ['main' => ['child-1' => StoredElementBuilder::create('core:text', 'child-1')->build()]], // @phpstan-ignore argument.type (intentionally passing a map instead of a list to test the guard branch)
+            ),
+            ContentSystemException::invalidMapValue('Element slot map', 'main', 'list', 'array'),
+        ];
+
+        yield 'a lone child instead of a list' => [
+            static fn (): StoredElement => new StoredElement(
+                'element-1',
+                'core:section',
+                slots: ['main' => StoredElementBuilder::create('core:text', 'child-1')->build()], // @phpstan-ignore argument.type (intentionally passing a bare child to test the guard branch)
+            ),
+            ContentSystemException::invalidMapValue('Element slot map', 'main', 'list', StoredElement::class),
+        ];
     }
 
     /**


### PR DESCRIPTION
Checklist item 4 of #19954: **`ContentTreePreparationEvent::replaceTree()` type-checks its input.**

## The hole

Both lifecycle events took their forest as a runtime `array` under a `list<StoredElement>` / `list<RenderedElement>` docblock, in `replaceTree()` and in the constructor. The pipeline's own post-event check does not close it: that check reads `id` and `slots`, and **both** element models carry those, so a forest of the wrong model passes it.

## What actually happened before the fix

Measured, not assumed — a listener handing the rendered model to the preparation event:

| Input | Before |
|---|---|
| `RenderedElement` root, FULL | `TypeError` on a closure parameter inside `StoredTreePreparer` |
| `RenderedElement` root, SKELETON | survives placeholder resolution, the virtual-root check, the prune, the scaffolding derivation **and** the duplicate-id check; dies in `WiringPlanner` reading `contextDefinitions` off an element that declares none — after a PHP warning for the undefined property |
| `RenderedElement` nested in a slot | identical to the root case, both modes |
| non-list keys | PHP warning for the missing index `0`, then `TypeError: isVirtualRoot(): Argument #1 must be StoredElement, null given` |
| sparse keys `[0 => a, 2 => b]` | no error; silently re-keyed downstream |

So **nothing served a wrong response** — the ticket's concern is real but its consequence is diagnostic, not correctness. Every report named a core internal instead of the listener that caused it, and two of the paths passed through a PHP warning first.

## The fix

**Two levels, because one is not enough.** The nested-slot row above is why: a root-only check at the event is bypassable one level down, since `StoredElement`'s constructor guarded only its map *keys* and would happily hold a `RenderedElement`.

1. **`StoredElement` refuses a foreign slot child** (`07ddb2e`) — the missing half of a guard `RenderedElement` already had, for the same reason. A malformed slot map, a non-list child list, a bare child, an undecoded array: all `INVALID_MAP_VALUE` (500). None of it is reachable from client input — `StoredElementCodec::decodeSlots()` rejects every one of those shapes as a client defect and mints each admitted child itself — so each is a producer defect and the code stays outside `CLIENT_DEFECT_CODES`.

2. **Both events reject a replacement that is not a list of their own model** (`57abe3e`), naming the offending index, from `replaceTree()` *and* the constructor, and **before** assignment — so a refused replacement leaves the held forest in place.

The event check stays at the roots deliberately: with (1) in place, an element of either model refuses a child of the other, so a list of valid roots is a valid forest by induction. Walking the tree at the event would put the rule in the wrong place and pay O(tree) on the render hot path for it.

`RenderedTreeFinalizationEvent` is not named in the ticket, but it has the identical hole in the identical method, and the module's README treats the two as one contract. It also had **no test at all**; it has one now.

## Not done here

No new error code. `INVALID_MAP_VALUE` already means "a map or list value has the wrong type or shape", is already used for exactly these two checks by `RenderedElement::rejectMalformedSlots()`, and is already correctly outside the client-defect catalogue.

## Documentation

The rationale went to `Event/README.md` rather than `Listener/docs/custom-listeners.md`: that file was at 9,715 of the 10,000-character ceiling — a limit **this same ticket** has an open item about — and the paragraph would have pushed it to 10,430, creating an eighth over-budget surface. It gets the table row and one clause; the reasoning lives where the repo says reasoning lives.

## Verification

| Gate | Result |
|---|---|
| ContentSystem unit | 2353 / 2353 |
| ContentSystem integration | 246 / 246 |
| PHPStan | no findings on the changed files |
| ECS | clean |

New tests: 10 provider cases × 2 call sites (constructor + `replaceTree()`) per event, the "refused replacement does not replace" property for both, and 4 malformed-slot cases on `StoredElement`.

## Note for review

The BC checker sees no signature change here, so this needs no `.bc-exclude.php` entry — unlike #20260. The `@experimental` marker discussed there would still be worth having.
