### PR TITLE
fix: admin es order search by document number

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -81,6 +81,8 @@ Customers download v2 documents through the existing storefront and Store API ro
 
 The `document.orderId` and `document.orderVersionId` fields are now optional. Extensions that read documents directly should not assume every document belongs to an order. Use the `order` association only when it is available.
 
+`document` is no longer a sub entity of `order`, with or without the `DOCUMENT_GENERATION_REWORK` flag. A write that only touches `document` leaves `getPrimaryKeys('order')` empty on the `EntityWrittenContainerEvent`. Subscribers that reacted to document writes through the order keys should read `orderId` from the `document` write results instead, or resolve it from the database when the write does not set it.
+
 #### Deprecation of the legacy implementation
 
 Everything replaced by v2 is deprecated with `@deprecated tag:v6.9.0`: the legacy document domain in `Shopware\Core\Checkout\Document`, the legacy Administration services and modals, and the `document_type` and `document_type_translation` entities. Document types and formats become code-registered strings. Surviving shared classes move into the `DocumentV2` namespace with 6.9.

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -140,12 +140,24 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     public function refresh(EntityWrittenContainerEvent $event): void
     {
-        if (!$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
+        // only index entities that are written in the live version
+        if (!$this->adminEsHelper->isEnabled() || $event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
             return;
         }
 
-        $indexers = $this->getIndexersArray();
-        if ($indexers === []) {
+        $work = [];
+        foreach ($this->getIndexersArray() as $indexer) {
+            $deletedIds = $event->getDeletedPrimaryKeys($indexer->getEntity());
+            $ids = array_values(array_diff($indexer->getUpdatedIds($event), $deletedIds));
+
+            if ($ids === [] && $deletedIds === []) {
+                continue;
+            }
+
+            $work[] = [$indexer, $ids, $deletedIds];
+        }
+
+        if ($work === []) {
             return;
         }
 
@@ -167,15 +179,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
         $isSalesChannelSource = $event->getContext()->getSource() instanceof SalesChannelApiSource;
 
-        foreach ($indexers as $indexer) {
-            $ids = $indexer->getUpdatedIds($event);
-            $deletedIds = $event->getDeletedPrimaryKeys($indexer->getEntity());
-            $ids = array_values(array_diff($ids, $deletedIds));
-
-            if ($ids === [] && $deletedIds === []) {
-                continue;
-            }
-
+        foreach ($work as [$indexer, $ids, $deletedIds]) {
             $msg = new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), $indices, $ids, $deletedIds);
 
             // if the event is triggered from storefront or sales channel API, we dispatch the message to the queue to not slow down the request
@@ -226,24 +230,6 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 'body' => $mapping,
             ]);
         }
-    }
-
-    private function isIndexedEntityWritten(EntityWrittenContainerEvent $event): bool
-    {
-        // only index entities that are written in the live version
-        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
-            return false;
-        }
-
-        foreach ($this->indexer as $indexer) {
-            $ids = $event->getPrimaryKeys($indexer->getEntity());
-
-            if ($ids !== []) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private function push(AbstractAdminIndexer $indexer, AdminSearchIndexingMessage $message): void

--- a/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
+++ b/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
@@ -82,10 +82,7 @@ final class OrderAdminSearchIndexer extends AbstractAdminIndexer
             'orderId',
         ]);
 
-        $orderDocuments = $event->getPrimaryKeysWithPropertyChange(DocumentDefinition::ENTITY_NAME, [
-            'config',
-            'orderId',
-        ]);
+        $documents = $event->getResults(DocumentDefinition::ENTITY_NAME)->withPayloadProperties('config', 'orderId');
 
         $transactions = $event->getPrimaryKeysWithPropertyChange(OrderTransactionDefinition::ENTITY_NAME, [
             'stateId',
@@ -95,8 +92,12 @@ final class OrderAdminSearchIndexer extends AbstractAdminIndexer
             'stateId',
         ]);
 
-        if ($addresses !== [] || $orderDocuments !== [] || $transactions !== [] || $deliveries !== []) {
+        if ($addresses !== [] || $documents->count() > 0 || $transactions !== [] || $deliveries !== []) {
             $orderIds = array_merge($orderIds, $event->getPrimaryKeys($this->getEntity()));
+        }
+
+        foreach ($documents as $document) {
+            $orderIds[] = $document->getProperty('orderId');
         }
 
         $tags = $event->getPrimaryKeysWithPropertyChange(OrderTagDefinition::ENTITY_NAME, [

--- a/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -194,7 +194,7 @@ class AdminSearchRegistryTest extends TestCase
             new EntityWrittenEvent('promotion', [
                 new EntityWriteResult(
                     'c1a28776116d4431a2208eb2960ec340',
-                    [],
+                    ['active' => true],
                     'promotion',
                     EntityWriteResult::OPERATION_INSERT
                 ),

--- a/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -8,6 +8,7 @@ use OpenSearch\Exception\RuntimeException;
 use OpenSearch\Namespaces\IndicesNamespace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -489,6 +490,89 @@ class AdminSearchRegistryTest extends TestCase
         ]), []));
     }
 
+    #[TestDox('An indexer is asked for updated ids even when the event writes none of the indexed entities')]
+    public function testRefreshAsksIndexersForWritesOfUnindexedEntities(): void
+    {
+        $orderId = 'c1a28776116d4431a2208eb2960ec340';
+
+        $indexer = $this->createMock(AbstractAdminIndexer::class);
+        $indexer->method('getName')->willReturn('order-listing');
+        $indexer->method('getEntity')->willReturn('order');
+        $indexer->expects($this->once())->method('getUpdatedIds')->willReturn([$orderId]);
+        $indexer->method('fetch')->willReturn([
+            $orderId => ['id' => $orderId, 'text' => 'invoice 1000'],
+        ]);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllKeyValue')->willReturn(['sw-admin-order-listing' => 'sw-admin-order-listing_12345']);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())->method('bulk')->with(static::callback(
+            static fn (array $params): bool => $params['index'] === 'sw-admin-order-listing_12345'
+                && $params['body'][0] === ['index' => ['_id' => $orderId]]
+        ));
+
+        $registry = new AdminSearchRegistry(
+            ['order' => $indexer],
+            $connection,
+            static::createStub(MessageBusInterface::class),
+            static::createStub(EventDispatcherInterface::class),
+            $client,
+            new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger()),
+            static::createStub(LoggerInterface::class),
+            [],
+            [],
+            'test',
+            new NativeClock()
+        );
+
+        $registry->refresh(new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([
+            new EntityWrittenEvent('document', [
+                new EntityWriteResult(
+                    'a1a28776116d4431a2208eb2960ec341',
+                    ['orderId' => $orderId, 'config' => ['documentNumber' => '1000']],
+                    'document',
+                    EntityWriteResult::OPERATION_INSERT
+                ),
+            ], Context::createDefaultContext()),
+        ]), []));
+    }
+
+    #[TestDox('No index task is read when no indexer has updated or deleted ids')]
+    public function testRefreshDoesNotReadIndexTasksWithoutWork(): void
+    {
+        $this->indexer->method('getEntity')->willReturn('promotion');
+        $this->indexer->method('getUpdatedIds')->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchAllKeyValue');
+
+        $registry = new AdminSearchRegistry(
+            ['promotion' => $this->indexer],
+            $connection,
+            static::createStub(MessageBusInterface::class),
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(Client::class),
+            new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger()),
+            static::createStub(LoggerInterface::class),
+            [],
+            [],
+            'test',
+            new NativeClock()
+        );
+
+        $registry->refresh(new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([
+            new EntityWrittenEvent('document', [
+                new EntityWriteResult(
+                    'a1a28776116d4431a2208eb2960ec341',
+                    ['sent' => true],
+                    'document',
+                    EntityWriteResult::OPERATION_UPDATE
+                ),
+            ], Context::createDefaultContext()),
+        ]), []));
+    }
+
     public function testRefreshQueuesEveryAffectedIndexerForSalesChannelSources(): void
     {
         $this->indexer->method('getName')->willReturn('promotion-listing');
@@ -595,6 +679,7 @@ class AdminSearchRegistryTest extends TestCase
         $indexer = $this->createMock(AbstractAdminIndexer::class);
         $indexer->method('getName')->willReturn('promotion-listing');
         $indexer->method('getEntity')->willReturn('promotion');
+        $indexer->method('getUpdatedIds')->willReturn(['c1a28776116d4431a2208eb2960ec340']);
         $indexer->expects($this->never())->method('fetch');
 
         $client = $this->createMock(Client::class);

--- a/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Unit\Elasticsearch\Admin\Indexer;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
@@ -176,6 +178,71 @@ class OrderAdminSearchIndexerTest extends TestCase
         );
 
         static::assertSame([$orderId], $indexer->getUpdatedIds($event));
+    }
+
+    #[TestDox('A document write queues its order for reindexing without an order write in the event')]
+    public function testGetUpdatedIdsForDocumentWrite(): void
+    {
+        $orderId = Uuid::randomHex();
+
+        $event = new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(DocumentDefinition::ENTITY_NAME, [
+                    new EntityWriteResult(
+                        Uuid::randomHex(),
+                        ['orderId' => $orderId, 'config' => ['documentNumber' => '1000']],
+                        DocumentDefinition::ENTITY_NAME,
+                        EntityWriteResult::OPERATION_INSERT,
+                    ),
+                ], Context::createDefaultContext()),
+            ]),
+            []
+        );
+
+        static::assertSame([$orderId], $this->searchIndexer->getUpdatedIds($event));
+    }
+
+    #[TestDox('A document write without an order queues nothing')]
+    public function testGetUpdatedIdsForDocumentWriteWithoutOrder(): void
+    {
+        $event = new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(DocumentDefinition::ENTITY_NAME, [
+                    new EntityWriteResult(
+                        Uuid::randomHex(),
+                        ['orderId' => null, 'config' => ['documentNumber' => '1000']],
+                        DocumentDefinition::ENTITY_NAME,
+                        EntityWriteResult::OPERATION_INSERT,
+                    ),
+                ], Context::createDefaultContext()),
+            ]),
+            []
+        );
+
+        static::assertSame([], $this->searchIndexer->getUpdatedIds($event));
+    }
+
+    #[TestDox('A config-only document update queues nothing, its order id is not in the payload')]
+    public function testGetUpdatedIdsForConfigOnlyDocumentUpdate(): void
+    {
+        $event = new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(DocumentDefinition::ENTITY_NAME, [
+                    new EntityWriteResult(
+                        Uuid::randomHex(),
+                        ['config' => ['documentNumber' => '1000']],
+                        DocumentDefinition::ENTITY_NAME,
+                        EntityWriteResult::OPERATION_UPDATE,
+                    ),
+                ], Context::createDefaultContext()),
+            ]),
+            []
+        );
+
+        static::assertSame([], $this->searchIndexer->getUpdatedIds($event));
     }
 
     private function getConnection(): Connection


### PR DESCRIPTION
follow-up to #19678

With `SHOPWARE_ADMIN_ES_ENABLED=1`, a newly generated document number was not findable in the admin global search until something reindexed the order. #19678 removed `DocumentDefinition`'s parent definition, so a `document` write no longer puts its order into `EntityWrittenContainerEvent`, which is where admin search takes the ids it reindexes.