### PR TITLE
fix(core): keep dynamic group mapping writes free of FK violations

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -11,7 +11,6 @@ use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteR
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\UnmappedFieldException as DeprecatedUnmappedFieldException;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -85,8 +84,6 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
             return;
         }
 
-        $version = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
-
         // an invalid stream, or one left without filters, has nothing to match against
         $criteria = null;
         if ((int) $stream['invalid'] === 0 && $stream['api_filter'] !== null) {
@@ -123,17 +120,11 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
         $toBeAdded = array_values(array_diff($newMatches, $oldMatches));
         $toBeDeleted = array_values(array_diff($oldMatches, $newMatches));
 
-        $insert = new MultiInsertQueryQueue($this->connection, 250, false, false);
-
-        foreach ($toBeAdded as $id) {
-            $insert->addInsert('product_stream_mapping', [
-                'product_id' => Uuid::fromHexToBytes($id),
-                'product_version_id' => $version,
-                'product_stream_id' => $binaryStreamId,
-            ]);
+        if ($toBeAdded !== []) {
+            RetryableTransaction::retryable($this->connection, function () use ($toBeAdded, $binaryStreamId): void {
+                $this->insertMappings($toBeAdded, $binaryStreamId);
+            });
         }
-
-        $insert->execute();
 
         if ($toBeDeleted !== []) {
             RetryableTransaction::retryable($this->connection, function () use ($toBeDeleted, $binaryStreamId): void {
@@ -196,11 +187,10 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
 
         $streams = $this->connection->fetchAllAssociative('SELECT id, api_filter FROM product_stream WHERE invalid = 0 AND api_filter IS NOT NULL');
 
-        $insert = new MultiInsertQueryQueue($this->connection);
-
-        $version = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
-
         $languageContexts = $this->getLanguageContexts($context);
+
+        /** @var list<array{streamId: string, productIds: list<string>}> $matches */
+        $matches = [];
 
         foreach ($streams as $stream) {
             $filter = json_decode((string) $stream['api_filter'], true, 512, \JSON_THROW_ON_ERROR);
@@ -222,22 +212,23 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
                 continue;
             }
 
-            foreach ($matchedIds as $id) {
-                $insert->addInsert('product_stream_mapping', [
-                    'product_id' => Uuid::fromHexToBytes($id),
-                    'product_version_id' => $version,
-                    'product_stream_id' => $stream['id'],
-                ]);
+            if ($matchedIds === []) {
+                continue;
             }
+
+            $matches[] = ['streamId' => (string) $stream['id'], 'productIds' => $matchedIds];
         }
 
-        RetryableTransaction::retryable($this->connection, function () use ($ids, $insert): void {
+        RetryableTransaction::retryable($this->connection, function () use ($ids, $matches): void {
             $this->connection->executeStatement(
                 'DELETE FROM product_stream_mapping WHERE product_id IN (:ids)',
                 ['ids' => Uuid::fromHexToBytesList($ids)],
                 ['ids' => ArrayParameterType::BINARY]
             );
-            $insert->execute();
+
+            foreach ($matches as $match) {
+                $this->insertMappings($match['productIds'], $match['streamId']);
+            }
         });
     }
 
@@ -250,6 +241,30 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
     public function getDecorated(): EntityIndexer
     {
         throw new DecorationPatternException(static::class);
+    }
+
+    /**
+     * Selecting from `product` keeps the existence check in the insert, as the ids come from a search that
+     * ran before the write, so a product may be deleted by now.
+     *
+     * @param list<string> $productIds
+     */
+    private function insertMappings(array $productIds, string $binaryStreamId): void
+    {
+        foreach (array_chunk($productIds, 250) as $chunk) {
+            $this->connection->executeStatement(
+                'INSERT IGNORE INTO product_stream_mapping (product_id, product_version_id, product_stream_id)
+                 SELECT product.id, product.version_id, :streamId
+                 FROM product
+                 WHERE product.id IN (:ids) AND product.version_id = :version',
+                [
+                    'streamId' => $binaryStreamId,
+                    'ids' => Uuid::fromHexToBytesList($chunk),
+                    'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                ],
+                ['ids' => ArrayParameterType::BINARY],
+            );
+        }
     }
 
     /**

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -220,6 +220,10 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
         }
 
         RetryableTransaction::retryable($this->connection, function () use ($ids, $matches): void {
+            if ($matches !== []) {
+                $this->lockProducts($ids);
+            }
+
             $this->connection->executeStatement(
                 'DELETE FROM product_stream_mapping WHERE product_id IN (:ids)',
                 ['ids' => Uuid::fromHexToBytesList($ids)],
@@ -241,6 +245,29 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
     public function getDecorated(): EntityIndexer
     {
         throw new DecorationPatternException(static::class);
+    }
+
+    /**
+     * Locks the products before the mapping rows are touched, as a concurrent product delete takes the same
+     * locks in that order through its cascade. Sorted ids keep parallel runs in one order.
+     *
+     * @param string[] $productIds
+     */
+    private function lockProducts(array $productIds): void
+    {
+        $ids = Uuid::fromHexToBytesList($productIds);
+        sort($ids);
+
+        foreach (array_chunk($ids, 250) as $chunk) {
+            $this->connection->executeStatement(
+                'SELECT id FROM product WHERE id IN (:ids) AND version_id = :version ORDER BY id FOR UPDATE',
+                [
+                    'ids' => $chunk,
+                    'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                ],
+                ['ids' => ArrayParameterType::BINARY],
+            );
+        }
     }
 
     /**

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -583,8 +583,7 @@ class ProductStreamUpdaterTest extends TestCase
      */
     private function createUpdaterWithStaticMatches(array $matches): ProductStreamUpdater
     {
-        /** @var StaticEntityRepository<ProductCollection> $productRepository */
-        $productRepository = new StaticEntityRepository([], new ProductDefinition());
+        $productRepository = StaticEntityRepository::of(ProductCollection::class, [], new ProductDefinition());
 
         // one search runs per stream and language context, so the stale match has to stay available
         $search = static function () use ($matches, &$search, $productRepository): array {
@@ -596,8 +595,7 @@ class ProductStreamUpdaterTest extends TestCase
 
         $language = new LanguageEntity();
         $language->setId(Defaults::LANGUAGE_SYSTEM);
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([new LanguageCollection([$language])]);
+        $languageRepository = StaticEntityRepository::of(LanguageCollection::class, [new LanguageCollection([$language])]);
 
         return new ProductStreamUpdater(
             static::getContainer()->get(Connection::class),

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Content\Product\DataAbstractionLayer;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
@@ -22,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ManyToManyIdFieldUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
@@ -29,9 +31,11 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\Messenger\TraceableMessageBus;
 
@@ -524,6 +528,97 @@ class ProductStreamUpdaterTest extends TestCase
         $this->productStreamUpdater->updateProducts([$productId], Context::createDefaultContext());
 
         $this->assertProductIsInStream($productId, $streamId);
+    }
+
+    public function testHandleSkipsProductsDeletedAfterTheStreamSearch(): void
+    {
+        $streamId = Uuid::randomHex();
+        $this->createStream($streamId, [[
+            'type' => 'equals',
+            'field' => 'active',
+            'value' => '1',
+        ]]);
+
+        $productId = Uuid::randomHex();
+        $this->createProduct($productId);
+
+        $deletedProductId = Uuid::randomHex();
+        $this->createProduct($deletedProductId);
+        $this->productRepository->delete([['id' => $deletedProductId]], Context::createDefaultContext());
+
+        $updater = $this->createUpdaterWithStaticMatches([$productId, $deletedProductId]);
+
+        $updater->handle(new ProductStreamMappingIndexingMessage($streamId, null, Context::createDefaultContext()));
+
+        static::assertSame([$productId], $this->getMappedProductIds($streamId));
+    }
+
+    public function testUpdateProductsSkipsProductsDeletedAfterTheStreamSearch(): void
+    {
+        $streamId = Uuid::randomHex();
+        $this->createStream($streamId, [[
+            'type' => 'equals',
+            'field' => 'active',
+            'value' => '1',
+        ]]);
+
+        $productId = Uuid::randomHex();
+        $this->createProduct($productId);
+
+        $deletedProductId = Uuid::randomHex();
+        $this->createProduct($deletedProductId);
+        $this->productRepository->delete([['id' => $deletedProductId]], Context::createDefaultContext());
+
+        $updater = $this->createUpdaterWithStaticMatches([$productId, $deletedProductId]);
+
+        $updater->updateProducts([$productId, $deletedProductId], Context::createDefaultContext());
+
+        static::assertSame([$productId], $this->getMappedProductIds($streamId));
+    }
+
+    /**
+     * Returns an updater whose search reports a stale match, as a concurrent delete would.
+     *
+     * @param list<string> $matches
+     */
+    private function createUpdaterWithStaticMatches(array $matches): ProductStreamUpdater
+    {
+        /** @var StaticEntityRepository<ProductCollection> $productRepository */
+        $productRepository = new StaticEntityRepository([], new ProductDefinition());
+
+        // one search runs per stream and language context, so the stale match has to stay available
+        $search = static function () use ($matches, &$search, $productRepository): array {
+            $productRepository->searches[] = $search;
+
+            return $matches;
+        };
+        $productRepository->searches[] = $search;
+
+        $language = new LanguageEntity();
+        $language->setId(Defaults::LANGUAGE_SYSTEM);
+        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
+        $languageRepository = new StaticEntityRepository([new LanguageCollection([$language])]);
+
+        return new ProductStreamUpdater(
+            static::getContainer()->get(Connection::class),
+            static::getContainer()->get(ProductDefinition::class),
+            $productRepository,
+            static::getContainer()->get('messenger.default_bus'),
+            static::getContainer()->get(ManyToManyIdFieldUpdater::class),
+            $languageRepository,
+            true,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getMappedProductIds(string $streamId): array
+    {
+        return static::getContainer()->get(Connection::class)->fetchFirstColumn(
+            'SELECT LOWER(HEX(product_id)) FROM product_stream_mapping WHERE product_stream_id = :id',
+            ['id' => Uuid::fromHexToBytes($streamId)]
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request refactors how product-to-stream mappings are inserted in `ProductStreamUpdater`, improving reliability when products are deleted between stream search and mapping. The new approach uses a single SQL statement to insert only existing products and adds tests to ensure deleted products are skipped, preventing foreign key violations and making the process more robust.

**Refactoring of mapping insertion logic:**

* Replaced the use of `MultiInsertQueryQueue` with a new `insertMappings` method that performs an `INSERT IGNORE ... SELECT ... FROM product` statement, ensuring only existing products are mapped and avoiding foreign key violations if products are deleted after the stream search. [[1]](diffhunk://#diff-3fe6cebe48b5f0371b2df47d32688b69c0193a8cb85fe2152418366c3fa560d0L126-L137) [[2]](diffhunk://#diff-3fe6cebe48b5f0371b2df47d32688b69c0193a8cb85fe2152418366c3fa560d0L225-R231) [[3]](diffhunk://#diff-3fe6cebe48b5f0371b2df47d32688b69c0193a8cb85fe2152418366c3fa560d0R246-R272)
* Removed unnecessary variables and streamlined the logic in both `handle` and `updateProducts` methods to use the new insertion approach. [[1]](diffhunk://#diff-3fe6cebe48b5f0371b2df47d32688b69c0193a8cb85fe2152418366c3fa560d0L88-L89) [[2]](diffhunk://#diff-3fe6cebe48b5f0371b2df47d32688b69c0193a8cb85fe2152418366c3fa560d0L199-R194)
