### PR TITLE
test: dummy PR with short description (do not merge)

### DIFF
--- a/DANGER_DESCRIPTION_TEST.md
+++ b/DANGER_DESCRIPTION_TEST.md
@@ -1,0 +1,1 @@
+Dummy file for testing the MissingPullRequestDescription Danger rule (short description). Delete with the PR.


### PR DESCRIPTION
### 1. Why is this change necessary?
This dummy pull request checks that editing the description re-runs Danger.

### 2. What does this change do, exactly?
It adds one markdown file and nothing else; the description is the thing under test.