### PR TITLE
ci: bump deno version in publish release workflow

### DIFF
--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -17,9 +17,9 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v7
 
-        - uses: denoland/setup-deno@v2
+        - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
           with:
-            deno-version: 1.29.1
+            deno-version: v2.9.4
 
         - name: Generate Release Info
           run: |


### PR DESCRIPTION
### 1. Why is this change necessary?

The `release` job of `05-publish-release.yml` has been failing on every 6.6 release since v6.6.10.21 (2026-07-23):

```
error: Uncaught TypeError: URL.canParse is not a function
  at baseUrl (npm/marked-base-url/1.1.10/src/index.js:5:30)
  at generateVersionInfo (.github/release_info_generator.ts:121)
```

`release_info_generator.ts` imports `npm:marked-base-url` unpinned, so it resolves to the current version, which requires `URL.canParse` (Deno 1.38+). The workflow pinned Deno 1.29.1.

Because the generator is the first step, everything after it was skipped: the S3 changelog sync, the CloudFront invalidation and the Store API, Admin API, `shopware/production` and `testenv-platform` dispatches.

### 2. What does this change do, exactly?

Bumps `deno-version` from `1.29.1` to `v2.9.4` and pins `denoland/setup-deno` to a commit hash, matching what trunk already uses.

### 3. Describe each step to reproduce the issue or behaviour.

Publish a release on 6.6.x and watch the `release` job of the "Generate Release Info" workflow, e.g. https://github.com/shopware/shopware/actions/runs/34446950245

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.