### PR TITLE
fix(storefront): backport finished cart quantity edits to 6.6

### DIFF
--- a/changelog/_unreleased/2026-09-10-commit-cart-quantity-changes-on-finished-edit.md
+++ b/changelog/_unreleased/2026-09-10-commit-cart-quantity-changes-on-finished-edit.md
@@ -1,0 +1,18 @@
+---
+title: Commit cart quantity changes once the edit is finished
+issue: 19871
+author: Daniel Vien
+author_email: d.vienphamtri@shopware.com
+---
+# Storefront
+* Changed `QuantitySelectorPlugin` to apply typed and arrow-key quantity changes on blur or `Enter`, while retaining delayed updates for step buttons and native spinners.
+* Added the `submitOnFinish` option and `detail.submitImmediately` on committed quantity changes so `FormAutoSubmitPlugin` and `OffCanvasCartPlugin` can cancel pending updates and use their existing submission handlers immediately.
+* Changed `OffCanvasCartPlugin` to listen for quantity changes on the form and serialize cart mutations, including the shipping refresh, using the existing `HttpClient`.
+* Added `cancel()` and `flush(...args)` to callbacks returned by `Debouncer.debounce()`.
+* Added the `component.product.quantitySelect.cartUpdateHint` snippet to the cart quantity legend.
+___
+# Upgrade Information
+## Cart quantity change events
+Custom `change` listeners on a quantity form now receive the finished value when the input loses focus or the user presses `Enter`. On cart quantity controls, these events carry `detail.submitImmediately: true`; custom submission handlers should cancel any pending delayed update and apply the value immediately through their usual submission path.
+
+Step buttons and native spinners still use the configured delay. A move from the input to a step button also retains the delay so the edit and the next step can be sent together.

--- a/src/Storefront/Resources/app/storefront/src/helper/debouncer.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/debouncer.helper.js
@@ -11,18 +11,33 @@ export default class Debouncer {
      * @param {int} delay
      * @param {boolean} immediate
      *
-     * @returns {Function}
+     * @returns {Function} Debounced callback with `cancel()` to drop its pending invocations and
+     *                     `flush(...args)` to drop them and call back right away.
      */
     static debounce(callback, delay, immediate = false) {
         let timeout;
+        let leading;
 
-        return (...args) => {
+        const debounced = (...args) => {
             if (immediate &&  !timeout) {
-                setTimeout(callback.bind(callback, ...args), 0);
+                leading = setTimeout(callback.bind(callback, ...args), 0);
             }
 
             clearTimeout(timeout);
             timeout = setTimeout(callback.bind(callback, ...args), delay);
         };
+
+        debounced.cancel = () => {
+            clearTimeout(leading);
+            clearTimeout(timeout);
+            timeout = undefined;
+        };
+
+        debounced.flush = (...args) => {
+            debounced.cancel();
+            callback(...args);
+        };
+
+        return debounced;
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
@@ -90,24 +90,23 @@ export default class FormAutoSubmitPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
-        if (this.options.useAjax) {
-            const onSubmit =
-                this.options.delayChangeEvent ?
-                    Debouncer.debounce(this._onSubmit.bind(this), this.options.delayChangeEvent) :
-                    this._onSubmit.bind(this);
+        const onChange = this.options.useAjax ? this._onSubmit.bind(this) : this._onChange.bind(this);
+        if (this.options.delayChangeEvent) {
+            const delayedChange = Debouncer.debounce(onChange, this.options.delayChangeEvent);
+            this._form.addEventListener('change', (event) => {
+                if (event.detail?.submitImmediately) {
+                    delayedChange.flush(event);
+                    return;
+                }
 
-            this._form.removeEventListener('change', onSubmit);
-            this._form.addEventListener('change', onSubmit);
+                delayedChange(event);
+            });
         } else {
-            const onChange =
-                this.options.delayChangeEvent ?
-                    Debouncer.debounce(this._onChange.bind(this), this.options.delayChangeEvent) :
-                    this._onChange.bind(this);
-
-            this._form.removeEventListener('change', onChange);
             this._form.addEventListener('change', onChange);
+        }
 
-            // // Remove the loading indicator before leaving the page to not cache it in back/forward-cache.
+        if (!this.options.useAjax) {
+            // Remove the loading indicator before leaving the page to not cache it in back/forward-cache.
             window.addEventListener('pagehide', () => {
                 PageLoadingIndicatorUtil.remove();
             });

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
@@ -42,6 +42,7 @@ export default class OffCanvasCartPlugin extends Plugin {
 
     init() {
         this.client = new HttpClient();
+        this._requestQueue = Promise.resolve();
         this._registerOpenTriggerEvents();
     }
 
@@ -108,10 +109,19 @@ export default class OffCanvasCartPlugin extends Plugin {
 
         if (numberInputs) {
             Iterator.iterate(numberInputs, (input) => {
-                input.addEventListener('change', Debouncer.debounce(
+                // On the form: the `QuantitySelectorPlugin` withholds events on the input.
+                const delayedChange = Debouncer.debounce(
                     this._onChangeProductQuantity.bind(this),
                     this.options.changeQuantityInputDelay,
-                ));
+                );
+                input.form?.addEventListener('change', (event) => {
+                    if (event.detail?.submitImmediately) {
+                        delayedChange.flush(event);
+                        return;
+                    }
+
+                    delayedChange(event);
+                });
             });
         }
     }
@@ -202,15 +212,59 @@ export default class OffCanvasCartPlugin extends Plugin {
      * @private
      */
     _fireRequest(form, selector, callback) {
-        ElementLoadingIndicatorUtil.create(form.closest(selector));
+        const container = form.closest(selector);
+        ElementLoadingIndicatorUtil.create(container);
 
         const cb = callback ? callback.bind(this) : this._onOffCanvasOpened.bind(this, this._updateOffCanvasContent.bind(this));
         const requestUrl = DomAccess.getAttribute(form, 'action');
         const data = FormSerializeUtil.serialize(form);
 
-        this.$emitter.publish('beforeFireRequest');
+        // Snapshot the form before a preceding response replaces it, then apply mutations
+        // in order. Dropping responses cannot prevent older requests from changing the cart.
+        this._requestQueue = this._requestQueue
+            .then(() => {
+                this.$emitter.publish('beforeFireRequest');
 
-        this.client.post(requestUrl, data, cb);
+                return this._sendRequest('post', requestUrl, data);
+            })
+            .then(({ response, request }) => cb(response, request))
+            .catch((error) => {
+                // A failed mutation must not block later edits in the queue.
+                ElementLoadingIndicatorUtil.remove(container);
+                console.warn('Unable to update the off-canvas cart.', error);
+            });
+    }
+
+    /**
+     * Keep the 6.6 HttpClient callbacks while waiting for each request to finish.
+     *
+     * @param {'get'|'post'} method
+     * @param {string} url
+     * @param {FormData|null} data
+     * @returns {Promise}
+     * @private
+     */
+    _sendRequest(method, url, data = null) {
+        return new Promise((resolve, reject) => {
+            const onResponse = (response, request) => {
+                // HttpClient calls back on loadend, including failed and aborted requests.
+                if (request && request.status === 0) {
+                    reject(new Error(`The request to ${url} failed.`));
+                    return;
+                }
+
+                resolve({ response, request });
+            };
+
+            const request = method === 'post'
+                ? this.client.post(url, data, onResponse)
+                : this.client.get(url, onResponse, 'text/html');
+
+            // With internal error handling enabled, HttpClient only calls back on load.
+            ['error', 'abort', 'timeout'].forEach((eventName) => {
+                request?.addEventListener(eventName, () => reject(new Error(`The request to ${url} failed (${eventName}).`)));
+            });
+        });
     }
 
     /**
@@ -245,7 +299,7 @@ export default class OffCanvasCartPlugin extends Plugin {
 
         this.$emitter.publish('onChangeProductQuantity');
 
-        this._saveFocusState(select);
+        this._saveFocusState(form.contains(document.activeElement) ? document.activeElement : select);
         this._fireRequest(form, selector);
     }
 
@@ -303,10 +357,10 @@ export default class OffCanvasCartPlugin extends Plugin {
         const url = window.router['frontend.cart.offcanvas'];
 
         const _callback = () => {
-            this.client.get(url, response => {
+            return this._sendRequest('get', url).then(({ response }) => {
                 this._updateOffCanvasContent(response);
                 this._registerEvents();
-            }, 'text/html');
+            });
         };
 
         this._fireRequest(event.target.form, '.offcanvas-summary', _callback);

--- a/src/Storefront/Resources/app/storefront/src/plugin/quantity-selector/quantity-selector.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/quantity-selector/quantity-selector.plugin.js
@@ -19,12 +19,21 @@ export default class QuantitySelectorPlugin extends Plugin {
         ariaLiveUpdateMode: 'live',
         ariaLiveTextValueToken: '%quantity%',
         ariaLiveTextProductToken: '%product%',
+
+        /**
+         * Mark a change the user finished, by leaving the input or confirming with `Enter`,
+         * with `detail.submitImmediately` so the form handler applies it without its delay.
+         * Used where the form applies the quantity itself.
+         */
+        submitOnFinish: false,
     };
 
     init() {
         this._input = DomAccess.querySelector(this.el, 'input.js-quantity-selector');
         this._btnPlus = DomAccess.querySelector(this.el, '.js-btn-plus');
         this._btnMinus = DomAccess.querySelector(this.el, '.js-btn-minus');
+        this._committedValue = this._input.value;
+        this._pointerTarget = null;
 
         if (this.options.ariaLiveUpdates) {
             this._initAriaLiveUpdates();
@@ -68,35 +77,140 @@ export default class QuantitySelectorPlugin extends Plugin {
         this._btnPlus.addEventListener('click', this._stepUp.bind(this));
         this._btnMinus.addEventListener('click', this._stepDown.bind(this));
 
-        // prevent default submit on
-        this._input.addEventListener('keydown', (event) => {
-            if (event.keyCode === 13) {
-                event.preventDefault();
-                this._triggerChange();
-                return false;
+        this._input.addEventListener('keydown', this._onKeyDown.bind(this));
+        this._input.addEventListener('change', this._onChange.bind(this));
+        this._input.addEventListener('blur', this._onBlur.bind(this));
+        this._input.form?.addEventListener('submit', this._onSubmit.bind(this));
+
+        // In 6.6 the auto-submit plugin uses form.submit(), which does not emit `submit`.
+        this._input.form?.addEventListener('beforeChange', this._onSubmit.bind(this));
+        this._input.form?.addEventListener('beforeSubmit', this._onSubmit.bind(this));
+
+        this.el.addEventListener('pointerdown', this._onPointerDown.bind(this));
+    }
+
+    /**
+     * withhold a value the user is still editing, it is applied on blur or `Enter`
+     *
+     * @param {Event} event
+     * @private
+     */
+    _onChange(event) {
+        if (event.detail) {
+            this._committedValue = this._input.value;
+        } else {
+            event.stopPropagation();
+
+            if (this._pointerTarget === this._input) {
+                this._commit();
             }
-        });
+        }
+    }
+
+    /**
+     * remember the control under the pointer, a clicked button is not focused in every browser
+     * and the blur it causes then has no `relatedTarget`
+     *
+     * @param {PointerEvent} event
+     * @private
+     */
+    _onPointerDown(event) {
+        this._pointerTarget = event.target.closest('input, button');
+    }
+
+    /**
+     * the form sent the current value, it is the one to compare against from now on
+     *
+     * @private
+     */
+    _onSubmit() {
+        this._committedValue = this._input.value;
+    }
+
+    /**
+     * apply the current value on `Enter`
+     *
+     * @param {KeyboardEvent} event
+     * @private
+     */
+    _onKeyDown(event) {
+        this._pointerTarget = null;
+
+        if (event.key !== 'Enter') {
+            return;
+        }
+
+        event.preventDefault();
+        this._commit(undefined, this.options.submitOnFinish);
+    }
+
+    /**
+     * @private
+     */
+    _onBlur(event) {
+        const pointerTarget = this._pointerTarget;
+        this._pointerTarget = null;
+
+        // Tabbing or clicking on to the `[+]` and `[-]` buttons still applies the value, but lets
+        // a step the user makes next bundle into the same request.
+        if (this.el.contains(event.relatedTarget) || (pointerTarget && pointerTarget !== this._input)) {
+            this._commit();
+            return;
+        }
+
+        this._commit(undefined, this.options.submitOnFinish);
+    }
+
+    /**
+     * pass on a value as a change event
+     *
+     * @param {'up'|'down'|undefined} btn
+     * @param {boolean} submitImmediately
+     * @private
+     */
+    _commit(btn, submitImmediately = false) {
+        if (this._input.value === this._committedValue) {
+            return;
+        }
+
+        this._triggerChange(btn, submitImmediately);
     }
 
     /**
      * trigger change event on input element
      *
+     * @param {'up'|'down'|undefined} btn
+     * @param {boolean} submitImmediately
      * @private
      */
-    _triggerChange(btn) {
-        const event = new Event('change', { bubbles: true, cancelable: false });
+    _triggerChange(btn, submitImmediately = false) {
+        // Keep form submission with its owner, including AJAX, redirects and extension hooks.
+        const event = new CustomEvent('change', {
+            bubbles: true,
+            cancelable: false,
+            detail: { submitImmediately },
+        });
         this._input.dispatchEvent(event);
 
-        if (this.options.ariaLiveUpdateMode === 'live') {
-            this._updateAriaLive();
-        } else if (this.options.ariaLiveUpdateMode === 'onload') {
-            window.localStorage.setItem('lastQuantityChange', this.ariaLiveProductName);
-        }
+        this._announceChange();
 
         if (btn === 'up') {
             this._btnPlus.dispatchEvent(event);
         } else if (btn === 'down') {
             this._btnMinus.dispatchEvent(event);
+        }
+    }
+
+    /**
+     * announce the new quantity, now or after the next page load
+     *
+     * @private
+     */
+    _announceChange() {
+        if (this.options.ariaLiveUpdateMode === 'live') {
+            this._updateAriaLive();
+        } else if (this.options.ariaLiveUpdateMode === 'onload') {
+            window.localStorage.setItem('lastQuantityChange', this.ariaLiveProductName);
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/test/helper/debounce.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/debounce.helper.test.js
@@ -8,6 +8,49 @@ describe('debouncer helper', () => {
         jest.useFakeTimers();
     });
 
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test('cancels a pending invocation and allows subsequent calls', () => {
+        const callback = jest.fn();
+        const debounced = Debouncer.debounce(callback, 800);
+
+        debounced('stale');
+        debounced.cancel();
+        jest.advanceTimersByTime(800);
+        expect(callback).not.toHaveBeenCalled();
+
+        debounced('current');
+        jest.advanceTimersByTime(800);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith('current');
+    });
+
+    test('cancels the leading invocation of immediate mode as well', () => {
+        const callback = jest.fn();
+        const debounced = Debouncer.debounce(callback, 800, true);
+
+        debounced('stale');
+        debounced.cancel();
+        jest.advanceTimersByTime(800);
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    test('flushes a pending invocation with the given arguments right away', () => {
+        const callback = jest.fn();
+        const debounced = Debouncer.debounce(callback, 800);
+
+        debounced('stale');
+        debounced.flush('current');
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith('current');
+
+        jest.advanceTimersByTime(800);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
     test('it calls a function only once when called before timeout fired', () => {
         const spy = jest.fn();
 
@@ -68,5 +111,5 @@ describe('debouncer helper', () => {
         expect(spy).toBeCalledTimes(2);
         expect(spy).nthCalledWith(1, 1);
         expect(spy).nthCalledWith(2, 2);
-    })
+    });
 });

--- a/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-cart/offcanvas-cart.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-cart/offcanvas-cart.plugin.test.js
@@ -1,4 +1,5 @@
 import OffCanvasCartPlugin from 'src/plugin/offcanvas-cart/offcanvas-cart.plugin';
+import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-loading-indicator.util';
 
 /**
  * @package checkout
@@ -26,7 +27,8 @@ jest.mock('src/service/http-client.service', () => {
                 <a class="cart-item-label" href="#">Weird product with huge quantity</a>
 
                 <form action="/checkout/line-item/change-quantity/uuid555">
-                    <input type="number" name="quantity" class="js-offcanvas-cart-change-quantity-number" min="1" max="150" step="1" value="1">
+                    <input type="number" name="quantity" class="js-offcanvas-cart-change-quantity-number" min="1" max="150" step="1" value="1" data-focus-id="quantity-uuid555">
+                    <button type="button" class="js-btn-plus" data-focus-id="quantity-up-uuid555">+</button>
                 </form>
             </div>
         </div>
@@ -57,6 +59,11 @@ jest.mock('src/plugin-system/plugin.manager', () => ({
 describe('OffCanvasCartPlugin tests', () => {
 
     let plugin;
+
+    function flushPromises() {
+        // Let a finished response pass through the callback before the next queued request starts.
+        return new Promise(resolve => jest.requireActual('timers').setImmediate(resolve));
+    }
 
     beforeEach(() => {
 
@@ -101,6 +108,7 @@ describe('OffCanvasCartPlugin tests', () => {
 
     afterEach(() => {
         fireRequestSpy.mockClear();
+        jest.useRealTimers();
     });
 
     test('creates plugin instance', () => {
@@ -118,7 +126,7 @@ describe('OffCanvasCartPlugin tests', () => {
         expect(document.querySelector('.cart-item-product')).toBeTruthy();
     });
 
-    test('change product quantity using select', () => {
+    test('change product quantity using select', async () => {
         const el = document.querySelector('.header-cart');
 
         // Open offcanvas cart with click
@@ -128,6 +136,7 @@ describe('OffCanvasCartPlugin tests', () => {
 
         // Edit quantity using change event
         quantitySelect.dispatchEvent(new Event('change', { bubbles: true }));
+        await plugin._requestQueue;
 
         expect(plugin.$emitter.publish).toBeCalledWith('beforeFireRequest');
         expect(fireRequestSpy).toHaveBeenCalledTimes(1);
@@ -136,7 +145,7 @@ describe('OffCanvasCartPlugin tests', () => {
         expect(document.querySelector('.offcanvas-body').textContent).toBe('Content after update');
     });
 
-    test('change product quantity using number input', () => {
+    test('change product quantity using number input', async () => {
         const el = document.querySelector('.header-cart');
 
         // Open offcanvas cart with click
@@ -151,6 +160,7 @@ describe('OffCanvasCartPlugin tests', () => {
 
         // Wait for debounce with time from defaults
         jest.advanceTimersByTime(800);
+        await plugin._requestQueue;
 
         expect(plugin.$emitter.publish).toBeCalledWith('beforeFireRequest');
         expect(fireRequestSpy).toHaveBeenCalledTimes(1);
@@ -159,7 +169,19 @@ describe('OffCanvasCartPlugin tests', () => {
         expect(document.querySelector('.offcanvas-body').textContent).toBe('Content after update');
     });
 
-    test('change product quantity should not send too many requests when spamming the number input', () => {
+    test('does not submit a number input change withheld from the form', () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+
+        const quantityInput = document.querySelector('.js-offcanvas-cart-change-quantity-number');
+        // The quantity selector withholds native arrow-key changes until the edit is finished.
+        quantityInput.addEventListener('change', event => event.stopPropagation());
+        quantityInput.dispatchEvent(new Event('change', { bubbles: true }));
+        jest.advanceTimersByTime(800);
+
+        expect(fireRequestSpy).not.toHaveBeenCalled();
+    });
+
+    test('change product quantity should not send too many requests when spamming the number input', async () => {
         const el = document.querySelector('.header-cart');
 
         // Open offcanvas cart with click
@@ -177,15 +199,200 @@ describe('OffCanvasCartPlugin tests', () => {
         // Wait for debounce with time from defaults
         jest.advanceTimersByTime(800);
 
+        await plugin._requestQueue;
+
         // Change quantity again, this time after waiting long enough
         quantityInput.dispatchEvent(new Event('change', { bubbles: true }));
 
         // Wait for debounce with time from defaults
         jest.advanceTimersByTime(800);
+        await plugin._requestQueue;
 
         expect(plugin.$emitter.publish).toBeCalledWith('beforeFireRequest');
 
         // Only 2 requests should be fired because the throttling should prevent the first spam inputs
         expect(fireRequestSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('applies a committed change immediately and cancels the delayed update', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const input = document.querySelector('.js-offcanvas-cart-change-quantity-number');
+        const post = jest.spyOn(plugin.client, 'post');
+
+        input.value = '2';
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.value = '3';
+        input.dispatchEvent(new CustomEvent('change', { bubbles: true, detail: { submitImmediately: true } }));
+
+        expect(fireRequestSpy).toHaveBeenCalledTimes(1);
+        await plugin._requestQueue;
+        expect(post).toHaveBeenCalledTimes(1);
+        expect(post.mock.calls[0][1].get('quantity')).toBe('3');
+
+        jest.advanceTimersByTime(800);
+        await plugin._requestQueue;
+        expect(post).toHaveBeenCalledTimes(1);
+    });
+
+    test('restores focus to the element focused when the delayed request fires', async () => {
+        plugin.options.autoFocus = true;
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        jest.runOnlyPendingTimers();
+
+        const input = document.querySelector('.js-offcanvas-cart-change-quantity-number');
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        document.querySelector('.js-btn-plus').focus();
+        jest.advanceTimersByTime(800);
+        await plugin._requestQueue;
+
+        expect(window.focusHandler.saveFocusState).toHaveBeenCalledWith('offcanvas-cart', '[data-focus-id="quantity-up-uuid555"]');
+    });
+
+    test('applies removal and quantity mutations in order and snapshots the submitted quantity', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const responses = [];
+        const serverCart = { a: 1, b: 1 };
+        const post = jest.spyOn(plugin.client, 'post').mockImplementation((url, data, callback) => {
+            responses.push(() => {
+                if (url === '/remove-a') {
+                    delete serverCart.a;
+                } else {
+                    serverCart.b = Number(data.get('quantity'));
+                }
+
+                callback(`<div class="offcanvas-body">${JSON.stringify(serverCart)}</div>`, { status: 200 });
+            });
+        });
+
+        const removeForm = document.querySelector('form');
+        removeForm.action = '/remove-a';
+        removeForm.classList.add('js-offcanvas-cart-remove-product');
+        plugin._registerRemoveProductTriggerEvents();
+        removeForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+        const input = document.querySelector('.js-offcanvas-cart-change-quantity-number');
+        input.value = '2';
+        input.dispatchEvent(new CustomEvent('change', { bubbles: true, detail: { submitImmediately: true } }));
+        input.value = '3';
+        await flushPromises();
+        expect(post).toHaveBeenCalledTimes(1);
+
+        responses.shift()();
+        await flushPromises();
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('{"b":1}');
+        expect(post).toHaveBeenCalledTimes(2);
+
+        responses.shift()();
+        await plugin._requestQueue;
+        expect(serverCart).toEqual({ b: 2 });
+        expect(document.querySelector('.offcanvas-body').textContent).toBe(JSON.stringify(serverCart));
+    });
+
+    test('continues with queued mutations after a failed XMLHttpRequest calls back on loadend', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const removeIndicator = jest.spyOn(ElementLoadingIndicatorUtil, 'remove');
+        const post = jest.spyOn(plugin.client, 'post')
+            .mockImplementationOnce((url, data, callback) => callback('', { status: 0 }))
+            .mockImplementationOnce((url, data, callback) => callback('<div class="offcanvas-body">Recovered</div>', { status: 200 }));
+        const forms = document.querySelectorAll('form');
+        const failedContainer = forms[0].closest('.js-cart-item');
+
+        plugin._fireRequest(forms[0], '.js-cart-item');
+        plugin._fireRequest(forms[1], '.js-cart-item');
+        await plugin._requestQueue;
+
+        expect(warn).toHaveBeenCalledWith('Unable to update the off-canvas cart.', expect.any(Error));
+        expect(removeIndicator).toHaveBeenCalledWith(failedContainer);
+        expect(post).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('Recovered');
+        warn.mockRestore();
+        removeIndicator.mockRestore();
+    });
+
+    test.each(['error', 'abort', 'timeout'])('continues after an XMLHttpRequest %s without a response callback', async (eventName) => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const request = document.createElement('div');
+        const post = jest.spyOn(plugin.client, 'post').mockReturnValueOnce(request);
+        const forms = document.querySelectorAll('form');
+
+        plugin._fireRequest(forms[0], '.js-cart-item');
+        plugin._fireRequest(forms[1], '.js-cart-item');
+        await flushPromises();
+        expect(post).toHaveBeenCalledTimes(1);
+
+        // HttpClient with internal error handling does not invoke its callback in these cases.
+        request.dispatchEvent(new Event(eventName));
+        await plugin._requestQueue;
+
+        expect(warn).toHaveBeenCalledWith('Unable to update the off-canvas cart.', expect.any(Error));
+        expect(post).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('Content after update');
+        warn.mockRestore();
+    });
+
+    test('continues with queued mutations after a response callback throws', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const error = new Error('Unable to render response');
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const post = jest.spyOn(plugin.client, 'post');
+        const forms = document.querySelectorAll('form');
+
+        plugin._fireRequest(forms[0], '.js-cart-item', () => { throw error; });
+        plugin._fireRequest(forms[1], '.js-cart-item');
+        await plugin._requestQueue;
+
+        expect(warn).toHaveBeenCalledWith('Unable to update the off-canvas cart.', error);
+        expect(post).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('Content after update');
+        warn.mockRestore();
+    });
+
+    test('preserves the callback context and XMLHttpRequest argument', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        const request = { status: 200 };
+        jest.spyOn(plugin.client, 'post').mockImplementationOnce((url, data, callback) => callback('Response', request));
+        const callback = jest.fn();
+
+        plugin._fireRequest(document.querySelector('form'), '.js-cart-item', callback);
+        await plugin._requestQueue;
+
+        expect(callback).toHaveBeenCalledWith('Response', request);
+        expect(callback.mock.instances[0]).toBe(plugin);
+    });
+
+    test('waits for the shipping refresh before sending the next mutation', async () => {
+        document.querySelector('.header-cart').dispatchEvent(new Event('click', { bubbles: true }));
+        document.body.insertAdjacentHTML('beforeend', `
+            <div class="offcanvas-summary">
+                <form action="/shipping"><select name="shippingMethodId"><option value="express">Express</option></select></form>
+            </div>`);
+        const responses = [];
+        const post = jest.spyOn(plugin.client, 'post').mockImplementation((url, data, callback) => { responses.push(callback); });
+        const get = jest.spyOn(plugin.client, 'get').mockImplementation((url, callback) => { responses.push(callback); });
+
+        plugin._onChangeShippingMethod({
+            preventDefault: jest.fn(),
+            target: document.querySelector('.offcanvas-summary select'),
+        });
+        plugin._fireRequest(document.querySelector('.js-cart-item form'), '.js-cart-item');
+        await flushPromises();
+        expect(post).toHaveBeenCalledTimes(1);
+        expect(get).not.toHaveBeenCalled();
+
+        responses.shift()('');
+        await flushPromises();
+        expect(get).toHaveBeenCalledWith('/checkout/offcanvas', expect.any(Function), 'text/html');
+        expect(post).toHaveBeenCalledTimes(1);
+
+        responses.shift()('<div class="offcanvas-body">Shipping updated</div>');
+        await flushPromises();
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('Shipping updated');
+        expect(post).toHaveBeenCalledTimes(2);
+
+        responses.shift()('<div class="offcanvas-body">Quantity updated</div>');
+        await plugin._requestQueue;
+        expect(document.querySelector('.offcanvas-body').textContent).toBe('Quantity updated');
     });
 });

--- a/src/Storefront/Resources/app/storefront/test/plugin/quantity-selector/quantity-selector-submit.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/quantity-selector/quantity-selector-submit.test.js
@@ -1,0 +1,180 @@
+import QuantitySelectorPlugin from 'src/plugin/quantity-selector/quantity-selector.plugin';
+import OffCanvasCartPlugin from 'src/plugin/offcanvas-cart/offcanvas-cart.plugin';
+import FormAutoSubmitPlugin from 'src/plugin/forms/form-auto-submit.plugin';
+
+/**
+ * @package checkout
+ */
+describe('Quantity selector form submission', () => {
+    function renderQuantity(quantity = 1) {
+        document.body.innerHTML = `
+            <div class="header-cart"></div>
+            <div class="js-cart-item">
+                <form action="/quantity" method="post">
+                    <div data-quantity-selector>
+                        <button type="button" class="js-btn-minus">-</button>
+                        <input type="number" name="quantity" min="1" max="100" step="1" value="${quantity}"
+                            class="js-quantity-selector js-offcanvas-cart-change-quantity-number">
+                        <button type="button" class="js-btn-plus">+</button>
+                    </div>
+                </form>
+            </div>`;
+
+        new QuantitySelectorPlugin(document.querySelector('[data-quantity-selector]'), {
+            submitOnFinish: true,
+            ariaLiveUpdates: false,
+        });
+
+        const input = document.querySelector('input');
+        // The 6.6 JSDOM version does not implement the native number-input step methods.
+        input.stepUp = jest.fn(() => { input.value = Number(input.value) + 1; });
+        input.stepDown = jest.fn(() => { input.value = Number(input.value) - 1; });
+        return input;
+    }
+
+    function finishEdit(input, value, finish = 'enter') {
+        input.focus();
+        input.value = value;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        if (finish === 'blur') {
+            input.blur();
+        } else {
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+        }
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        window.history.replaceState({}, '', '/');
+    });
+
+    test.each(['native', 'offcanvas'])('does not submit slow arrow-key edits in the %s cart', (mode) => {
+        const input = renderQuantity();
+        const submit = jest.fn();
+        if (mode === 'native') {
+            input.form.submit = submit;
+            new FormAutoSubmitPlugin(input.form, { autoFocus: false, delayChangeEvent: 800 });
+        } else {
+            const cart = new OffCanvasCartPlugin(document.querySelector('.header-cart'));
+            jest.spyOn(cart, '_fireRequest').mockImplementation(submit);
+            cart._registerChangeQuantityProductTriggerEvents();
+        }
+
+        input.focus();
+        for (const value of ['2', '3']) {
+            // A native number input emits change for each arrow key, without losing focus.
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+            input.value = value;
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            jest.advanceTimersByTime(1000);
+        }
+
+        expect(document.activeElement).toBe(input);
+        expect(submit).not.toHaveBeenCalled();
+        input.blur();
+        expect(submit).toHaveBeenCalledTimes(1);
+        jest.advanceTimersByTime(1000);
+        expect(submit).toHaveBeenCalledTimes(1);
+    });
+
+    test.each(['enter', 'blur'])('keeps redirect parameters and cancels delayed native updates on %s', (finish) => {
+        const input = renderQuantity();
+        const form = input.form;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+        window.history.replaceState({}, '', '?test-param=retained');
+        const submissions = [];
+        form.submit = jest.fn(() => {
+            submissions.push(new FormData(form));
+        });
+
+        document.querySelector('.js-btn-plus').click();
+        finishEdit(input, '3', finish);
+
+        expect(submissions).toHaveLength(1);
+        expect(submissions[0].get('redirectParameters[test-param]')).toBe('retained');
+        expect(submissions[0].get('quantity')).toBe('3');
+        jest.advanceTimersByTime(800);
+        expect(submissions).toHaveLength(1);
+    });
+
+    test.each(['enter', 'blur'])('keeps AJAX submission and cancels delayed updates on %s', (finish) => {
+        const input = renderQuantity();
+        const autoSubmit = new FormAutoSubmitPlugin(input.form, {
+            autoFocus: false,
+            delayChangeEvent: 800,
+            useAjax: true,
+            ajaxContainerSelector: '.js-cart-item',
+        });
+        const ajaxSubmit = jest.spyOn(autoSubmit, 'sendAjaxFormSubmit').mockImplementation(() => {});
+        const nativeSubmit = jest.fn();
+        input.form.submit = nativeSubmit;
+
+        document.querySelector('.js-btn-plus').click();
+        finishEdit(input, '3', finish);
+
+        expect(ajaxSubmit).toHaveBeenCalledTimes(1);
+        expect(nativeSubmit).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(800);
+        expect(ajaxSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    test.each(['enter', 'blur'])('does not overwrite a newer offcanvas quantity after %s', (finish) => {
+        let input = renderQuantity();
+        const cart = new OffCanvasCartPlugin(document.querySelector('.header-cart'));
+        const quantities = [];
+        jest.spyOn(cart, '_fireRequest').mockImplementation(form => quantities.push(new FormData(form).get('quantity')));
+        cart._registerChangeQuantityProductTriggerEvents();
+
+        document.querySelector('.js-btn-plus').click();
+        finishEdit(input, '3', finish);
+        expect(quantities).toEqual(['3']);
+
+        // A successful response replaces the form before its old debounce timer expires.
+        input = renderQuantity(3);
+        cart._registerChangeQuantityProductTriggerEvents();
+        finishEdit(input, '4', finish);
+        expect(quantities).toEqual(['3', '4']);
+
+        jest.advanceTimersByTime(800);
+        expect(quantities).toEqual(['3', '4']);
+    });
+
+    test.each([
+        ['native', 'enter'],
+        ['native', 'blur'],
+        ['ajax', 'enter'],
+        ['ajax', 'blur'],
+    ])('does not repeat an already sent %s quantity on %s', (mode, finish) => {
+        const input = renderQuantity();
+        const form = input.form;
+        const autoSubmit = new FormAutoSubmitPlugin(form, {
+            autoFocus: false,
+            delayChangeEvent: 800,
+            useAjax: mode === 'ajax',
+            ajaxContainerSelector: '.js-cart-item',
+        });
+        const submissions = [];
+        const submit = () => submissions.push(new FormData(form).get('quantity'));
+        if (mode === 'ajax') {
+            jest.spyOn(autoSubmit, 'sendAjaxFormSubmit').mockImplementation(submit);
+        } else {
+            form.submit = jest.fn(submit);
+        }
+
+        document.querySelector('.js-btn-plus').click();
+        // An arrow key press while the step is still delayed rides along with it.
+        input.focus();
+        input.value = '3';
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        jest.advanceTimersByTime(800);
+        expect(submissions).toEqual(['3']);
+
+        finishEdit(input, '3', finish);
+        expect(submissions).toEqual(['3']);
+    });
+});

--- a/src/Storefront/Resources/app/storefront/test/plugin/quantity-selector/quantity-selector.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/quantity-selector/quantity-selector.plugin.test.js
@@ -1,4 +1,5 @@
 import QuantitySelectorPlugin from 'src/plugin/quantity-selector/quantity-selector.plugin.js';
+import FormAutoSubmitPlugin from 'src/plugin/forms/form-auto-submit.plugin';
 
 /**
  * @package checkout
@@ -166,4 +167,268 @@ describe('QuantitySelectorPlugin tests', () => {
         expect(ariaLiveSpy).toHaveBeenCalledTimes(1);
         expect(window.localStorage.getItem('lastQuantityChange')).toBe('Test Product');
     });
+    test('withholds change events while the value is still being edited', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        // Native stepping of `input[type=number]` keeps the focus and emits `change` per key press.
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.value = 22;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(formChangeSpy).not.toHaveBeenCalled();
+    });
+
+    test('commits a withheld change once the input loses focus', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(formChangeSpy).not.toHaveBeenCalled();
+
+        input.blur();
+
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+        expect(input.value).toBe('21');
+    });
+
+    test('commits a withheld change on enter without waiting for blur', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(formChangeSpy).not.toHaveBeenCalled();
+
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+        expect(document.activeElement).toBe(input);
+    });
+
+    test('does not commit twice when a withheld change is followed by blur', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(formChangeSpy).not.toHaveBeenCalled();
+
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        input.blur();
+
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not commit when the value is back at the rendered quantity', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.value = 20;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.blur();
+
+        expect(formChangeSpy).not.toHaveBeenCalled();
+    });
+
+    test('passes on a typed value once the input loses focus', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        // Typing emits `change` around the blur that ends the edit.
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(formChangeSpy).not.toHaveBeenCalled();
+
+        input.blur();
+
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('commits button changes even while the input keeps the focus', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.focus();
+        document.querySelector('.js-btn-plus').dispatchEvent(new Event('click', { bubbles: true }));
+
+        expect(formChangeSpy).toHaveBeenCalled();
+        expect(input.value).toBe('21');
+    });
+
+    test('submits the form on enter when the form applies the quantity itself', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+        const formChangeSpy = jest.fn();
+
+        form.submit = jest.fn();
+        form.addEventListener('change', formChangeSpy);
+        plugin.options.submitOnFinish = true;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        // The committed change bypasses the delay while retaining the form handler.
+        expect(form.submit).toHaveBeenCalledTimes(1);
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+        expect(formChangeSpy.mock.calls[0][0].detail.submitImmediately).toBe(true);
+    });
+
+    test('does not submit on enter when the value is unchanged', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+
+        form.submit = jest.fn();
+        plugin.options.submitOnFinish = true;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+
+        input.focus();
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(form.submit).not.toHaveBeenCalled();
+    });
+
+    test('does not submit again on blur after enter submitted the value', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+        const formChangeSpy = jest.fn();
+
+        form.submit = jest.fn();
+        form.addEventListener('change', formChangeSpy);
+        plugin.options.submitOnFinish = true;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        input.blur();
+
+        expect(form.submit).toHaveBeenCalledTimes(1);
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+        expect(formChangeSpy.mock.calls[0][0].detail.submitImmediately).toBe(true);
+    });
+
+    test('submits the form as soon as the input loses focus', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+
+        form.submit = jest.fn();
+        plugin.options.submitOnFinish = true;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(form.submit).not.toHaveBeenCalled();
+
+        input.blur();
+
+        // Applied right away, not after the delay a `change` would run into.
+        expect(form.submit).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes the value on when the focus moves to the step buttons', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+        const formChangeSpy = jest.fn();
+
+        form.submit = jest.fn();
+        form.addEventListener('change', formChangeSpy);
+        plugin.options.submitOnFinish = true;
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        // Tab moves the focus from the input on to the `[+]` button next to it.
+        input.dispatchEvent(new FocusEvent('blur', {
+            relatedTarget: document.querySelector('.js-btn-plus'),
+        }));
+
+        // Not submitted directly, so a step made next lands in the same request, but the
+        // edit must not be dropped either.
+        expect(form.submit).not.toHaveBeenCalled();
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('treats a click on the step buttons like tabbing to them', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const form = document.querySelector('form');
+        const plusBtn = document.querySelector('.js-btn-plus');
+
+        form.submit = jest.fn();
+        new FormAutoSubmitPlugin(form, { autoFocus: false, delayChangeEvent: 800 });
+        plugin.options.submitOnFinish = true;
+
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        // Safari does not focus a clicked button, so the blur comes without `relatedTarget`.
+        plusBtn.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+        input.dispatchEvent(new FocusEvent('blur', { relatedTarget: null }));
+        expect(form.submit).not.toHaveBeenCalled();
+
+        plusBtn.dispatchEvent(new Event('click', { bubbles: true }));
+        jest.advanceTimersByTime(800);
+
+        expect(form.submit).toHaveBeenCalledTimes(1);
+        expect(input.value).toBe('22');
+    });
+
+    test('passes on a step made with the native spinner without waiting for blur', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        // The spinner keeps the focus in the input, only the pointer tells it from an arrow key.
+        input.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+        input.focus();
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+        expect(formChangeSpy.mock.calls[0][0].detail.submitImmediately).toBe(false);
+
+        input.blur();
+        expect(formChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('withholds arrow key steps again once a key follows the pointer', () => {
+        const input = document.querySelector('.js-quantity-selector');
+        const formChangeSpy = jest.fn();
+        document.querySelector('form').addEventListener('change', formChangeSpy);
+
+        input.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+        input.focus();
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+        input.value = 21;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(formChangeSpy).not.toHaveBeenCalled();
+    });
+
 });

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -821,6 +821,7 @@
       },
       "quantitySelect": {
         "legend": "Produkt Anzahl: Gib den gewünschten Wert ein oder benutze die Schaltflächen um die Anzahl zu erhöhen oder zu reduzieren.",
+        "cartUpdateHint": "Das Ändern der Anzahl aktualisiert den Warenkorb.",
         "areaLiveText": "Anzahl für %product% ist %quantity%.",
         "label": "Anzahl",
         "labelWithProduct": "Anzahl von %product%",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -821,6 +821,7 @@
       },
       "quantitySelect": {
         "legend": "Product Quantity: Enter the desired amount or use the buttons to increase or decrease the quantity.",
+        "cartUpdateHint": "Changing the quantity updates the cart.",
         "areaLiveText": "Quantity of %product% set to %quantity%.",
         "label": "Quantity",
         "labelWithProduct": "Quantity of %product%",

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -65,10 +65,12 @@
                                         {% block component_line_item_quantity_select_input %}
                                             <legend class="form-label visually-hidden">
                                                 {{ 'component.product.quantitySelect.legend'|trans|striptags }}
+                                                {{ 'component.product.quantitySelect.cartUpdateHint'|trans|striptags }}
                                             </legend>
 
                                             {% set quantitySelectorOptions = {
                                                 ariaLiveUpdateMode: 'onload',
+                                                submitOnFinish: true,
                                             } %}
                                             <div
                                                 id="line-item-quantity-group-{{ lineItem.id }}"


### PR DESCRIPTION
### 1. Why is this change necessary?

Backport of #20055 to `6.6.x`: cart quantity arrow-key changes still submit after 800 ms while the input retains focus. Regression tests against unchanged 6.6 reproduced two submissions for two arrow-key edits one second apart in both the native and off-canvas cart handlers.

### 2. What does this change do, exactly?

- Commit typed and arrow-key edits on blur or `Enter`, cancel pending delayed updates, and retain the existing delay for step buttons and native spinners.
- Adapt the fix to 6.6's `form.submit()` and callback-based `HttpClient`, including submission baseline tracking and serialized off-canvas mutations with shipping refresh and failure recovery.
- Add the cart quantity advisory to the existing 6.6 locale snippets and Twig template, regression coverage, and an `_unreleased` changelog with extension guidance.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a product to the cart, focus its quantity input, and press the up arrow twice, pausing one second after each press; the cart should not reload while the edit is in progress.
2. Press `Enter` or move focus outside the quantity control; the final value should be applied once immediately, while repeated `[+]`/`[-]` clicks remain debounced.
3. Repeat in the off-canvas cart and checkout confirm page with quantity editing enabled, including typing a quantity and then clicking a step button.

### 4. Please link to the relevant issues (if any).

- Backport of #20055
- Relates #19871
- Relates #14015

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

Validation: full 6.6 Storefront Jest suite passes (105 suites, 834 tests passed, 1 skipped); Storefront production build, JavaScript lint, changed-test lint, changelog validation, snippet validation, Twig syntax check, and `git diff --check` pass. Manual browser verification remains pending because the local browser connection timed out.
