### PR TITLE
Use StructArmed on QA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,6 +31,7 @@
 /phpstan-baseline.php export-ignore
 /phpunit.xml.dist export-ignore
 /rector.php export-ignore
+/structarmed.php export-ignore
 /sonar-project.properties export-ignore
 
 # Use union merge strategy for these files to avoid merge conflicts

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -168,6 +168,38 @@ jobs:
           path: var/cache/rector
           key: "rector-result-cache-${{ github.run_id }}"
 
+  structarmed:
+    needs:
+      - markdown-only-changes
+    if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-24.04
+    name: "StructArmed"
+    steps:
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+          keep-composer-tools: "true"
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: var/cache/structarmed
+          key: "structarmed-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            structarmed-result-cache-
+
+      - name: StructArmed
+        run: composer structarmed
+
+      - name: "Save result cache"
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: always()
+        with:
+          path: var/cache/structarmed
+          key: "structarmed-result-cache-${{ github.run_id }}"
+
   bc-checker:
     needs:
       - markdown-only-changes

--- a/.github/workflows/static-analysis-cache-warm.yml
+++ b/.github/workflows/static-analysis-cache-warm.yml
@@ -83,3 +83,33 @@ jobs:
         with:
           path: var/cache/rector
           key: "rector-result-cache-${{ github.run_id }}"
+
+  structarmed:
+    if: github.repository == 'shopware/shopware'
+    runs-on: ubuntu-24.04
+    name: "StructArmed cache warm"
+    steps:
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+          keep-composer-tools: "true"
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: var/cache/structarmed
+          key: "structarmed-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            structarmed-result-cache-
+
+      - name: StructArmed
+        run: composer structarmed
+
+      - name: "Save result cache"
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: always()
+        with:
+          path: var/cache/structarmed
+          key: "structarmed-result-cache-${{ github.run_id }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ German snippets differ in register between the two UIs. The Administration addre
 |------------------------|-------------------------------|----------------------------------------------|
 | **PHP** (.php)         | `composer cs`                 | `composer cs-fix`                            |
 | **PHP** (types)        | `composer phpstan`            | N/A - must fix manually                      |
+| **PHP** (types)        | `composer structarmed`        | `composer structarmed-fix` (some rules implements `Boundwize\StructArmed\Rule\FixableInterface` support it)  |
 | **JS/TS/Vue** (Admin)  | `composer eslint:admin`       | `composer eslint:admin:fix`                  |
 | **JS/TS** (Storefront) | `composer eslint:storefront`  | `composer eslint:storefront:fix`             |
 | **SCSS**               | `composer stylelint`          | `composer stylelint:[admin\|storefront]:fix` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,6 +259,7 @@ All commands below should be run inside the Docker container prefixed with `dock
 | `composer rector`                 | Check with Rector for automated PHP refactoring possibilities |
 | `composer rector-fix`             | Run Rector for automated PHP refactoring                      |
 | `composer phpstan-errors-by-area` | Print PHPStan baseline errors grouped by area                 |
+| `composer structarmed`            | Check with StructArmed for Architecture analysis              |
 
 ### Testing
 

--- a/composer.json
+++ b/composer.json
@@ -520,6 +520,9 @@
         "structarmed": [
             "structarmed analyze"
         ],
+        "structarmed-fix": [
+            "structarmed analyze --fix"
+        ],
         "phpunit": [
             "phpunit"
         ],

--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,7 @@
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*",
         "bamarni/composer-bin-plugin": "^1.8.2",
+        "boundwize/structarmed": "^0.17.3",
         "doctrine/sql-formatter": "^1.5.4",
         "dominikb/composer-license-checker": "^2.5",
         "ergebnis/phpunit-slow-test-detector": "^2.4",
@@ -515,6 +516,9 @@
         "rector-fix": [
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
             "rector process"
+        ],
+        "structarmed": [
+            "structarmed analyze"
         ],
         "phpunit": [
             "phpunit"

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+use Shopware\Administration\Administration;
+use Shopware\Administration\Notification\NotificationCollection as AdminNotificationCollection;
+use Shopware\Administration\Notification\NotificationEntity as AdminNotificationEntity;
+use Shopware\Core\Content\Cookie\Service\CookieProvider;
+use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Internal\InternalClassRule;
+use Shopware\Core\Framework\Notification\NotificationCollection;
+use Shopware\Core\Framework\Notification\NotificationEntity;
+use Shopware\Core\Framework\Script\Api\ScriptResponseFactoryFacade;
+use Shopware\Core\Framework\Script\Api\ScriptResponseFactoryFacadeHookFactory;
+use Shopware\Core\Framework\Store\Helper\PermissionCategorization;
+use Shopware\Core\Framework\Store\Services\StoreAppLifecycleService;
+use Shopware\Core\System\Snippet\SnippetFileHandler;
+use Shopware\Storefront\Controller\ScriptController;
+use Shopware\Storefront\Controller\StorefrontController;
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Shopware\Storefront\Storefront;
+use Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition;
+use Shopware\Storefront\Theme\ThemeCollection;
+use Shopware\Storefront\Theme\ThemeDefinition;
+
+return Architecture::define()
+    ->skip([
+        Psr4Preset::CLASSES_MUST_MATCH_COMPOSER => [
+            __DIR__ . '/src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php',
+            'tests/**/data',
+            'tests/unit',
+            'tests/devops/Core/Migration',
+            'tests/integration',
+        ],
+    ])
+    ->withPresets(Preset::PSR4())
+    ->layerPattern('Core', '#^Shopware\\\\Core\\\\#', '#(?:\\\\Exception\\\\|Exception$)#')
+    ->layer('Administration', 'src/Administration/')
+    ->layer('Storefront', 'src/Storefront/')
+    ->layer('Elasticsearch', 'src/Elasticsearch/')
+    ->ruleset([
+        'Core' => [],
+        'Administration' => ['Core'],
+        'Storefront' => ['Core'],
+        'Elasticsearch' => ['Core'],
+    ])
+
+    // Class names are used only to locate optional bundles' snippet directories.
+    ->skipClassViolation(SnippetFileHandler::class, [Administration::class, Storefront::class])
+    // The development rule compares a reflected parent class name.
+    ->skipClassViolation(InternalClassRule::class, StorefrontController::class)
+    // Theme definitions are referenced only by @see annotations for entity names.
+    ->skipClassViolation(PermissionCategorization::class, [
+        ThemeMediaDefinition::class,
+        ThemeSalesChannelDefinition::class,
+        ThemeTranslationDefinition::class,
+        ThemeDefinition::class,
+    ])
+    // Optional theme repository; remove when shopware/shopware#12966 is resolved.
+    ->skipClassViolation(StoreAppLifecycleService::class, ThemeCollection::class)
+    // Remove with the v6.8.0 notification inheritance compatibility paths.
+    ->skipClassViolation(NotificationCollection::class, [AdminNotificationCollection::class, AdminNotificationEntity::class])
+    ->skipClassViolation(NotificationEntity::class, AdminNotificationEntity::class)
+    // Remove with the v6.8.0 render() compatibility path.
+    ->skipClassViolation(ScriptResponseFactoryFacade::class, ScriptController::class)
+    ->skipClassViolation(ScriptResponseFactoryFacadeHookFactory::class, ScriptController::class)
+    // Remove with the legacy cookie provider in the next major version.
+    ->skipClassViolation(CookieProvider::class, CookieProviderInterface::class);

--- a/tests/devops/Core/Framework/Api/ApiAliasTest.php
+++ b/tests/devops/Core/Framework/Api/ApiAliasTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Devops\Core\Framework\Api;
+namespace Shopware\Tests\DevOps\Core\Framework\Api;
 
 use Composer\ClassMapGenerator\ClassMapGenerator;
 use PHPUnit\Framework\TestCase;

--- a/tests/devops/Core/Framework/ServiceDefinitionTest.php
+++ b/tests/devops/Core/Framework/ServiceDefinitionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Devops\Core\Framework;
+namespace Shopware\Tests\DevOps\Core\Framework;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

StructArmed is configurable PHP architecture guards. StructArmed is both static analyzer and fixer tool. It act as architecture guard that we can define layer and rules that enforce relation and usage, eg on ddd preset use:

<p align="center">
    <img src="https://boundwize.github.io/structarmed/assets/structarmed-showoff.svg" alt="StructArmed violation">
</p>

also has additional preset and rules to support that: PSR4 is just one of them, and can be a starter.

This already used by PHP frameworks:


| Project          | Configuration                                                                                |
| ---------------- | -------------------------------------------------------------------------------------------- |
| CakePHP          | https://github.com/cakephp/cakephp/blob/5.x/structarmed.php               |
| CodeIgniter 4    | https://github.com/codeigniter4/CodeIgniter4/blob/develop/structarmed.php |
| Spiral Framework | https://github.com/spiral/framework/blob/master/structarmed.php           |

### 2. What does this change do, exactly?

This PR apply StructArmed with register:

- PSR4 Preset and it already help fix 2 violations.
- I also enable ruleset so it show more ability of layering setup to define which layers each layer is allowed to depend on.
- Register to Github workflow.

### 3. Describe each step to reproduce the issue or behaviour.

It can be run with:

```bash
vendor/bin/structarmed analyze
```

### 4. Please link to the relevant issues (if any).

There are existing rules that can implements its `FixableInterface` and it can just run:

```bash
vendor/bin/structarmed analyze --fix
```

eg: finalize class without children on tests that can be later be enabled for this repo: for example usage:

-    https://github.com/spiral/framework/pull/1294
- https://github.com/FriendsOfShopware/shopware-rector/pull/70

to fix the violations. This PR is for starter to add more presets and rules gradually.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
