### PR TITLE
fix(framework): isolate app template rendering failures

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -89,6 +89,12 @@ Timeline: 6.7 opt-in, 6.8 default (opt-out), 6.9 legacy implementation and flag 
 
 ## Core
 
+### App template errors fall back during rendering
+
+When a database-backed app template fails during rendering, Shopware logs the template error and retries without that app's templates. Other overrides remain active; app fragments without a fallback render as empty content. The app is eligible again on the next render, and degraded storefront responses are marked `no-store`.
+
+Rendering may execute Twig functions more than once when a retry is necessary. Template functions should avoid side effects. Filesystem templates used in development continue to report errors normally. This handles catchable Twig errors; it does not impose execution-time or memory limits.
+
 ### GARAN label in the order confirmation mail is sized and sits next to the line item
 
 The GARAN label that 6.7.14.0 added to the `order_confirmation_mail` template (see "GARAN commercial guarantee label and EU legal guarantee notice") rendered without dimensions on a full width row of its own, so mail clients scaled the SVG data URI up to the width of the mail and cut it off. The label now carries explicit `width`/`height` attributes and renders inside the line item's description cell, with a translated `alt` text instead of an empty one.

--- a/src/Core/Framework/Adapter/Twig/EntityTemplateLoader.php
+++ b/src/Core/Framework/Adapter/Twig/EntityTemplateLoader.php
@@ -24,6 +24,11 @@ class EntityTemplateLoader implements LoaderInterface, EventSubscriberInterface,
     private ?array $databaseTemplateCache = null;
 
     /**
+     * @var list<string>
+     */
+    private array $disabledApps = [];
+
+    /**
      * @internal
      */
     public function __construct(
@@ -40,6 +45,44 @@ class EntityTemplateLoader implements LoaderInterface, EventSubscriberInterface,
     public function reset(): void
     {
         $this->databaseTemplateCache = null;
+        $this->disabledApps = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDisabledApps(): array
+    {
+        return $this->disabledApps;
+    }
+
+    /**
+     * @param list<string> $apps
+     */
+    public function setDisabledApps(array $apps): void
+    {
+        $this->disabledApps = $apps;
+    }
+
+    public function isAppDisabled(string $name): bool
+    {
+        return $this->disabledApps !== [] && \in_array($this->splitTemplateName($name)['namespace'], $this->disabledApps, true);
+    }
+
+    public function isTemplateDisabled(string $name): bool
+    {
+        return $this->isAppDisabled($name) && $this->findDatabaseTemplate($name) !== null;
+    }
+
+    public function disableApp(string $name): bool
+    {
+        if (!$this->exists($name)) {
+            return false;
+        }
+
+        $this->disabledApps[] = $this->splitTemplateName($name)['namespace'];
+
+        return true;
     }
 
     public function getSourceContext(string $name): Source
@@ -80,7 +123,7 @@ class EntityTemplateLoader implements LoaderInterface, EventSubscriberInterface,
      */
     public function exists(string $name)
     {
-        return $this->findDatabaseTemplate($name) !== null;
+        return !$this->isAppDisabled($name) && $this->findDatabaseTemplate($name) !== null;
     }
 
     /**

--- a/src/Core/Framework/Adapter/Twig/TemplateFinder.php
+++ b/src/Core/Framework/Adapter/Twig/TemplateFinder.php
@@ -54,6 +54,7 @@ class TemplateFinder implements TemplateFinderInterface, ResetInterface
         $sourcePath = $source ? $this->getTemplateName($source) : null;
         $sourceBundleName = $source ? $this->getSourceBundleName($source) : null;
         $originalTemplate = $source ? null : $template;
+        $disabledTemplate = null;
 
         $queue = $this->getNamespaceHierarchy();
         $modifiedQueue = $queue;
@@ -80,6 +81,10 @@ class TemplateFinder implements TemplateFinderInterface, ResetInterface
             }
 
             if (!$this->loader->exists($name)) {
+                if ($source === null && $this->twig instanceof TwigEnvironment && $this->twig->isAppTemplateDisabled($name)) {
+                    $disabledTemplate ??= $name;
+                }
+
                 continue;
             }
 
@@ -97,6 +102,16 @@ class TemplateFinder implements TemplateFinderInterface, ResetInterface
 
         // if no other bundle extends the requested template, load the original template
         if ($this->loader->exists($originalTemplate)) {
+            return $originalTemplate;
+        }
+
+        // Let the environment render an omitted app fragment as empty when there is no
+        // replacement. Never reintroduce it while resolving an inheritance parent.
+        if ($disabledTemplate !== null) {
+            return $disabledTemplate;
+        }
+
+        if ($this->twig instanceof TwigEnvironment && $this->twig->isAppTemplateDisabled($originalTemplate)) {
             return $originalTemplate;
         }
 

--- a/src/Core/Framework/Adapter/Twig/TwigEnvironment.php
+++ b/src/Core/Framework/Adapter/Twig/TwigEnvironment.php
@@ -2,15 +2,22 @@
 
 namespace Shopware\Core\Framework\Adapter\Twig;
 
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Adapter\Twig\Extension\NodeExtension;
 use Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Service\ResetInterface;
 use Twig\Environment;
+use Twig\Error\Error;
 use Twig\Extension\CoreExtension;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Node;
 use Twig\Runtime\EscaperRuntime;
+use Twig\Template;
 use Twig\TemplateWrapper;
 
 /**
@@ -21,6 +28,12 @@ class TwigEnvironment extends Environment implements ResetInterface
 {
     private ?\DateTimeZone $configuredTimezone = null;
 
+    private ?EntityTemplateLoader $appTemplateLoader = null;
+
+    private ?LoggerInterface $appTemplateLogger = null;
+
+    private ?RequestStack $requestStack = null;
+
     /**
      * @param array<string, mixed> $options
      */
@@ -30,6 +43,92 @@ class TwigEnvironment extends Environment implements ResetInterface
         $options['use_yield'] = true;
 
         parent::__construct($loader, $options);
+    }
+
+    public function configureAppTemplateFailureHandling(EntityTemplateLoader $loader, LoggerInterface $logger, RequestStack $requestStack): void
+    {
+        $this->appTemplateLoader = $loader;
+        $this->appTemplateLogger = $logger;
+        $this->requestStack = $requestStack;
+    }
+
+    public function isAppTemplateDisabled(string $name): bool
+    {
+        return $this->appTemplateLoader?->isTemplateDisabled($name) ?? false;
+    }
+
+    /**
+     * @param string|TemplateWrapper $name
+     * @param array<string, mixed> $context
+     */
+    public function render($name, array $context = []): string
+    {
+        if ($this->appTemplateLoader === null || !$this->hasExtension(NodeExtension::class)) {
+            return parent::render($name, $context);
+        }
+
+        $disabledApps = $this->appTemplateLoader->getDisabledApps();
+
+        try {
+            while (true) {
+                try {
+                    // render() buffers the complete output, so a failed attempt is discarded.
+                    return parent::render($name, $context);
+                } catch (Error $error) {
+                    $source = $error->getSourceContext()?->getName();
+                    if ($source === null || !$this->appTemplateLoader->disableApp($source)) {
+                        throw $error;
+                    }
+
+                    $this->appTemplateLogger?->error('Failed to render app template "{template}". Retrying without the app templates.', [
+                        'template' => $source,
+                        'exception' => $error,
+                    ]);
+
+                    // A context-specific failure must not put the degraded page into the HTTP cache.
+                    $this->requestStack?->getCurrentRequest()?->attributes->set(PlatformRequest::ATTRIBUTE_NO_STORE, true);
+                    $this->requestStack?->getMainRequest()?->attributes->set(PlatformRequest::ATTRIBUTE_NO_STORE, true);
+
+                    if ($name instanceof TemplateWrapper) {
+                        $name = $name->getTemplateName();
+                    }
+                }
+            }
+        } finally {
+            $this->appTemplateLoader->setDisabledApps($disabledApps);
+        }
+    }
+
+    public function getTemplateClass(string $name, ?int $index = null): string
+    {
+        $disabledApps = $this->appTemplateLoader?->getDisabledApps() ?? [];
+        if ($disabledApps === []) {
+            return parent::getTemplateClass($name, $index);
+        }
+
+        // Cached template instances retain their parents and blocks. Each retry needs a
+        // separate class/cache key for the entire inheritance chain, including core templates.
+        sort($disabledApps);
+        $class = $this->appTemplateLoader?->isAppDisabled($name)
+            ? '__TwigTemplate_' . Hasher::hash($name)
+            : parent::getTemplateClass($name);
+
+        return $class . '_' . Hasher::hash($disabledApps) . ($index === null ? '' : '___' . $index);
+    }
+
+    public function loadTemplate(string $cls, string $name, ?int $index = null): Template
+    {
+        if ($this->appTemplateLoader?->isAppDisabled($name) && $this->hasExtension(NodeExtension::class)) {
+            $fallback = $this->getExtension(NodeExtension::class)->getFinder()->find($name, true, $name);
+
+            if (!$this->getLoader()->exists($fallback)) {
+                return $this->createTemplate('')->unwrap();
+            }
+
+            return $this->loadTemplate($this->getTemplateClass($fallback), $fallback);
+        }
+
+        return parent::loadTemplate($cls, $name, $index);
     }
 
     /**

--- a/src/Core/Framework/DependencyInjection/CompilerPass/TwigEnvironmentCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/TwigEnvironmentCompilerPass.php
@@ -2,10 +2,12 @@
 
 namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
 
+use Shopware\Core\Framework\Adapter\Twig\EntityTemplateLoader;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 #[Package('framework')]
 class TwigEnvironmentCompilerPass implements CompilerPassInterface
@@ -16,6 +18,11 @@ class TwigEnvironmentCompilerPass implements CompilerPassInterface
         // Symfony service subscriber somehow doesn't work. Therefore, the service has to be public
         $twigEnvironment->setPublic(true);
         $twigEnvironment->setClass(TwigEnvironment::class);
+        $twigEnvironment->addMethodCall('configureAppTemplateFailureHandling', [
+            new Reference(EntityTemplateLoader::class),
+            new Reference('logger'),
+            new Reference('request_stack'),
+        ]);
 
         $twigEnvironment->addTag('kernel.reset', ['method' => 'reset']);
 

--- a/tests/unit/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
@@ -235,4 +235,35 @@ class EntityTemplateLoaderTest extends TestCase
 
         static::assertFalse($loader->exists('@TestApp/storefront/page/index.html.twig'));
     }
+
+    public function testDisablingAnAppHidesItsTemplatesUntilRestoredOrReset(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['namespace' => 'TestApp', 'path' => 'storefront/page.html.twig', 'template' => 'page', 'hash' => 'page', 'updatedAt' => null],
+            ['namespace' => 'TestApp', 'path' => 'storefront/fragment.html.twig', 'template' => 'fragment', 'hash' => 'fragment', 'updatedAt' => null],
+            ['namespace' => 'OtherApp', 'path' => 'storefront/page.html.twig', 'template' => 'other', 'hash' => 'other', 'updatedAt' => null],
+        ]);
+        $loader = new EntityTemplateLoader($connection, 'prod');
+
+        static::assertTrue($loader->disableApp('@TestApp/storefront/page.html.twig'));
+        static::assertSame(['TestApp'], $loader->getDisabledApps());
+        static::assertFalse($loader->exists('@TestApp/storefront/page.html.twig'));
+        static::assertFalse($loader->exists('@TestApp/storefront/fragment.html.twig'));
+        static::assertTrue($loader->isTemplateDisabled('@TestApp/storefront/fragment.html.twig'));
+        static::assertFalse($loader->isTemplateDisabled('@TestApp/storefront/missing.html.twig'));
+        static::assertTrue($loader->exists('@OtherApp/storefront/page.html.twig'));
+        static::assertFalse($loader->disableApp('@TestApp/storefront/page.html.twig'));
+        static::assertFalse($loader->disableApp('@Missing/storefront/page.html.twig'));
+
+        $loader->setDisabledApps([]);
+
+        static::assertTrue($loader->exists('@TestApp/storefront/page.html.twig'));
+        static::assertTrue($loader->disableApp('@TestApp/storefront/page.html.twig'));
+
+        $loader->reset();
+
+        static::assertSame([], $loader->getDisabledApps());
+        static::assertTrue($loader->exists('@TestApp/storefront/fragment.html.twig'));
+    }
 }

--- a/tests/unit/Core/Framework/Adapter/Twig/TemplateFinderTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TemplateFinderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Adapter\Twig\ConfigurableFilesystemCache;
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
+use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\Log\Package;
 use Twig\Cache\FilesystemCache;
 use Twig\Environment;
@@ -88,6 +89,35 @@ class TemplateFinderTest extends TestCase
         $foundTemplate = $this->finder->find($template, $ignoreMissing, $source);
 
         static::assertSame($expectedTemplate, $foundTemplate);
+    }
+
+    #[DataProvider('disabledAppFragmentProvider')]
+    public function testFindOmittedAppFragments(string $template, ?string $source, ?string $expected): void
+    {
+        $twig = static::createStub(TwigEnvironment::class);
+        $twig->method('isAppTemplateDisabled')->willReturnCallback(static fn (string $name): bool => $name === '@App/storefront/fragment.html.twig');
+        $this->loader->method('exists')->willReturn(false);
+        $this->hierarchyBuilder->expects($this->once())->method('buildHierarchy')->willReturn(['App' => 1, 'Storefront' => 0]);
+        $this->templateScopeDetector->expects($this->never())->method('getScopes');
+        $this->twig->expects($this->never())->method('getCache');
+        $finder = new TemplateFinder($twig, $this->loader, '', $this->hierarchyBuilder, $this->templateScopeDetector);
+
+        if ($expected === null) {
+            $this->expectException(LoaderError::class);
+        }
+
+        static::assertSame($expected, $finder->find($template, false, $source));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null, string|null}>
+     */
+    public static function disabledAppFragmentProvider(): iterable
+    {
+        yield 'resolve omitted app fragment through storefront namespace' => ['@Storefront/storefront/fragment.html.twig', null, '@App/storefront/fragment.html.twig'];
+        yield 'resolve explicit omitted app fragment' => ['@App/storefront/fragment.html.twig', null, '@App/storefront/fragment.html.twig'];
+        yield 'never reintroduce omitted app as an inheritance parent' => ['@Storefront/storefront/fragment.html.twig', '@App/storefront/fragment.html.twig', null];
+        yield 'unrelated missing templates still fail' => ['@Storefront/storefront/missing.html.twig', null, null];
     }
 
     public function testFindModifiesCache(): void

--- a/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentAppTemplateTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentAppTemplateTest.php
@@ -1,0 +1,268 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig;
+
+use Doctrine\DBAL\Connection;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\EntityTemplateLoader;
+use Shopware\Core\Framework\Adapter\Twig\Extension\NodeExtension;
+use Shopware\Core\Framework\Adapter\Twig\Extension\TwigFeaturesWithInheritanceExtension;
+use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
+use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
+use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
+use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
+use Twig\TwigFunction;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(TwigEnvironment::class)]
+class TwigEnvironmentAppTemplateTest extends TestCase
+{
+    private const PAGE = 'storefront/page.html.twig';
+
+    /**
+     * @var array<string, string>
+     */
+    private array $appTemplates = [];
+
+    private EntityTemplateLoader $appLoader;
+
+    private ArrayLoader $filesystemLoader;
+
+    private TwigEnvironment $twig;
+
+    private TemplateFinder $finder;
+
+    private TestHandler $logs;
+
+    private RequestStack $requests;
+
+    protected function setUp(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturnCallback(function (): array {
+            $rows = [];
+            foreach ($this->appTemplates as $name => $template) {
+                [$namespace, $path] = explode('/', substr($name, 1), 2);
+                $rows[] = ['namespace' => $namespace, 'path' => $path, 'template' => $template, 'hash' => hash('sha256', $template), 'updatedAt' => null];
+            }
+
+            return $rows;
+        });
+        $this->appLoader = new EntityTemplateLoader($connection, 'prod');
+        $this->filesystemLoader = new ArrayLoader([
+            '@Storefront/' . self::PAGE => 'before|{% block content %}core{% endblock %}|after',
+        ]);
+        $loader = new ChainLoader([$this->appLoader, $this->filesystemLoader]);
+        $this->twig = new TwigEnvironment($loader);
+        $hierarchy = static::createStub(NamespaceHierarchyBuilder::class);
+        $hierarchy->method('buildHierarchy')->willReturn(['HealthyApp' => 2, 'BrokenApp' => 1, 'Storefront' => 0]);
+        $this->requests = new RequestStack();
+        $scopes = new TemplateScopeDetector($this->requests);
+        $this->finder = new TemplateFinder($this->twig, $loader, '', $hierarchy, $scopes);
+        $this->twig->addExtension(new NodeExtension($this->finder, $scopes));
+        $this->twig->addExtension(new TwigFeaturesWithInheritanceExtension($this->finder));
+        $this->logs = new TestHandler();
+        $this->twig->configureAppTemplateFailureHandling($this->appLoader, new Logger('test', [$this->logs]), $this->requests);
+    }
+
+    public function testSyntaxErrorFallsBackToCoreAndLogsTheAppTemplate(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{% broken %}';
+
+        static::assertSame('before|core|after', $this->twig->render($name));
+        $records = $this->logs->getRecords();
+        static::assertCount(1, $records);
+        static::assertSame($name, $records[0]->context['template']);
+        static::assertInstanceOf(SyntaxError::class, $records[0]->context['exception']);
+        static::assertSame([], $this->appLoader->getDisabledApps());
+    }
+
+    public function testRuntimeErrorDiscardsPartialOutputAndKeepsHealthyOverrides(): void
+    {
+        $this->appTemplates['@HealthyApp/' . self::PAGE] = '{% sw_extends "@Storefront/' . self::PAGE . '" %}{% block content %}healthy[{{ parent() }}]{% endblock %}';
+        $this->appTemplates['@BrokenApp/' . self::PAGE] = '{% sw_extends "@Storefront/' . self::PAGE . '" %}{% block content %}partial{{ 1 / divisor }}{% endblock %}';
+        $name = $this->finder->find('@Storefront/' . self::PAGE);
+
+        // Warm the parent/block instances before exercising the failure path.
+        static::assertSame('before|healthy[partial1]|after', $this->twig->render($name, ['divisor' => 1]));
+        static::assertSame('before|healthy[core]|after', $this->twig->render($name, ['divisor' => 0]));
+        static::assertCount(1, $this->logs->getRecords());
+        // A failure with one context must not disable the app for subsequent renders.
+        static::assertSame('before|healthy[partial1]|after', $this->twig->render($name, ['divisor' => 1]));
+    }
+
+    public function testMissingIncludeInAppFallsBack(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{% sw_extends "@Storefront/' . self::PAGE . '" %}{% block content %}{% include "missing.html.twig" %}{% endblock %}';
+
+        static::assertSame('before|core|after', $this->twig->render($name));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testNestedAppIncludeFailureOmitsTheWholeFailingApp(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{% sw_extends "@Storefront/' . self::PAGE . '" %}{% block content %}partial{% include "@BrokenApp/storefront/fragment.html.twig" %}{% endblock %}';
+        $this->appTemplates['@BrokenApp/storefront/fragment.html.twig'] = '{{ 1 / 0 }}';
+
+        static::assertSame('before|core|after', $this->twig->render($name));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testMultipleBrokenAppsEachGetOneRetry(): void
+    {
+        $this->appTemplates['@HealthyApp/' . self::PAGE] = '{% broken %}';
+        $this->appTemplates['@BrokenApp/' . self::PAGE] = '{{ 1 / 0 }}';
+
+        static::assertSame('before|core|after', $this->twig->render($this->finder->find('@Storefront/' . self::PAGE)));
+        static::assertCount(2, $this->logs->getRecords());
+    }
+
+    public function testStandaloneAppFragmentWithoutFallbackBecomesEmpty(): void
+    {
+        $this->filesystemLoader->setTemplate('page', 'before|{% include "@BrokenApp/storefront/fragment.html.twig" %}|after');
+        $this->appTemplates['@BrokenApp/storefront/fragment.html.twig'] = 'partial{{ 1 / 0 }}';
+
+        static::assertSame('before||after', $this->twig->render('page'));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testSwIncludeTagCanOmitAnAppFragmentWithoutFallback(): void
+    {
+        $this->filesystemLoader->setTemplate('page', 'before|{% sw_include "@Storefront/storefront/fragment.html.twig" %}|after');
+        $this->appTemplates['@BrokenApp/storefront/fragment.html.twig'] = 'partial{{ 1 / 0 }}';
+
+        static::assertSame('before||after', $this->twig->render('page'));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testSwIncludeFunctionCanOmitAnExplicitAppFragment(): void
+    {
+        $this->filesystemLoader->setTemplate('page', 'before|{{ sw_include("@BrokenApp/storefront/fragment.html.twig") }}|after');
+        $this->appTemplates['@BrokenApp/storefront/fragment.html.twig'] = 'partial{{ 1 / 0 }}';
+
+        static::assertSame('before||after', $this->twig->render('page'));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testOmittingAnAppDoesNotHideAnUnrelatedMissingCoreTemplate(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->filesystemLoader->setTemplate('@Storefront/' . self::PAGE, '{% sw_include "@Storefront/storefront/missing.html.twig" %}');
+        $this->appTemplates[$name] = '{% broken %}';
+
+        $this->expectException(LoaderError::class);
+
+        try {
+            $this->twig->render($name);
+        } finally {
+            static::assertCount(1, $this->logs->getRecords());
+        }
+    }
+
+    public function testPreviouslyLoadedTemplateWrapperIsReloadedForRetry(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{{ 1 / 0 }}';
+        $wrapper = $this->twig->load($name);
+
+        static::assertSame('before|core|after', $this->twig->render($wrapper));
+    }
+
+    public function testEmbeddedTemplateFailureUsesTheFallbackAndCanRecover(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{% embed "@Storefront/' . self::PAGE . '" %}{% block content %}partial{{ 1 / divisor }}{% endblock %}{% endembed %}';
+
+        static::assertSame('before|partial1|after', $this->twig->render($name, ['divisor' => 1]));
+        static::assertSame('before|core|after', $this->twig->render($name, ['divisor' => 0]));
+        static::assertSame('before|partial1|after', $this->twig->render($name, ['divisor' => 1]));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testCoreErrorIsPropagatedWithoutLoggingAnAppFailure(): void
+    {
+        $this->filesystemLoader->setTemplate('@Storefront/' . self::PAGE, '{{ 1 / 0 }}');
+        $this->appTemplates['@BrokenApp/' . self::PAGE] = '{% sw_extends "@Storefront/' . self::PAGE . '" %}';
+
+        $this->expectException(RuntimeError::class);
+
+        try {
+            $this->twig->render('@BrokenApp/' . self::PAGE);
+        } finally {
+            static::assertSame([], $this->logs->getRecords());
+            static::assertSame([], $this->appLoader->getDisabledApps());
+        }
+    }
+
+    public function testFailureInCoreFallbackStillPropagatesAndRestoresApps(): void
+    {
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->filesystemLoader->setTemplate('@Storefront/' . self::PAGE, '{{ 1 / 0 }}');
+        $this->appTemplates[$name] = '{% broken %}';
+
+        $this->expectException(RuntimeError::class);
+
+        try {
+            $this->twig->render($name);
+        } finally {
+            static::assertCount(1, $this->logs->getRecords());
+            static::assertTrue($this->appLoader->exists($name));
+        }
+    }
+
+    public function testExceptionsFromAppTwigFunctionsAreIsolated(): void
+    {
+        $this->twig->addFunction(new TwigFunction('fail', static function (): never {
+            throw new \RuntimeException('App rendering failed');
+        }));
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{{ fail() }}';
+
+        static::assertSame('before|core|after', $this->twig->render($name));
+        static::assertCount(1, $this->logs->getRecords());
+    }
+
+    public function testDegradedPagesCannotBeStoredInTheHttpCache(): void
+    {
+        $main = new Request();
+        $sub = new Request();
+        $this->requests->push($main);
+        $this->requests->push($sub);
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = '{% broken %}';
+
+        static::assertSame('before|core|after', $this->twig->render($name));
+        static::assertTrue($main->attributes->get(PlatformRequest::ATTRIBUTE_NO_STORE));
+        static::assertTrue($sub->attributes->get(PlatformRequest::ATTRIBUTE_NO_STORE));
+    }
+
+    public function testSuccessfulRenderRemainsCacheable(): void
+    {
+        $request = new Request();
+        $this->requests->push($request);
+        $name = '@BrokenApp/' . self::PAGE;
+        $this->appTemplates[$name] = 'working';
+
+        static::assertSame('working', $this->twig->render($name));
+        static::assertFalse($request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE));
+        static::assertSame([], $this->logs->getRecords());
+    }
+}

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/TwigEnvironmentCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/TwigEnvironmentCompilerPassTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Unit\Core\Framework\DependencyInjection\CompilerPass;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\EntityTemplateLoader;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\TwigEnvironmentCompilerPass;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Twig\Environment;
 
 /**
@@ -27,6 +29,9 @@ class TwigEnvironmentCompilerPassTest extends TestCase
         $twig = $container->getDefinition('twig');
         static::assertTrue($twig->isPublic());
         static::assertSame(TwigEnvironment::class, $twig->getClass());
+        static::assertEquals([
+            ['configureAppTemplateFailureHandling', [new Reference(EntityTemplateLoader::class), new Reference('logger'), new Reference('request_stack')]],
+        ], $twig->getMethodCalls());
         static::assertSame(
             [['method' => 'reset']],
             $twig->getTag('kernel.reset'),


### PR DESCRIPTION
### 1. Why is this change necessary?

A syntax or runtime error in a database-backed app template currently aborts the entire storefront render. A broken app override can therefore make otherwise working pages unavailable.

### 2. What does this change do, exactly?

- Logs catchable Twig errors attributed to an app and retries the buffered render without that app's templates, discarding partial output while keeping healthy overrides.
- Falls back through the template hierarchy and renders omitted app fragments as empty when no replacement exists.
- Separates retry template classes and cache keys so cached parents cannot reintroduce a failed app. Restores app eligibility after rendering and marks degraded responses `no-store`.
- Preserves errors from core/filesystem templates and documents the behavior in `RELEASE_INFO-6.7.md`.

Retries can execute Twig functions more than once. This does not provide CPU or memory limits.

Validation: 374 Twig/compiler-pass unit tests passed using a database-free bootstrap with Shopware feature flags; PHPStan and code style passed for all touched PHP files. The syntax-error and runtime-error regression cases also failed against the upstream implementation in an isolated copy, with the new configuration call omitted. Database integration tests remain unverified because the local `DATABASE_URL` is invalid.

### 3. Describe each step to reproduce the issue or behaviour.

1. Activate an app with a production template overriding `storefront/base.html.twig`, extending the Storefront template and putting `{{ 1 / 0 }}` inside an overridden block.
2. Request a storefront page using that template. Before this change, rendering fails with a Twig runtime error.
3. With this change, the page renders using the remaining template hierarchy, the app error is logged, and the response is marked `no-store`.
4. Correct the template and render again. The app participates normally on subsequent renders.

Regression coverage also exercises invalid syntax, missing and nested includes, `sw_include`, embedded templates, cached parents, multiple failing apps, and propagation of core errors.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
