### PR TITLE
fix(checkout): replace dompdf page count placeholder for core and fallback fonts

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -89,6 +89,10 @@ Timeline: 6.7 opt-in, 6.8 default (opt-out), 6.9 legacy implementation and flag 
 
 ## Core
 
+### Dompdf page count placeholder replaced for core and fallback fonts
+
+In PDF document generation, Dompdf falls back to standard 14 built-in AFM fonts (such as `Helvetica`) when external web fonts are unavailable behind a firewall, or when documents are styled with core PDF fonts. Dompdf encodes those fonts using single-byte strings instead of UTF-16BE. `PdfRenderer` now replaces both encodings in the CPDF stream, ensuring `DOMPDF_PAGE_COUNT_PLACEHOLDER` is reliably replaced with the actual total page count regardless of active font encoding or network availability.
+
 ### GARAN label in the order confirmation mail is sized and sits next to the line item
 
 The GARAN label that 6.7.14.0 added to the `order_confirmation_mail` template (see "GARAN commercial guarantee label and EU legal guarantee notice") rendered without dimensions on a full width row of its own, so mail clients scaled the SVG data URI up to the width of the mail and cut it off. The label now carries explicit `width`/`height` attributes and renders inside the line item's description cell, with a translated `alt` text instead of an empty one.

--- a/changelog/_unreleased/2026-09-11-fix-dompdf-page-count-placeholder-for-core-fonts.md
+++ b/changelog/_unreleased/2026-09-11-fix-dompdf-page-count-placeholder-for-core-fonts.md
@@ -1,0 +1,7 @@
+---
+title: Fix Dompdf page count placeholder replacement for core fonts
+author: Alexander Bachmann
+author_email: email.bachmann@gmail.com
+---
+# Core
+* Fixed an issue where `DOMPDF_PAGE_COUNT_PLACEHOLDER` was not replaced with the total page count in generated documents when using built-in standard 14 AFM fonts (such as `Helvetica`) or when fallback fonts are used offline.

--- a/changelog/_unreleased/2026-09-11-fix-dompdf-page-count-placeholder-for-core-fonts.md
+++ b/changelog/_unreleased/2026-09-11-fix-dompdf-page-count-placeholder-for-core-fonts.md
@@ -1,7 +1,0 @@
----
-title: Fix Dompdf page count placeholder replacement for core fonts
-author: Alexander Bachmann
-author_email: email.bachmann@gmail.com
----
-# Core
-* Fixed an issue where `DOMPDF_PAGE_COUNT_PLACEHOLDER` was not replaced with the total page count in generated documents when using built-in standard 14 AFM fonts (such as `Helvetica`) or when fallback fonts are used offline.

--- a/src/Core/Checkout/Document/Service/PdfRenderer.php
+++ b/src/Core/Checkout/Document/Service/PdfRenderer.php
@@ -23,6 +23,8 @@ class PdfRenderer extends AbstractDocumentTypeRenderer
 
     public const FILE_CONTENT_TYPE = FileTypes::PDF_CONTENT_TYPE;
 
+    private const PAGE_COUNT_PLACEHOLDER = 'DOMPDF_PAGE_COUNT_PLACEHOLDER';
+
     /**
      * @internal
      *
@@ -122,14 +124,27 @@ class PdfRenderer extends AbstractDocumentTypeRenderer
     }
 
     /**
-     * Replace a predefined placeholder with the total page count in the whole PDF document
+     * Replace a predefined placeholder with the total page count in the whole PDF document.
+     *
+     * Unicode TrueType fonts encode text in the CPDF stream as UTF-16BE (null-byte padded),
+     * while built-in standard 14 AFM fonts (such as Helvetica, when external fonts are blocked
+     * or fallback is used) encode text as single-byte strings. Both encodings are replaced.
      */
     private function injectPageCount(Dompdf $dompdf): void
     {
         /** @var CPDF $canvas */
         $canvas = $dompdf->getCanvas();
-        $search = $this->insertNullByteBeforeEachCharacter('DOMPDF_PAGE_COUNT_PLACEHOLDER');
-        $replace = $this->insertNullByteBeforeEachCharacter((string) $canvas->get_page_count());
+        $pageCount = (string) $canvas->get_page_count();
+
+        $search = [
+            $this->insertNullByteBeforeEachCharacter(self::PAGE_COUNT_PLACEHOLDER),
+            self::PAGE_COUNT_PLACEHOLDER,
+        ];
+        $replace = [
+            $this->insertNullByteBeforeEachCharacter($pageCount),
+            $pageCount,
+        ];
+
         $pdf = $canvas->get_cpdf();
 
         foreach ($pdf->objects as &$o) {

--- a/src/Core/Checkout/DocumentV2/Renderer/PdfRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/PdfRenderer.php
@@ -25,6 +25,8 @@ final readonly class PdfRenderer extends AbstractDocumentRenderer
 {
     final public const FORMAT = DocumentFormat::PDF;
 
+    private const PAGE_COUNT_PLACEHOLDER = 'DOMPDF_PAGE_COUNT_PLACEHOLDER';
+
     /**
      * @param array<string, mixed> $dompdfOptions
      */
@@ -85,19 +87,26 @@ final readonly class PdfRenderer extends AbstractDocumentRenderer
 
     /**
      * Replaces the literal `DOMPDF_PAGE_COUNT_PLACEHOLDER` emitted by the footer Twig with the
-     * real page count after rendering. Strings are written into the CPDF object stream null-byte
-     * padded, so the search + replace value must match that encoding.
+     * real page count after rendering.
      *
-     * Verbatim port of the v1 implementation at
-     * {@see \Shopware\Core\Checkout\Document\Service\PdfRenderer::injectPageCount}.
+     * Unicode TrueType fonts encode text in the CPDF stream as UTF-16BE (null-byte padded),
+     * while built-in standard 14 AFM fonts (such as Helvetica, when external fonts are blocked
+     * or fallback is used) encode text as single-byte strings. Both encodings are replaced.
      */
     private function injectPageCount(Dompdf $dompdf): void
     {
         /** @var CPDF $canvas */
         $canvas = $dompdf->getCanvas();
+        $pageCount = (string) $canvas->get_page_count();
 
-        $search = $this->insertNullByteBeforeEachCharacter('DOMPDF_PAGE_COUNT_PLACEHOLDER');
-        $replace = $this->insertNullByteBeforeEachCharacter((string) $canvas->get_page_count());
+        $search = [
+            $this->insertNullByteBeforeEachCharacter(self::PAGE_COUNT_PLACEHOLDER),
+            self::PAGE_COUNT_PLACEHOLDER,
+        ];
+        $replace = [
+            $this->insertNullByteBeforeEachCharacter($pageCount),
+            $pageCount,
+        ];
 
         $pdf = $canvas->get_cpdf();
 

--- a/tests/unit/Core/Checkout/Document/Service/PdfRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/PdfRendererTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Checkout\Document\Service;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Document\Extension\PdfRendererExtension;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\Locale\LocaleEntity;
+use Smalot\PdfParser\Parser;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
@@ -116,6 +118,57 @@ class PdfRendererTest extends TestCase
         );
 
         $htmlRenderer->render($rendered);
+    }
+
+    #[DataProvider('provideFontFamiliesForPageCountInjection')]
+    public function testPageCountInjected(string $fontFamily): void
+    {
+        $rendered = new RenderedDocument(
+            '1001',
+            InvoiceRenderer::TYPE,
+        );
+
+        $rendered->setContext(Context::createDefaultContext());
+        $rendered->setOrder($this->getOrder());
+
+        $raw = <<<HTML
+            <html><head><style>body { font-family: {$fontFamily}; }</style></head><body>
+                <p>Page 1 / DOMPDF_PAGE_COUNT_PLACEHOLDER</p>
+            </body></html>
+            HTML;
+
+        $documentTemplateRenderer = $this->createMock(DocumentTemplateRenderer::class);
+        $documentTemplateRenderer->expects($this->once())
+            ->method('render')
+            ->willReturn($raw);
+
+        $pdfRenderer = new PdfRenderer(
+            [
+                'isRemoteEnabled' => false,
+                'isHtml5ParserEnabled' => true,
+            ],
+            $documentTemplateRenderer,
+            '',
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $generatorOutput = $pdfRenderer->render($rendered);
+        static::assertNotEmpty($generatorOutput);
+
+        $text = (new Parser())->parseContent($generatorOutput)->getText();
+
+        static::assertStringNotContainsString('DOMPDF_PAGE_COUNT_PLACEHOLDER', $text);
+        static::assertStringContainsString('Page 1 / 1', $text);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideFontFamiliesForPageCountInjection(): iterable
+    {
+        yield 'unicode TrueType font (UTF-16BE)' => ['DejaVu Sans'];
+        yield 'standard core AFM font (8-bit ANSI)' => ['Helvetica'];
+        yield 'generic sans-serif fallback (8-bit ANSI)' => ['sans-serif'];
     }
 
     private function getOrder(): OrderEntity

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/PdfRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/PdfRendererTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Renderer;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\DocumentV2\Config\DocumentCompanyInfo;
 use Shopware\Core\Checkout\DocumentV2\Config\DocumentConfig;
@@ -123,12 +124,13 @@ class PdfRendererTest extends TestCase
         $renderer->renderToString($input, $state, Context::createDefaultContext());
     }
 
-    public function testPageCountInjected(): void
+    #[DataProvider('provideFontFamiliesForPageCountInjection')]
+    public function testPageCountInjected(string $fontFamily): void
     {
         $renderer = new PdfRenderer(self::DOMPDF_OPTIONS);
 
-        $raw = <<<'HTML'
-            <html><head><style>body { font-family: DejaVu Sans; }</style></head><body>
+        $raw = <<<HTML
+            <html><head><style>body { font-family: {$fontFamily}; }</style></head><body>
                 <p>Page 1 / DOMPDF_PAGE_COUNT_PLACEHOLDER</p>
             </body></html>
             HTML;
@@ -148,6 +150,16 @@ class PdfRendererTest extends TestCase
 
         static::assertStringNotContainsString('DOMPDF_PAGE_COUNT_PLACEHOLDER', $text);
         static::assertStringContainsString('Page 1 / 1', $text);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideFontFamiliesForPageCountInjection(): iterable
+    {
+        yield 'unicode TrueType font (UTF-16BE)' => ['DejaVu Sans'];
+        yield 'standard core AFM font (8-bit ANSI)' => ['Helvetica'];
+        yield 'generic sans-serif fallback (8-bit ANSI)' => ['sans-serif'];
     }
 
     public function testScreenHiddenContentRemainsVisibleInPdf(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

When generating documents in Shopware (such as invoices or delivery notes), Dompdf uses the literal `DOMPDF_PAGE_COUNT_PLACEHOLDER` in the HTML footer, which `PdfRenderer::injectPageCount()` replaces with the total page count after layout.

Currently, `injectPageCount()` assumes the CPDF content stream is always encoded as UTF-16BE (null-byte padded `\0D\0O...`). However, when outbound access to external fonts (such as Google Fonts) is blocked behind a firewall, or when documents use standard 14 core fonts (such as `Helvetica`), Dompdf falls back to built-in AFM fonts where `isUnicode = false`. In that mode, Dompdf emits standard 8-bit ANSI text in the CPDF stream without null-byte padding. As a result, `str_replace()` fails to find the placeholder and `DOMPDF_PAGE_COUNT_PLACEHOLDER` appears literally in the generated PDF.

### 2. What does this change do, exactly?

- Updates `injectPageCount()` in both `Shopware\Core\Checkout\Document\Service\PdfRenderer` (v1) and `Shopware\Core\Checkout\DocumentV2\Renderer\PdfRenderer` (v2) to replace both:
  - The null-byte padded UTF-16BE string (for TrueType Unicode fonts like `DejaVu Sans`)
  - The plain ASCII string (for standard 14 AFM fonts like `Helvetica` and offline fallbacks)
- Adds unit tests parameterized via `provideFontFamiliesForPageCountInjection` covering `DejaVu Sans`, `Helvetica`, and `sans-serif` in both renderer test suites.
- Adds an unreleased changelog entry under `Core`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Block outbound network access (or configure templates to use a standard core font like `Helvetica` / `sans-serif` without external font access).
2. Generate an invoice or document with page count enabled in document configuration (`displayPageCount: true`).
3. Inspect the footer in the generated PDF: the total page count displays `DOMPDF_PAGE_COUNT_PLACEHOLDER` instead of the actual page count.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them