### PR TITLE
fix(content-system): name the invalidated tables through their definitions

### DIFF
--- a/src/Core/Framework/ContentSystem/Cache/AGENTS.md
+++ b/src/Core/Framework/ContentSystem/Cache/AGENTS.md
@@ -7,3 +7,5 @@
 - `RenderingCacheContext` created in route, passed through pipeline — tags accumulate, `disable()` is irreversible
 - Supported entities: product, category, landing_page, cms_page, product_stream — all others cause uncacheable
 - Invalidation triggers: `EntityWrittenContainerEvent` for content_layout + all 5 assignment tables
+- Table names come from the definitions' `ENTITY_NAME`; the two Storefront-owned section tables arrive via the
+  `shopware.content_system.section_assignment_entities` parameter, never as a literal in Core

--- a/src/Core/Framework/ContentSystem/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/ContentSystem/Cache/CacheInvalidationSubscriber.php
@@ -4,11 +4,15 @@ namespace Shopware\Core\Framework\ContentSystem\Cache;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Category\Aggregate\CategoryContentLayout\CategoryContentLayoutDefinition;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageContentLayout\LandingPageContentLayoutDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\Log\Package;
@@ -24,27 +28,42 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 #[AsEventListener(event: EntityWrittenContainerEvent::class)]
 class CacheInvalidationSubscriber
 {
+    /**
+     * @var array<string, ContentSection>
+     */
+    private readonly array $sectionAssignments;
+
+    /**
+     * Header and footer live in the Storefront bundle, so their table names arrive as a container parameter
+     * instead of an import; a Core-only installation passes an empty map.
+     *
+     * @param array<string, string> $sectionAssignmentEntities assignment table name => ContentSection value
+     */
     public function __construct(
         private readonly CacheInvalidator $cacheInvalidator,
         private readonly Connection $connection,
         private readonly EntityCacheTagResolver $cacheTagResolver,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
+        array $sectionAssignmentEntities,
     ) {
+        $this->sectionAssignments = array_map(ContentSection::from(...), $sectionAssignmentEntities);
     }
 
     public function __invoke(EntityWrittenContainerEvent $event): void
     {
         $this->invalidateContentLayout($event);
-        $this->invalidateEntityContentLayout($event, 'product_content_layout', 'product_id', ProductDefinition::class);
-        $this->invalidateEntityContentLayout($event, 'category_content_layout', 'category_id', CategoryDefinition::class);
-        $this->invalidateEntityContentLayout($event, 'landing_page_content_layout', 'landing_page_id', LandingPageDefinition::class);
-        $this->invalidateSectionContentLayout($event, 'header_content_layout', ContentSection::HEADER);
-        $this->invalidateSectionContentLayout($event, 'footer_content_layout', ContentSection::FOOTER);
+        $this->invalidateEntityContentLayout($event, ProductContentLayoutDefinition::ENTITY_NAME, 'product_id', ProductDefinition::class);
+        $this->invalidateEntityContentLayout($event, CategoryContentLayoutDefinition::ENTITY_NAME, 'category_id', CategoryDefinition::class);
+        $this->invalidateEntityContentLayout($event, LandingPageContentLayoutDefinition::ENTITY_NAME, 'landing_page_id', LandingPageDefinition::class);
+
+        foreach ($this->sectionAssignments as $entityName => $section) {
+            $this->invalidateSectionContentLayout($event, $entityName, $section);
+        }
     }
 
     private function invalidateContentLayout(EntityWrittenContainerEvent $event): void
     {
-        $ids = $event->getPrimaryKeys('content_layout');
+        $ids = $event->getPrimaryKeys(ContentLayoutDefinition::ENTITY_NAME);
 
         if ($ids === []) {
             return;

--- a/src/Core/Framework/ContentSystem/Cache/README.md
+++ b/src/Core/Framework/ContentSystem/Cache/README.md
@@ -26,3 +26,7 @@ Unsupported entities return null → page becomes uncacheable.
 `CacheInvalidationSubscriber` listens to `EntityWrittenContainerEvent`:
 - **content_layout** → `content-layout-{id}`
 - **assignment tables** (product/category/landing_page/header/footer) → looks up associated entity and invalidates its tag
+
+Every table name comes from its definition's `ENTITY_NAME`. Header and footer are Storefront-owned, so
+the Storefront hands those two to the subscriber through the container parameter
+`shopware.content_system.section_assignment_entities`; Core declares it empty.

--- a/src/Core/Framework/DependencyInjection/content-system.php
+++ b/src/Core/Framework/DependencyInjection/content-system.php
@@ -128,6 +128,10 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    // Filled by the bundle that owns the section assignment tables; the Storefront sets header and footer.
+    $containerConfigurator->parameters()
+        ->set('shopware.content_system.section_assignment_entities', []);
+
     $services = $containerConfigurator->services();
 
     // Entity Definitions
@@ -269,6 +273,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(Connection::class),
             service(EntityCacheTagResolver::class),
             service(DefinitionInstanceRegistry::class),
+            param('shopware.content_system.section_assignment_entities'),
         ])
         ->tag('kernel.event_listener');
 

--- a/src/Storefront/DependencyInjection/content-system.php
+++ b/src/Storefront/DependencyInjection/content-system.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\DependencyInjection;
 use Shopware\Core\Framework\ContentSystem\Adapter\FactoryHelper\DomainAwareLayoutResolver;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationFactory;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationResolver;
+use Shopware\Core\Framework\ContentSystem\ContentSection;
 use Shopware\Core\Framework\ContentSystem\Validation\LayoutRootSourceReader;
 use Shopware\Storefront\ContentSystem\Extension\ContentLayoutExtension;
 use Shopware\Storefront\ContentSystem\Extension\SalesChannelDomainExtension;
@@ -19,6 +20,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    // CacheInvalidationSubscriber lives in Core and cannot import these definitions, so the two table names
+    // it needs travel as a parameter.
+    $containerConfigurator->parameters()
+        ->set('shopware.content_system.section_assignment_entities', [
+            HeaderContentLayoutDefinition::ENTITY_NAME => ContentSection::HEADER->value,
+            FooterContentLayoutDefinition::ENTITY_NAME => ContentSection::FOOTER->value,
+        ]);
+
     $services = $containerConfigurator->services();
 
     // Entity Definitions

--- a/tests/integration/Core/Framework/ContentSystem/Cache/CacheInvalidationTableNamesTest.php
+++ b/tests/integration/Core/Framework/ContentSystem/Cache/CacheInvalidationTableNamesTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\ContentSystem\Cache;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Aggregate\CategoryContentLayout\CategoryContentLayoutDefinition;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageContentLayout\LandingPageContentLayoutDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
+use Shopware\Core\Framework\ContentSystem\Cache\CacheInvalidationSubscriber;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * {@see CacheInvalidationSubscriber} queries each assignment table by name; a name no table answers to
+ * makes invalidation a silent no-op, so every name it can reach is checked against the live schema.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class CacheInvalidationTableNamesTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    #[TestDox('every table the cache invalidation subscriber names exists in the schema')]
+    public function testEveryInvalidatedTableExists(): void
+    {
+        $sectionAssignments = static::getContainer()->getParameter('shopware.content_system.section_assignment_entities');
+        static::assertIsArray($sectionAssignments);
+
+        $tables = [
+            ContentLayoutDefinition::ENTITY_NAME,
+            ProductContentLayoutDefinition::ENTITY_NAME,
+            CategoryContentLayoutDefinition::ENTITY_NAME,
+            LandingPageContentLayoutDefinition::ENTITY_NAME,
+            ...array_keys($sectionAssignments),
+        ];
+
+        $schemaManager = static::getContainer()->get(Connection::class)->createSchemaManager();
+
+        foreach ($tables as $table) {
+            static::assertIsString($table);
+            static::assertTrue($schemaManager->tablesExist([$table]), \sprintf('Table "%s" does not exist.', $table));
+        }
+    }
+}

--- a/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
+++ b/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
@@ -8,15 +8,15 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidateCacheEvent;
 use Shopware\Core\Framework\ContentSystem\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Entity;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\ContentSystem\TestElementTypeLoader;
 use Shopware\Storefront\ContentSystem\FooterContentLayout\FooterContentLayoutDefinition;
+use Shopware\Storefront\ContentSystem\HeaderContentLayout\HeaderContentLayoutCollection;
 use Shopware\Storefront\ContentSystem\HeaderContentLayout\HeaderContentLayoutDefinition;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -62,7 +62,7 @@ class SectionAssignmentWiringTest extends TestCase
     }
 
     /**
-     * @return array<string>
+     * @return list<string>
      */
     private function collectInvalidatedKeys(callable $write): array
     {
@@ -71,7 +71,7 @@ class SectionAssignmentWiringTest extends TestCase
         static::assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
 
         $listener = static function (InvalidateCacheEvent $event) use (&$keys): void {
-            $keys = [...$keys, ...$event->getKeys()];
+            $keys = [...$keys, ...array_values($event->getKeys())];
         };
 
         $dispatcher->addListener(InvalidateCacheEvent::class, $listener);
@@ -107,7 +107,7 @@ class SectionAssignmentWiringTest extends TestCase
     }
 
     /**
-     * @return EntityRepository<EntityCollection<Entity>>
+     * @return EntityRepository<HeaderContentLayoutCollection>
      */
     private function headerRepository(): EntityRepository
     {
@@ -118,7 +118,7 @@ class SectionAssignmentWiringTest extends TestCase
     }
 
     /**
-     * @return EntityRepository<EntityCollection<Entity>>
+     * @return EntityRepository<ContentLayoutCollection>
      */
     private function layoutRepository(): EntityRepository
     {

--- a/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
+++ b/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
@@ -4,12 +4,21 @@ namespace Shopware\Tests\Integration\Storefront\ContentSystem\Cache;
 
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
+use Shopware\Core\Framework\Adapter\Cache\InvalidateCacheEvent;
 use Shopware\Core\Framework\ContentSystem\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\ContentSystem\TestElementTypeLoader;
 use Shopware\Storefront\ContentSystem\FooterContentLayout\FooterContentLayoutDefinition;
 use Shopware\Storefront\ContentSystem\HeaderContentLayout\HeaderContentLayoutDefinition;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Header and footer are Storefront tables, so {@see CacheInvalidationSubscriber} learns their names from a
@@ -33,5 +42,89 @@ class SectionAssignmentWiringTest extends TestCase
             ],
             static::getContainer()->getParameter('shopware.content_system.section_assignment_entities'),
         );
+    }
+
+    #[TestDox('writing a header assignment invalidates the layout route tags')]
+    public function testHeaderAssignmentWriteInvalidatesRouteTags(): void
+    {
+        $context = Context::createDefaultContext();
+        $layoutId = $this->createLayout(ContentSection::HEADER->value, $context);
+
+        $keys = $this->collectInvalidatedKeys(function () use ($layoutId, $context): void {
+            $this->headerRepository()->create(
+                [['id' => Uuid::randomHex(), 'contentLayoutId' => $layoutId]],
+                $context
+            );
+        });
+
+        static::assertContains(ContentSection::MAIN->buildLayoutTag($layoutId), $keys);
+        static::assertContains(ContentSection::HEADER->buildLayoutTag($layoutId), $keys);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function collectInvalidatedKeys(callable $write): array
+    {
+        $keys = [];
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        static::assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
+
+        $listener = static function (InvalidateCacheEvent $event) use (&$keys): void {
+            $keys = [...$keys, ...$event->getKeys()];
+        };
+
+        $dispatcher->addListener(InvalidateCacheEvent::class, $listener);
+
+        try {
+            $write();
+
+            $invalidator = static::getContainer()->get(CacheInvalidator::class);
+            static::assertInstanceOf(CacheInvalidator::class, $invalidator);
+            $invalidator->invalidateExpired();
+        } finally {
+            $dispatcher->removeListener(InvalidateCacheEvent::class, $listener);
+        }
+
+        return $keys;
+    }
+
+    private function createLayout(string $rootSource, Context $context): string
+    {
+        $id = Uuid::randomHex();
+
+        $this->layoutRepository()->create([[
+            'id' => $id,
+            'name' => 'cache-invalidation-layout',
+            'version' => '1.0.0',
+            'rootSource' => $rootSource,
+            'layout' => [
+                ['id' => Uuid::randomHex(), 'component' => TestElementTypeLoader::RESOLVABLE, 'properties' => []],
+            ],
+        ]], $context);
+
+        return $id;
+    }
+
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>
+     */
+    private function headerRepository(): EntityRepository
+    {
+        $repository = static::getContainer()->get(HeaderContentLayoutDefinition::ENTITY_NAME . '.repository');
+        static::assertInstanceOf(EntityRepository::class, $repository);
+
+        return $repository;
+    }
+
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>
+     */
+    private function layoutRepository(): EntityRepository
+    {
+        $repository = static::getContainer()->get('content_layout.repository');
+        static::assertInstanceOf(EntityRepository::class, $repository);
+
+        return $repository;
     }
 }

--- a/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
+++ b/tests/integration/Storefront/ContentSystem/Cache/SectionAssignmentWiringTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\ContentSystem\Cache;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\ContentSystem\Cache\CacheInvalidationSubscriber;
+use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Storefront\ContentSystem\FooterContentLayout\FooterContentLayoutDefinition;
+use Shopware\Storefront\ContentSystem\HeaderContentLayout\HeaderContentLayoutDefinition;
+
+/**
+ * Header and footer are Storefront tables, so {@see CacheInvalidationSubscriber} learns their names from a
+ * container parameter the Storefront fills. Core declares the parameter empty, which only holds while the
+ * Storefront bundle is loaded after the Framework bundle.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class SectionAssignmentWiringTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    #[TestDox('the storefront contributes the header and footer assignment tables to cache invalidation')]
+    public function testStorefrontContributesSectionAssignments(): void
+    {
+        static::assertSame(
+            [
+                HeaderContentLayoutDefinition::ENTITY_NAME => ContentSection::HEADER->value,
+                FooterContentLayoutDefinition::ENTITY_NAME => ContentSection::FOOTER->value,
+            ],
+            static::getContainer()->getParameter('shopware.content_system.section_assignment_entities'),
+        );
+    }
+}

--- a/tests/unit/Core/Framework/ContentSystem/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Cache/CacheInvalidationSubscriberTest.php
@@ -9,10 +9,14 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Aggregate\CategoryContentLayout\CategoryContentLayoutDefinition;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageContentLayout\LandingPageContentLayoutDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\ContentSystem\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\ContentSystem\Cache\EntityCacheTagResolver;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -30,6 +34,10 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(CacheInvalidationSubscriber::class)]
 class CacheInvalidationSubscriberTest extends TestCase
 {
+    private const HEADER_ASSIGNMENT = 'test_header_assignment';
+
+    private const FOOTER_ASSIGNMENT = 'test_footer_assignment';
+
     private CacheInvalidator&MockObject $cacheInvalidator;
 
     private Connection&Stub $connection;
@@ -55,6 +63,10 @@ class CacheInvalidationSubscriberTest extends TestCase
             $this->connection,
             $this->cacheTagResolver,
             $this->definitionRegistry,
+            [
+                self::HEADER_ASSIGNMENT => ContentSection::HEADER->value,
+                self::FOOTER_ASSIGNMENT => ContentSection::FOOTER->value,
+            ],
         );
     }
 
@@ -63,7 +75,7 @@ class CacheInvalidationSubscriberTest extends TestCase
     {
         $layoutId = 'layout-id';
 
-        $event = $this->createWrittenEvent('content_layout', $layoutId);
+        $event = $this->createWrittenEvent(ContentLayoutDefinition::ENTITY_NAME, $layoutId);
 
         $this->cacheInvalidator->expects($this->once())
             ->method('invalidate')
@@ -127,9 +139,9 @@ class CacheInvalidationSubscriberTest extends TestCase
         $event = new EntityWrittenContainerEvent(
             Context::createDefaultContext(),
             new NestedEventCollection([
-                new EntityWrittenEvent('product_content_layout', [
-                    new EntityWriteResult($assignmentIdA, [], 'product_content_layout', EntityWriteResult::OPERATION_INSERT),
-                    new EntityWriteResult($assignmentIdB, [], 'product_content_layout', EntityWriteResult::OPERATION_INSERT),
+                new EntityWrittenEvent(ProductContentLayoutDefinition::ENTITY_NAME, [
+                    new EntityWriteResult($assignmentIdA, [], ProductContentLayoutDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_INSERT),
+                    new EntityWriteResult($assignmentIdB, [], ProductContentLayoutDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_INSERT),
                 ], Context::createDefaultContext()),
             ]),
             [],
@@ -157,7 +169,7 @@ class CacheInvalidationSubscriberTest extends TestCase
     #[TestDox('skips section invalidation when no layout IDs are found in database')]
     public function testSkipsSectionInvalidationWhenNoLayoutIdsFound(): void
     {
-        $event = $this->createWrittenEvent('header_content_layout', $this->ids->get('assignment'));
+        $event = $this->createWrittenEvent(self::HEADER_ASSIGNMENT, $this->ids->get('assignment'));
 
         $this->connection->method('fetchFirstColumn')
             ->willReturn([]);
@@ -182,7 +194,7 @@ class CacheInvalidationSubscriberTest extends TestCase
     #[TestDox('skips entity invalidation when no assignment IDs are found in database')]
     public function testSkipsEntityInvalidationWhenNoAssignmentIdsFound(): void
     {
-        $event = $this->createWrittenEvent('product_content_layout', $this->ids->get('assignment'));
+        $event = $this->createWrittenEvent(ProductContentLayoutDefinition::ENTITY_NAME, $this->ids->get('assignment'));
 
         $this->connection->method('fetchFirstColumn')
             ->willReturn([]);
@@ -193,14 +205,50 @@ class CacheInvalidationSubscriberTest extends TestCase
         ($this->subscriber)($event);
     }
 
+    #[TestDox('ignores a section assignment table that no bundle registered')]
+    public function testIgnoresUnregisteredSectionAssignment(): void
+    {
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            $this->cacheTagResolver,
+            $this->definitionRegistry,
+            [],
+        );
+
+        $event = $this->createWrittenEvent(self::HEADER_ASSIGNMENT, $this->ids->get('assignment'));
+
+        $this->cacheInvalidator->expects($this->never())
+            ->method('invalidate');
+
+        $subscriber($event);
+    }
+
+    #[TestDox('rejects a section assignment map naming an unknown section')]
+    public function testRejectsUnknownSection(): void
+    {
+        $this->cacheInvalidator->expects($this->never())
+            ->method('invalidate');
+
+        static::expectException(\ValueError::class);
+
+        new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            $this->cacheTagResolver,
+            $this->definitionRegistry,
+            ['sidebar_content_layout' => 'sidebar'],
+        );
+    }
+
     /**
      * @return \Generator<string, array{string, string}>
      */
     public static function invalidatesEntityAssignmentCacheTagProvider(): \Generator
     {
-        yield 'product assignment' => ['product_content_layout', 'product-'];
-        yield 'category assignment' => ['category_content_layout', 'category-route-'];
-        yield 'landing page assignment' => ['landing_page_content_layout', 'landing-page-route-'];
+        yield 'product assignment' => [ProductContentLayoutDefinition::ENTITY_NAME, 'product-'];
+        yield 'category assignment' => [CategoryContentLayoutDefinition::ENTITY_NAME, 'category-route-'];
+        yield 'landing page assignment' => [LandingPageContentLayoutDefinition::ENTITY_NAME, 'landing-page-route-'];
     }
 
     /**
@@ -208,8 +256,8 @@ class CacheInvalidationSubscriberTest extends TestCase
      */
     public static function invalidatesSectionCacheTagProvider(): \Generator
     {
-        yield 'header section' => ['header_content_layout', ContentSection::HEADER];
-        yield 'footer section' => ['footer_content_layout', ContentSection::FOOTER];
+        yield 'header section' => [self::HEADER_ASSIGNMENT, ContentSection::HEADER];
+        yield 'footer section' => [self::FOOTER_ASSIGNMENT, ContentSection::FOOTER];
     }
 
     private function createWrittenEvent(string $entityName, string $id): EntityWrittenContainerEvent


### PR DESCRIPTION
Item 5 of shopware/shopware#19954.

## Problem

`CacheInvalidationSubscriber` passed all six table names to `EntityWrittenContainerEvent::getPrimaryKeys()` as string literals. That method filters the contained events by an exact entity-name match (`EntityWrittenContainerEvent::getResults()`), so a name no definition answers to yields an empty result — the invalidation silently does nothing. Renaming one of the six tables therefore disables its invalidation without anything turning red, and the unit test re-typed the same literals, so it could not catch it either.

## Change

The four Core names come from their definitions' `ENTITY_NAME`, the way the sibling `EntityCacheTagResolver` already keys its tag patterns.

Header and footer are Storefront-owned. Importing those definitions into Core would invert the bundle dependency, so the two names arrive through a new container parameter `shopware.content_system.section_assignment_entities` (assignment table name → `ContentSection` value). Core declares it empty; the Storefront fills it from `HeaderContentLayoutDefinition::ENTITY_NAME` / `FooterContentLayoutDefinition::ENTITY_NAME`. An unknown section value fails at construction rather than per write.

## Tests

The module had **no** end-to-end coverage of content cache invalidation before this PR — the unit test stubs `Connection`, so nothing exercised the listener registration, the assignment SQL, or the column names it interpolates.

- `SectionAssignmentWiringTest::testHeaderAssignmentWriteInvalidatesRouteTags` (integration) — a real DAL write to `header_content_layout` against the booted container; the invalidated tags are read off `InvalidateCacheEvent`. Verified by falsification: dropping the header entry from the Storefront parameter makes it fail (`Failed asserting that an array contains 'content-layout-…'`), so it covers the wiring rather than restating it.
- `SectionAssignmentWiringTest::testStorefrontContributesSectionAssignments` (integration) — pins the load-order assumption: Core's empty default only loses because the Storefront bundle is registered after the Framework bundle.
- `CacheInvalidationTableNamesTest` (integration, Core) — every name the subscriber can reach, the four constants plus the parameter's keys, exists in the live schema. This is the assertion a rename actually breaks; re-typing the constants in the unit test would not be.
- `CacheInvalidationSubscriberTest` — providers now yield the constants; two new cases cover an empty section map and an unknown section value.

## Not in scope

The column names (`product_id`, `content_layout_id`, …) stay literals — the ticket item is about table names, and they are not reachable through a definition constant the same way. The new end-to-end test does cover `content_layout_id` implicitly, since the SQL would fail on a wrong column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)