### PR TITLE
fix(storefront): use valid text input types in checkout address modals (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-09-11-fix-address-modal-input-types.md
+++ b/changelog/_unreleased/2026-09-11-fix-address-modal-input-types.md
@@ -1,0 +1,8 @@
+---
+title: Use valid text input types in checkout address modals
+issue: 18123
+author: Daniel Vien
+author_email: d.vienphamtri@shopware.com
+---
+# Storefront
+* Changed `address-manager-modal-create-address.html.twig` to prevent the billing or shipping address type from leaking into shared form inputs when `ACCESSIBILITY_TWEAKS` is enabled.

--- a/src/Storefront/Resources/views/storefront/component/address/address-manager-modal-create-address.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-manager-modal-create-address.html.twig
@@ -39,10 +39,12 @@
                         {% set accountType = '' %}
                     {% endif %}
 
+                    {# Prevent the address type from becoming the HTML input type in the shared form components. #}
                     {% sw_include '@Storefront/storefront/component/address/address-personal.html.twig' with {
                         data: postedAddress,
                         prefix: 'address',
-                        accountType
+                        accountType,
+                        type: null
                     } %}
                 {% endblock %}
 
@@ -51,6 +53,7 @@
                         data: postedAddress,
                         prefix: 'address',
                         showFormCompany: true,
+                        type: null
                     } %}
                 {% endblock %}
 

--- a/tests/integration/Storefront/Controller/AddressControllerTest.php
+++ b/tests/integration/Storefront/Controller/AddressControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
@@ -16,6 +17,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
@@ -32,6 +34,7 @@ use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -41,6 +44,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class AddressControllerTest extends TestCase
 {
+    use EnvTestBehaviour;
     use IntegrationTestBehaviour;
     use StorefrontControllerTestBehaviour;
     use StorefrontSalesChannelTestHelper;
@@ -1069,6 +1073,62 @@ class AddressControllerTest extends TestCase
         $response = $browser->getResponse();
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    #[DataProvider('addressManagerFormProvider')]
+    public function testAddressManagerFormUsesTextInputTypes(string $addressType, bool $editAddress, bool $accessibilityTweaks): void
+    {
+        $this->setEnvVars(['ACCESSIBILITY_TWEAKS' => $accessibilityTweaks]);
+
+        [$customerId] = $this->createCustomers();
+
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)
+            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL, [SalesChannelContextService::CUSTOMER_ID => $customerId]);
+
+        $customer = $context->getCustomer();
+        static::assertNotNull($customer);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $context);
+        $request->attributes->set(RequestTransformer::STOREFRONT_URL, 'shopware.test');
+        $request->setSession($this->getSession());
+        static::getContainer()->get('request_stack')->push($request);
+
+        $addressId = $editAddress ? $customer->getDefaultBillingAddressId() : null;
+        $response = static::getContainer()->get(AddressController::class)
+            ->addressManagerUpsert($request, new RequestDataBag(), $context, $customer, $addressId, $addressType);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $crawler = new Crawler((string) $response->getContent());
+
+        foreach (['firstName', 'lastName', 'street', 'zipcode', 'city', 'company', 'department'] as $field) {
+            $input = $crawler->filter(\sprintf('input[name="address[%s]"]', $field));
+            static::assertCount(1, $input);
+            static::assertSame('text', $input->attr('type'), $field . ' must use a valid text input type');
+        }
+
+        static::assertCount(0, $crawler->filter('input[type="billing"], input[type="shipping"]'));
+        static::assertStringContainsString(
+            'type=' . $addressType,
+            (string) $crawler->filter('#address-manager-modal-address-form')->attr('action')
+        );
+        static::assertSame($addressType, $crawler->filter('.address-form-create-cancel')->attr('data-address-type'));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool, bool}>
+     */
+    public static function addressManagerFormProvider(): iterable
+    {
+        foreach ([false, true] as $accessibilityTweaks) {
+            $suffix = $accessibilityTweaks ? ' with accessibility tweaks' : ' without accessibility tweaks';
+
+            yield 'create shipping address' . $suffix => [self::ADDRESS_TYPE_SHIPPING, false, $accessibilityTweaks];
+            yield 'create billing address' . $suffix => [self::ADDRESS_TYPE_BILLING, false, $accessibilityTweaks];
+            yield 'edit shipping address' . $suffix => [self::ADDRESS_TYPE_SHIPPING, true, $accessibilityTweaks];
+            yield 'edit billing address' . $suffix => [self::ADDRESS_TYPE_BILLING, true, $accessibilityTweaks];
+        }
     }
 
     private function login(): KernelBrowser


### PR DESCRIPTION
### 1. Why is this change necessary?

With `ADDRESS_SELECTION_REWORK` and `ACCESSIBILITY_TWEAKS` enabled on 6.6, checkout address modals render text fields with invalid `type="billing"` or `type="shipping"` attributes. The issue affects both creating and editing addresses and was reproduced on `6.6.x` before applying the fix.

### 2. What does this change do, exactly?

Backports the input-context fix from #18314 by clearing `type` when including the personal and general address forms. It preserves the 6.6 `type` template variable, `url()` routing, feature flags, and legacy validation instead of importing the 6.7 variable migration and deprecations. Eight regression cases cover billing/shipping, create/edit, and accessibility tweaks on/off; four failed before the fix and all eight pass afterward, alongside the full address-controller suite in both feature modes, PHPStan, PHP style, Twig syntax, and changelog validation.

### 3. Describe each step to reproduce the issue or behaviour.

1. On 6.6, enable `ADDRESS_SELECTION_REWORK` and `ACCESSIBILITY_TWEAKS`, add a product to the cart, and proceed to checkout confirmation.
2. Open the delivery or invoice address modal and choose to add or edit an address.
3. Inspect the raw `type` attributes of fields such as first name and street: they must be `text`, while the form action and back button must retain the selected billing/shipping address type.

### 4. Please link to the relevant issues (if any).

- Backport of #18314 to `6.6.x`.
- Relates to #18123.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
