### PR TITLE
docs(content-system): record what the data-requirement key fallback does on write-back

### DIFF
--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/docs/data-requirements.md
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/docs/data-requirements.md
@@ -29,9 +29,12 @@ Don't use data requirements when:
 
 Each data requirement is an object with these fields:
 
-- `key` (optional) - Names this data requirement. It does NOT place the loaded value: the element property the data lands under is the object's key name in the `dataRequirements` map, always. `Layout/Codec/StoredElementCodec::decodeDataRequirements()` keys the decoded map by the map key and `Rendering/RenderedElementFactory::create()` mints from those map keys, so an inner `key` differing from its map key changes nothing about placement. Omitted, it falls back to the map key.
+- `key` (optional) - Names this data requirement. It does NOT place the loaded value: the property the data lands under is always the entry's key in the `dataRequirements` map. `Layout/Codec/StoredElementCodec::decodeDataRequirements()` decodes by that map key and `Rendering/RenderedElementFactory::create()` mints from it, so an inner `key` differing from its map key changes nothing about placement. Omitted, it falls back to the map key.
 - `source` (required) - Loader identifier (e.g., `"entity"`, `"entity_collection"`, `"product_listing"`, `"navigation"`)
 - `config` (optional) - Loader-specific configuration object
+
+> [!NOTE]
+> A missing `key` is unambiguous rather than malformed, so decode fills it from the map key instead of failing. `Layout/Element/DataRequirement/DataRequirement::jsonSerialize()` always emits `key`, so such a requirement — written by raw SQL, or in a row predating that guarantee — gains an explicit `key` the next time its layout is saved: the stored bytes change, the tree does not.
 
 ## Multiple Data Requirements
 

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredElementCodecDataRequirementTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Codec/StoredElementCodecDataRequirementTest.php
@@ -36,6 +36,20 @@ class StoredElementCodecDataRequirementTest extends StoredElementCodecTestCase
         static::assertSame($expected, $element->dataRequirements['products']->key);
     }
 
+    #[TestDox('a requirement stored without a key gains an explicit one when the element is encoded again')]
+    public function testAKeylessRequirementIsNormalizedOnReEncode(): void
+    {
+        $stored = ['source' => 'entity', 'config' => ['entity' => 'product', 'property' => 'productId']];
+
+        $encoded = $this->codec()->decode(self::baseWire(['dataRequirements' => ['products' => $stored]]))->jsonSerialize();
+
+        static::assertArrayNotHasKey('key', $stored);
+        static::assertSame(
+            ['key' => 'products', 'source' => 'entity', 'config' => ['entity' => 'product', 'property' => 'productId']],
+            $encoded['dataRequirements']['products'] ?? null,
+        );
+    }
+
     #[TestDox('names the element whose data requirement points at an unregistered config serializer source')]
     public function testDecodeThrowsWithElementIdWhenSourceUnregistered(): void
     {


### PR DESCRIPTION
Item 6 of shopware/shopware#19954 — "Settle the data-requirement key fallback".

The ticket leaves the choice open: drop the fallback, or keep it and write down the normalize-on-next-write effect. **Kept and recorded.**

## What the investigation found

`StoredElementCodec::decodeDataRequirements()` resolves `$requirement['key'] ?? (string) $mapKey`, while `DataRequirement::jsonSerialize()` always emits `key`. So nothing the encoder writes exercises the fallback — it only ever sees a row written by raw SQL, or one predating that guarantee. Such a row gains an explicit `key` on its next save: the stored bytes change, the tree does not.

Two facts decided it:

- **The map key places the value, not the inner `key`.** `RenderedElementFactory::create()` mints from `array_keys($stored->dataRequirements)`. A missing inner key is therefore unambiguous rather than malformed — the map key *is* the answer.
- **The inner `key` is authoritative only off the storage path.** `ElementLowering` indexes by `$requirement->key`, but only for the page-level requirements (`$pageDataRequirements`), which are a PHP-built list from `AbstractContentLayoutAssignableDefinition` and never decoded from storage.

Making a keyless requirement a decode error would additionally require narrowing `StoredTreeConstraints` (`'key' => new Optional(...)` → required) and the published `StoredContentElement.json` — a wire-contract narrowing for a field that places nothing.

## Change

- `Hydration/DataLoader/docs/data-requirements.md` states the write-back effect and why the fallback is not an error. The `key` bullet was tightened in the same pass rather than grown.
- `StoredElementCodecDataRequirementTest::testAKeylessRequirementIsNormalizedOnReEncode` pins it, so the documented normalization cannot drift silently. The three existing decode cases are untouched.

No production code changed.

## Noted, not fixed

A stored `key: 'featured'` under map key `products` is accepted and round-trips while meaning nothing — the existing test pins that as deliberate. Neither option the ticket offers closes it, so it stays as it is; the doc says plainly that a diverging inner key changes nothing about placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)