### PR TITLE
fix: restore offcanvas cart quantity focus (6.6)

### DIFF
--- a/changelog/_unreleased/2026-09-11-restore-offcanvas-cart-quantity-focus.md
+++ b/changelog/_unreleased/2026-09-11-restore-offcanvas-cart-quantity-focus.md
@@ -1,0 +1,8 @@
+---
+title: Restore quantity input focus after offcanvas cart updates
+issue: 14015
+author: Daniel Vien
+author_email: d.vienphamtri@shopware.com
+---
+# Storefront
+* Changed `storefront/layout/header/header.html.twig` to enable the existing `OffCanvasCart` autofocus option, restoring focus to the quantity input after the offcanvas cart content is updated.

--- a/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-cart/offcanvas-cart.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-cart/offcanvas-cart.plugin.test.js
@@ -1,4 +1,5 @@
 import OffCanvasCartPlugin from 'src/plugin/offcanvas-cart/offcanvas-cart.plugin';
+import FocusHandler from 'src/helper/focus-handler.helper';
 
 /**
  * @package checkout
@@ -15,7 +16,7 @@ jest.mock('src/service/http-client.service', () => {
                 <a class="cart-item-label" href="#">Kek product</a>
 
                 <form action="/checkout/line-item/change-quantity/uuid12345">
-                    <select name="quantity" class="js-offcanvas-cart-change-quantity">
+                    <select name="quantity" class="js-offcanvas-cart-change-quantity" data-focus-id="line-item-offcanvas-quantity-uuid12345">
                         <option value="1" selected="selected">1</option>
                         <option value="2" >2</option>
                     </select>
@@ -26,7 +27,7 @@ jest.mock('src/service/http-client.service', () => {
                 <a class="cart-item-label" href="#">Weird product with huge quantity</a>
 
                 <form action="/checkout/line-item/change-quantity/uuid555">
-                    <input type="number" name="quantity" class="js-offcanvas-cart-change-quantity-number" min="1" max="150" step="1" value="1">
+                    <input type="number" name="quantity" class="js-offcanvas-cart-change-quantity-number" min="1" max="150" step="1" value="1" data-focus-id="line-item-offcanvas-quantity-uuid555">
                 </form>
             </div>
         </div>
@@ -58,18 +59,28 @@ describe('OffCanvasCartPlugin tests', () => {
 
     let plugin;
 
+    function createPlugin(options) {
+        document.body.innerHTML = '<div class="header-cart" data-off-canvas-cart="true"><a class="header-cart-btn">€ 0,00</a></div>';
+
+        const el = document.querySelector('.header-cart');
+
+        if (options) {
+            el.setAttribute('data-off-canvas-cart-options', JSON.stringify(options));
+        }
+
+        const instance = new OffCanvasCartPlugin(el, {}, 'OffCanvasCart');
+        instance.$emitter.publish = jest.fn();
+
+        return instance;
+    }
+
     beforeEach(() => {
 
         window.router = {
             'frontend.cart.offcanvas': '/checkout/offcanvas',
         };
 
-        window.focusHandler = {
-            saveFocusState: jest.fn(),
-            resumeFocusState: jest.fn(),
-        };
-
-        document.body.innerHTML = '<div class="header-cart"><a class="header-cart-btn">€ 0,00</a></div>';
+        window.focusHandler = new FocusHandler();
 
         window.PluginManager = {
             initializePlugins: jest.fn(),
@@ -89,18 +100,17 @@ describe('OffCanvasCartPlugin tests', () => {
             },
         };
 
-        const el = document.querySelector('.header-cart');
-
         fireRequestSpy = jest.spyOn(OffCanvasCartPlugin.prototype, '_fireRequest');
 
-        plugin = new OffCanvasCartPlugin(el);
-        plugin.$emitter.publish = jest.fn();
+        plugin = createPlugin();
 
         jest.useFakeTimers();
     });
 
     afterEach(() => {
         fireRequestSpy.mockClear();
+        jest.clearAllTimers();
+        jest.useRealTimers();
     });
 
     test('creates plugin instance', () => {
@@ -157,6 +167,38 @@ describe('OffCanvasCartPlugin tests', () => {
 
         // Verify updated content after quantity change
         expect(document.querySelector('.offcanvas-body').textContent).toBe('Content after update');
+    });
+
+    test.each([
+        ['enabled', { autoFocus: true }, true],
+        ['disabled', { autoFocus: false }, false],
+        ['omitted', undefined, false],
+    ])('restores quantity focus only when the header autoFocus option is enabled: %s', (description, options, shouldRestoreFocus) => {
+        plugin = createPlugin(options);
+        plugin.el.dispatchEvent(new Event('click', { bubbles: true }));
+        jest.runOnlyPendingTimers();
+
+        const quantitySelector = '[data-focus-id="line-item-offcanvas-quantity-uuid555"]';
+        const quantityInput = document.querySelector(quantitySelector);
+        const response = document.querySelector('.offcanvas').cloneNode(true);
+        response.querySelector(quantitySelector).setAttribute('value', '2');
+
+        jest.spyOn(plugin.client, 'post').mockImplementation((url, data, callback) => callback(response.innerHTML));
+
+        quantityInput.focus();
+        expect(document.activeElement).toBe(quantityInput);
+
+        quantityInput.value = '2';
+        quantityInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+        jest.advanceTimersByTime(800);
+
+        const updatedQuantityInput = document.querySelector(quantitySelector);
+
+        expect(plugin.client.post).toHaveBeenCalledTimes(1);
+        expect(updatedQuantityInput).not.toBe(quantityInput);
+        expect(updatedQuantityInput.value).toBe('2');
+        expect(document.activeElement).toBe(shouldRestoreFocus ? updatedQuantityInput : document.body);
     });
 
     test('change product quantity should not send too many requests when spamming the number input', () => {

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -101,11 +101,16 @@
                             </div>
                         {% endblock %}
 
+                        {% set offcanvasCartOptions = {
+                            autoFocus: true
+                        } %}
+
                         {% block layout_header_actions_cart %}
                             <div class="col-auto">
                                 <div
                                     class="header-cart"
                                     data-off-canvas-cart="true"
+                                    data-off-canvas-cart-options="{{ offcanvasCartOptions|json_encode }}"
                                 >
                                     <a
                                         class="btn header-cart-btn header-actions-btn"

--- a/tests/integration/Storefront/Framework/Twig/HeaderTemplateTest.php
+++ b/tests/integration/Storefront/Framework/Twig/HeaderTemplateTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Framework\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Test\Generator;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class HeaderTemplateTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testHeaderEnablesOffCanvasCartFocusRestoration(): void
+    {
+        $twig = static::getContainer()->get('twig');
+        static::assertInstanceOf(Environment::class, $twig);
+
+        $requestStack = static::getContainer()->get(RequestStack::class);
+        $requestStack->push(new Request());
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+        $context->getCurrency()->setIsoCode('EUR');
+
+        try {
+            $html = $twig->render('@Storefront/storefront/layout/header/header.html.twig', [
+                'context' => $context,
+            ]);
+        } finally {
+            $requestStack->pop();
+        }
+
+        $cart = (new Crawler($html))->filter('[data-off-canvas-cart]');
+        static::assertCount(1, $cart);
+
+        $options = json_decode($cart->attr('data-off-canvas-cart-options') ?? '{}', true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($options);
+        static::assertTrue($options['autoFocus'] ?? false);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

On 6.6, changing a product quantity with the keyboard in the offcanvas cart moves focus to the offcanvas container after the content reloads.

### 2. What does this change do, exactly?

Backports #14957 by enabling the existing `OffCanvasCart` `autoFocus` option in the header template, reusing 6.6's focus handler and callback-based requests. Adds a rendered-header regression test, DOM-level focus restoration and opt-out tests, and a 6.6 changelog. This covers the offcanvas portion of #14015; the full cart page's separate autofocus configuration remains outside this backport.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a product, close the offcanvas cart, then reopen it through the header cart link using the keyboard.
2. Focus the quantity input and press Arrow Up, then Enter to commit the edit; after the cart reloads, focus should return to that product's quantity input. Also verified after opening through add-to-cart, and Escape restores focus to the header cart link.
3. Reproduced focus loss in the browser and a failing rendered-header test on the original `6.6.x` baseline; both passed with the fix. Original validation: 30 focused Storefront Jest tests, header PHPUnit test, Storefront production build, PHPStan, PHP CS, ESLint, changelog validation, Twig syntax, and `git diff --check`. Current merge validation: 76 focused Storefront Jest tests, ESLint, and `git diff --check`.

### 4. Please link to the relevant issues (if any).

- Backport of #14957
- Relates to #14015 (offcanvas cart)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

