### PR TITLE
fix: bulk document download filename

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/documentV2.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/documentV2.api.service.spec.js
@@ -248,7 +248,7 @@ describe('documentV2ApiService', () => {
         await documentV2ApiService.getDocumentArchive([documentId]);
 
         expect(clientMock.history.post[0].url).toBe('/_action/order/document-v2/download-archive');
-        expect(JSON.parse(clientMock.history.post[0].data)).toEqual({ documentIds: [documentId] });
+        expect(JSON.parse(clientMock.history.post[0].data)).toEqual({ documentIds: [documentId], filename: null });
     });
 
     it('downloads all document files as archive for multiple documents', async () => {
@@ -263,6 +263,20 @@ describe('documentV2ApiService', () => {
         await documentV2ApiService.getDocumentArchive(documentIds);
 
         expect(clientMock.history.post[0].url).toBe('/_action/order/document-v2/download-archive');
-        expect(JSON.parse(clientMock.history.post[0].data)).toEqual({ documentIds });
+        expect(JSON.parse(clientMock.history.post[0].data)).toEqual({ documentIds, filename: null });
+    });
+
+    it('passes the filename through when given', async () => {
+        const { documentV2ApiService, clientMock } = createDocumentV2ApiService();
+        const documentIds = ['4a4a687257644d52bf481b4c20e59213'];
+
+        clientMock.onPost('/_action/order/document-v2/download-archive').reply(200, '');
+
+        await documentV2ApiService.getDocumentArchive(documentIds, 'my-custom-filename');
+
+        expect(JSON.parse(clientMock.history.post[0].data)).toEqual({
+            documentIds,
+            filename: 'my-custom-filename',
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/core/service/api/documentV2.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/documentV2.api.service.ts
@@ -196,11 +196,11 @@ export default class DocumentV2ApiService extends ApiService {
             });
     }
 
-    public getDocumentArchive(documentIds: string[]): Promise<DocumentFileResponse> {
+    public getDocumentArchive(documentIds: string[], filename: string | null = null): Promise<DocumentFileResponse> {
         return this.httpClient
             .post<Blob>(
                 '/_action/order/document-v2/download-archive',
-                { documentIds },
+                { documentIds, filename },
                 {
                     responseType: 'blob',
                     headers: this.getBasicHeaders(),

--- a/src/Administration/Resources/app/administration/src/core/service/api/order-document.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/order-document.api.service.js
@@ -21,10 +21,10 @@ export default class OrderDocumentApiService extends ApiService {
         });
     }
 
-    download(documentIds, additionalParams = {}, additionalHeaders = {}) {
+    download(documentIds, filename = null, additionalParams = {}, additionalHeaders = {}) {
         return this.httpClient.post(
             `/_action/${this.apiEndpoint}/download`,
-            { documentIds },
+            { documentIds, filename },
             {
                 additionalParams,
                 responseType: 'blob',

--- a/src/Administration/Resources/app/administration/src/core/service/api/order-document.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/order-document.api.service.spec.js
@@ -69,9 +69,26 @@ describe('orderDocumentApiService', () => {
             ];
             const additionalParams = {};
 
-            orderDocumentApiService.download(documentIds, additionalParams);
+            orderDocumentApiService.download(documentIds, null, additionalParams);
 
             expect(clientMock.history.post[0].url).toBe('/_action/order/document/download');
+            expect(clientMock.history.post[0].data).toBe(JSON.stringify({ documentIds, filename: null }));
+        });
+
+        it('passes the filename through when given', async () => {
+            const { orderDocumentApiService, clientMock } = createOrderDocumentApiService();
+
+            const documentIds = [
+                1,
+                2,
+                3,
+            ];
+
+            orderDocumentApiService.download(documentIds, 'my-custom-filename');
+
+            expect(clientMock.history.post[0].data).toBe(
+                JSON.stringify({ documentIds, filename: 'my-custom-filename' }),
+            );
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/index.js
@@ -307,9 +307,11 @@ export default {
 
             this.document[documentType].isDownloading = true;
 
+            const filename = documentIds.length > 1 ? `${documentType}s_bulk` : null;
+
             const request = this.feature.isActive('DOCUMENT_GENERATION_REWORK')
-                ? this.documentV2ApiService.getDocumentArchive(documentIds)
-                : this.orderDocumentApiService.download(documentIds).then((response) => {
+                ? this.documentV2ApiService.getDocumentArchive(documentIds, filename)
+                : this.orderDocumentApiService.download(documentIds, filename).then((response) => {
                       if (!response.data) {
                           return null;
                       }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/sw-bulk-edit-save-modal-success.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/sw-bulk-edit-save-modal-success.spec.js
@@ -422,6 +422,47 @@ describe('sw-bulk-edit-save-modal-success', () => {
         wrapper.vm.orderDocumentApiService.download.mockRestore();
     });
 
+    it('should request a bulk filename based on the document type', async () => {
+        window.URL.createObjectURL = jest.fn();
+        wrapper.vm.orderDocumentApiService.download = jest.fn(() => Promise.resolve({ data: null }));
+
+        await wrapper.setData({
+            latestDocuments: {
+                delivery_note: [
+                    'documentId1',
+                    'documentId2',
+                ],
+            },
+        });
+        await wrapper.vm.downloadDocument('delivery_note');
+
+        expect(wrapper.vm.orderDocumentApiService.download).toHaveBeenCalledWith(
+            [
+                'documentId1',
+                'documentId2',
+            ],
+            'delivery_notes_bulk',
+        );
+
+        wrapper.vm.orderDocumentApiService.download.mockRestore();
+    });
+
+    it('should keep the server filename when downloading a single document', async () => {
+        window.URL.createObjectURL = jest.fn();
+        wrapper.vm.orderDocumentApiService.download = jest.fn(() => Promise.resolve({ data: null }));
+
+        await wrapper.setData({
+            latestDocuments: {
+                delivery_note: ['documentId1'],
+            },
+        });
+        await wrapper.vm.downloadDocument('delivery_note');
+
+        expect(wrapper.vm.orderDocumentApiService.download).toHaveBeenCalledWith(['documentId1'], null);
+
+        wrapper.vm.orderDocumentApiService.download.mockRestore();
+    });
+
     it('should not be able to download documents', async () => {
         wrapper.vm.orderDocumentApiService.download = jest.fn(() => Promise.resolve());
 
@@ -480,15 +521,42 @@ describe('sw-bulk-edit-save-modal-success', () => {
 
         await wrapper.vm.downloadDocument('invoice');
 
-        expect(wrapper.vm.documentV2ApiService.getDocumentArchive).toHaveBeenCalledWith([
-            'documentId1',
-            'documentId2',
-        ]);
+        expect(wrapper.vm.documentV2ApiService.getDocumentArchive).toHaveBeenCalledWith(
+            [
+                'documentId1',
+                'documentId2',
+            ],
+            'invoices_bulk',
+        );
         expect(wrapper.vm.orderDocumentApiService.download).not.toHaveBeenCalled();
         expect(wrapper.vm.document.invoice.isDownloading).toBe(false);
 
         wrapper.vm.documentV2ApiService.getDocumentArchive.mockRestore();
         wrapper.vm.orderDocumentApiService.download.mockRestore();
+    });
+
+    it('should keep the server archive name when downloading a single document via the v2 endpoint', async () => {
+        global.activeFeatureFlags = ['DOCUMENT_GENERATION_REWORK'];
+        window.URL.createObjectURL = jest.fn();
+
+        wrapper.vm.documentV2ApiService.getDocumentArchive = jest.fn(() =>
+            Promise.resolve({
+                file: 'archive content',
+                fileName: '1000.zip',
+            }),
+        );
+
+        await wrapper.setData({
+            latestDocuments: {
+                invoice: ['documentId1'],
+            },
+        });
+
+        await wrapper.vm.downloadDocument('invoice');
+
+        expect(wrapper.vm.documentV2ApiService.getDocumentArchive).toHaveBeenCalledWith(['documentId1'], null);
+
+        wrapper.vm.documentV2ApiService.getDocumentArchive.mockRestore();
     });
 
     it('should call createNotificationError when the v2 archive download fails', async () => {

--- a/src/Core/Checkout/Document/Controller/DocumentController.php
+++ b/src/Core/Checkout/Document/Controller/DocumentController.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentMerger;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
+use Shopware\Core\Content\Media\File\FileNameValidator;
 use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -104,14 +105,18 @@ class DocumentController extends AbstractController
             throw DocumentException::invalidRequestParameter('documentIds');
         }
 
+        $filename = $request->request->getString('filename');
+
+        if ($filename !== '') {
+            (new FileNameValidator())->validateFileName($filename);
+        }
+
         $download = $request->query->getBoolean('download', true);
         $combinedDocument = $this->documentMerger->merge($documentIds, $context);
 
         if ($combinedDocument === null) {
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
         }
-
-        $filename = $request->request->getString('filename');
 
         return $this->createResponse(
             $filename !== '' ? $filename . '.' . $combinedDocument->getFileExtension() : $combinedDocument->getName(),

--- a/src/Core/Checkout/Document/Controller/DocumentController.php
+++ b/src/Core/Checkout/Document/Controller/DocumentController.php
@@ -111,8 +111,10 @@ class DocumentController extends AbstractController
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
         }
 
+        $filename = $request->request->getString('filename');
+
         return $this->createResponse(
-            $combinedDocument->getName(),
+            $filename !== '' ? $filename . '.' . $combinedDocument->getFileExtension() : $combinedDocument->getName(),
             $combinedDocument->getContent(),
             $download,
             $combinedDocument->getContentType()

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\DocumentV2\Service\DocumentReader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\File\FileNameProvider;
+use Shopware\Core\Content\Media\File\FileNameValidator;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
@@ -244,6 +245,12 @@ final class DocumentV2Controller extends AbstractController
             );
         }
 
+        $filename = $request->getPayload()->getString('filename');
+
+        if ($filename !== '') {
+            (new FileNameValidator())->validateFileName($filename);
+        }
+
         $documents = $this->loadDocuments($documentIds, $context);
 
         if ($documents->count() === 0) {
@@ -255,8 +262,6 @@ final class DocumentV2Controller extends AbstractController
         if ($archive === null) {
             throw DocumentV2Exception::documentArchiveUnavailable($documentIds);
         }
-
-        $filename = $request->getPayload()->getString('filename');
 
         return $this->createResponse(
             $filename !== '' ? $filename . '.' . $archive->getFileExtension() : $archive->getName(),

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -256,8 +256,10 @@ final class DocumentV2Controller extends AbstractController
             throw DocumentV2Exception::documentArchiveUnavailable($documentIds);
         }
 
+        $filename = $request->getPayload()->getString('filename');
+
         return $this->createResponse(
-            $archive->getName(),
+            $filename !== '' ? $filename . '.' . $archive->getFileExtension() : $archive->getName(),
             $archive->getContent(),
             $archive->getContentType(),
             HeaderUtils::DISPOSITION_ATTACHMENT,

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
@@ -15,10 +15,21 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "pattern": "^[0-9a-f]{32}$"
+                "type": "object",
+                "required": ["documentIds"],
+                "properties": {
+                  "documentIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "filename": {
+                    "description": "Optional file name without extension. The extension of the returned file is appended: `pdf` for merged documents, `zip` when the documents are archived, or the document's own extension for a single document. Falls back to the generated document name when omitted.",
+                    "type": "string",
+                    "nullable": true
+                  }
                 }
               }
             }
@@ -599,6 +610,11 @@
                       "pattern": "^[0-9a-f]{32}$"
                     },
                     "example": ["018f5972f9ea72a0be49f7c39f72a2a0"]
+                  },
+                  "filename": {
+                    "description": "Optional file name without extension. The extension of the returned file (`zip`) is appended. Falls back to the generated archive name when omitted.",
+                    "type": "string",
+                    "nullable": true
                   }
                 },
                 "example": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
@@ -26,7 +26,7 @@
                     }
                   },
                   "filename": {
-                    "description": "Optional file name without extension. The extension of the returned file is appended: `pdf` for merged documents, `zip` when the documents are archived, or the document's own extension for a single document. Falls back to the generated document name when omitted.",
+                    "description": "Optional file name without extension. The extension of the returned file is appended: `pdf` for merged documents, `zip` when the documents are archived, or the document's own extension for a single document. Falls back to the generated document name when omitted. Must follow the media file name rules: at most 255 characters, no leading or trailing dot, no trailing space, no control characters, and none of `\\ / ? * % & : | \" ' < > $ # { }`.",
                     "type": "string",
                     "nullable": true
                   }
@@ -612,7 +612,7 @@
                     "example": ["018f5972f9ea72a0be49f7c39f72a2a0"]
                   },
                   "filename": {
-                    "description": "Optional file name without extension. The extension of the returned file (`zip`) is appended. Falls back to the generated archive name when omitted.",
+                    "description": "Optional file name without extension. The extension of the returned file (`zip`) is appended. Falls back to the generated archive name when omitted. Must follow the media file name rules: at most 255 characters, no leading or trailing dot, no trailing space, no control characters, and none of `\\ / ? * % & : | \" ' < > $ # { }`.",
                     "type": "string",
                     "nullable": true
                   }

--- a/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
@@ -426,6 +426,38 @@ class DocumentControllerTest extends TestCase
         static::assertSame('application/pdf', $response->headers->get('Content-Type'));
     }
 
+    public function testDownloadUsesCustomFilenameWhenGiven(): void
+    {
+        $order = $this->createOrder($this->customerId, $this->context);
+        $documentTypes = [
+            'invoice' => [
+                'documentType' => 'invoice',
+                'documentRangerType' => 'document_invoice',
+                'documentNumber' => '1100',
+                'custom' => [
+                    'invoiceNumber' => '1100',
+                ],
+            ],
+        ];
+
+        static::assertNotNull($document = $this->createDocuments($order->getId(), $documentTypes, $this->context)->first());
+        static::assertInstanceOf(DocumentIdStruct::class, $document);
+
+        $this->getBrowser()->jsonRequest(
+            'POST',
+            '/api/_action/order/document/download',
+            [
+                'documentIds' => [$document->getId()],
+                'filename' => 'my-custom-filename',
+            ]
+        );
+
+        $response = $this->getBrowser()->getResponse();
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertStringContainsString('my-custom-filename.pdf', (string) $response->headers->get('Content-Disposition'));
+    }
+
     public function testDownloadPermission(): void
     {
         TestUser::createNewTestUser(

--- a/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -456,6 +457,35 @@ class DocumentControllerTest extends TestCase
 
         static::assertSame(200, $response->getStatusCode());
         static::assertStringContainsString('my-custom-filename.pdf', (string) $response->headers->get('Content-Disposition'));
+    }
+
+    #[DataProvider('unsafeFilenameProvider')]
+    public function testDownloadRejectsUnsafeFilename(string $filename, string $expectedErrorCode): void
+    {
+        $this->getBrowser()->jsonRequest(
+            'POST',
+            '/api/_action/order/document/download',
+            [
+                'documentIds' => [Uuid::randomHex()],
+                'filename' => $filename,
+            ]
+        );
+
+        $response = $this->getBrowser()->getResponse();
+        static::assertIsString($response->getContent());
+        $content = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(400, $response->getStatusCode());
+        static::assertSame($expectedErrorCode, $content['errors'][0]['code']);
+    }
+
+    public static function unsafeFilenameProvider(): \Generator
+    {
+        yield 'forward slash would act as a path separator' => ['invoices/2026', MediaException::MEDIA_ILLEGAL_FILE_NAME];
+        yield 'backslash would act as a path separator' => ['invoices\\2026', MediaException::MEDIA_ILLEGAL_FILE_NAME];
+        yield 'percent sign is not allowed in the ASCII filename fallback' => ['50%_off', MediaException::MEDIA_ILLEGAL_FILE_NAME];
+        yield 'line break is a control character' => ["delivery\nnotes", MediaException::MEDIA_ILLEGAL_FILE_NAME];
+        yield 'names longer than 255 characters are rejected' => [str_repeat('a', 256), MediaException::MEDIA_FILE_NAME_IS_TOO_LONG];
     }
 
     public function testDownloadPermission(): void

--- a/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -364,6 +364,36 @@ class DocumentV2ControllerTest extends TestCase
         (new Filesystem())->remove($tempFile);
     }
 
+    public function testDownloadArchiveUsesCustomFilenameWhenGiven(): void
+    {
+        $this->seedDemoBaseConfig(DocumentType::INVOICE->value);
+        $orderId = $this->createDraftOrder();
+        $documentNumber = 'legacy-archive-' . Uuid::randomHex();
+        $config = $this->getDemoInvoiceLegacyConfig();
+        $config['documentNumber'] = $documentNumber;
+
+        $document = static::getContainer()->get(LegacyDocumentGenerator::class)->generate(
+            InvoiceRenderer::TYPE,
+            [$orderId => new DocumentGenerateOperation($orderId, PdfRenderer::FILE_EXTENSION, $config)],
+            $this->context,
+        )->getSuccess()->first();
+
+        static::assertNotNull($document);
+
+        $this->getBrowser()->request(
+            'POST',
+            '/api/_action/order/document-v2/download-archive',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['documentIds' => [$document->getId()], 'filename' => 'my-custom-archive'], \JSON_THROW_ON_ERROR),
+        );
+
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+        static::assertStringContainsString('my-custom-archive.zip', (string) $response->headers->get('content-disposition'));
+    }
+
     private function createDraftOrder(): string
     {
         $cart = $this->generateDemoCartWithTaxes([19, 7]);

--- a/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Controller;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinition;
@@ -39,6 +40,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\MediaFile;
 use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\App\Feature\AppFeature;
 use Shopware\Core\Framework\App\Feature\AppFeatureStorage;
@@ -858,6 +860,57 @@ class DocumentV2ControllerTest extends TestCase
             ),
             Context::createDefaultContext(),
         );
+    }
+
+    #[DataProvider('unsafeFilenameProvider')]
+    public function testDownloadArchiveThrowsWhenFilenameIsUnsafe(string $filename, MediaException $expectedException): void
+    {
+        $controller = new DocumentV2Controller(
+            $this->createGenerator(new DocumentRendererRegistry([]), Uuid::randomHex()),
+            $this->createDocumentReader(new DocumentRendererRegistry([])),
+            $this->createTypeRegistry(),
+            $this->createArchiveGenerator(static::createStub(MediaService::class)),
+            $this->documentRepository,
+            $this->createDocumentPersister(),
+            static::createStub(MediaService::class),
+            static::createStub(FileNameProvider::class),
+        );
+
+        static::expectExceptionObject($expectedException);
+
+        $controller->downloadArchive(
+            Request::create(
+                '/api/_action/order/document-v2/download-archive',
+                Request::METHOD_POST,
+                server: ['CONTENT_TYPE' => 'application/json'],
+                content: json_encode(['documentIds' => [Uuid::randomHex()], 'filename' => $filename], \JSON_THROW_ON_ERROR),
+            ),
+            Context::createDefaultContext(),
+        );
+    }
+
+    public static function unsafeFilenameProvider(): \Generator
+    {
+        yield 'forward slash would act as a path separator' => [
+            'invoices/2026',
+            MediaException::illegalFileName('invoices/2026', 'Filename must not contain "/"'),
+        ];
+        yield 'backslash would act as a path separator' => [
+            'invoices\\2026',
+            MediaException::illegalFileName('invoices\\2026', 'Filename must not contain "\\"'),
+        ];
+        yield 'percent sign is not allowed in the ASCII filename fallback' => [
+            '50%_off',
+            MediaException::illegalFileName('50%_off', 'Filename must not contain "%"'),
+        ];
+        yield 'line break is a control character' => [
+            "delivery\nnotes",
+            MediaException::illegalFileName("delivery\nnotes", 'Filename must not contain character "a"'),
+        ];
+        yield 'names longer than 255 characters are rejected' => [
+            str_repeat('a', 256),
+            MediaException::fileNameTooLong(255),
+        ];
     }
 
     public function testDownloadArchiveThrowsWhenNoDocumentsAreFound(): void


### PR DESCRIPTION
- Add optional filename to both document archive download endpoints, so a custom filename can be set, extension is still driven by what file is created, documented in schema
- Send through filename from admin js, so filenames become descriptive (ex.: `delivery_notes_bulk`)