### PR TITLE
fix(storefront): improve cart helper form accessibility (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-09-11-improve-cart-helper-form-accessibility.md
+++ b/changelog/_unreleased/2026-09-11-improve-cart-helper-form-accessibility.md
@@ -1,0 +1,10 @@
+---
+title: Improve cart helper form accessibility
+issue: 14796
+author: Daniel Vien
+author_email: d.vienphamtri@shopware.com
+---
+# Storefront
+* Changed the cart product-number label to be visible and removed redundant ARIA attributes from the product-number and promotion-code inputs.
+* Removed the required attribute from the optional product-number and promotion-code fields in the cart and offcanvas cart.
+* Changed `CartLineItemController` to reject blank helper inputs with a validation message before product lookup or promotion processing, while preserving exact product numbers.

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -118,10 +118,12 @@ class CartLineItemController extends StorefrontController
     {
         return Profiler::trace('cart::add-promotion', function () use ($cart, $request, $context) {
             try {
-                $code = (string) $request->request->get('code');
+                $code = mb_trim((string) $request->request->get('code'));
 
                 if ($code === '') {
-                    throw RoutingException::missingRequestParameter('code');
+                    $this->addFlash(self::DANGER, $this->trans('error.VIOLATION::IS_BLANK_ERROR'));
+
+                    return $this->createActionResponse($request);
                 }
 
                 $lineItem = $this->promotionItemBuilder->buildPlaceholderItem($code);
@@ -212,8 +214,10 @@ class CartLineItemController extends StorefrontController
         return Profiler::trace('cart::add-product-by-number', function () use ($request, $context) {
             $number = (string) $request->request->get('number');
 
-            if (!$number) {
-                throw RoutingException::missingRequestParameter('number');
+            if (mb_trim($number) === '') {
+                $this->addFlash(self::DANGER, $this->trans('error.VIOLATION::IS_BLANK_ERROR'));
+
+                return $this->createActionResponse($request);
             }
 
             $criteria = new Criteria();

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -127,9 +127,6 @@
                                                            class="form-control"
                                                            placeholder="{{ 'checkout.addPromotionPlaceholder'|trans|striptags }}"
                                                            id="addPromotionOffcanvasCartInput"
-                                                           aria-label="{{ 'checkout.addPromotionLabel'|trans|striptags }}"
-                                                           aria-describedby="addPromotionOffcanvasCart"
-                                                           required="required"
                                                            aria-invalid="false">
                                                 {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -98,7 +98,7 @@
                             {% endblock %}
 
                             {% block page_checkout_cart_add_product_label %}
-                                <label class="visually-hidden" for="addProductInput">
+                                <label class="mb-1" for="addProductInput">
                                     {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
                                 </label>
                             {% endblock %}
@@ -110,10 +110,7 @@
                                                name="number"
                                                class="form-control"
                                                id="addProductInput"
-                                               placeholder="{{ 'checkout.addProductPlaceholder'|trans|striptags }}"
-                                               aria-label="{{ 'checkout.addProductLabel'|trans|striptags }}"
-                                               aria-describedby="addProductButton"
-                                               required="required">
+                                               placeholder="{{ 'checkout.addProductPlaceholder'|trans|striptags }}">
                                     {% endblock %}
 
                                     {% block page_checkout_cart_add_product_submit %}
@@ -253,9 +250,6 @@
                                    class="form-control"
                                    placeholder="{{ 'checkout.addPromotionPlaceholder'|trans|striptags }}"
                                    id="addPromotionInput"
-                                   aria-label="{{ 'checkout.addPromotionLabel'|trans|striptags }}"
-                                   aria-describedby="addPromotion"
-                                   required="required"
                                    aria-invalid="false">
                         {% endblock %}
 

--- a/tests/integration/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/integration/Storefront/Controller/CartLineItemControllerTest.php
@@ -167,6 +167,8 @@ class CartLineItemControllerTest extends TestCase
             [Uuid::randomHex(), 'test_123'],
             [Uuid::randomHex(), 'testäüö123'],
             [Uuid::randomHex(), 'test/123'],
+            [Uuid::randomHex(), ' test.123 '],
+            [Uuid::randomHex(), '0'],
             [Uuid::randomHex(), 'test/unavailableProduct', false],
             ['', 'nonExisting'],
             ['', 'with<br>HTML'],
@@ -192,6 +194,39 @@ class CartLineItemControllerTest extends TestCase
         static::assertArrayHasKey('danger', $flashBagEntries);
         static::assertSame(static::getContainer()->get('translator')->trans('checkout.promotion-not-found', ['%code%' => \strip_tags('testCode')]), $flashBagEntries['danger'][0]);
         static::assertCount(0, $cartService->getCart($contextToken, $salesChannelContext)->getLineItems());
+    }
+
+    #[DataProvider('blankHelperInputs')]
+    public function testBlankHelperInputAddsValidationFlash(string $field, ?string $input): void
+    {
+        $contextToken = Uuid::randomHex();
+        $cartService = static::getContainer()->get(CartService::class);
+        $request = $this->createRequest($input === null ? [] : [$field => $input]);
+        $salesChannelContext = $this->createSalesChannelContext($contextToken);
+        $controller = static::getContainer()->get(CartLineItemController::class);
+
+        if ($field === 'code') {
+            $response = $controller->addPromotion($cartService->getCart($contextToken, $salesChannelContext), $request, $salesChannelContext);
+        } else {
+            $response = $controller->addProductByNumber($request, $salesChannelContext);
+        }
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertSame([
+            'danger' => [static::getContainer()->get('translator')->trans('error.VIOLATION::IS_BLANK_ERROR')],
+        ], $this->getFlashBag()->all());
+        static::assertCount(0, $cartService->getCart($contextToken, $salesChannelContext)->getLineItems());
+    }
+
+    public static function blankHelperInputs(): \Generator
+    {
+        foreach (['number', 'code'] as $field) {
+            yield $field . ' missing' => [$field, null];
+            yield $field . ' empty' => [$field, ''];
+            yield $field . ' spaces' => [$field, '   '];
+            yield $field . ' tabs and newlines' => [$field, "\t\n\r"];
+            yield $field . ' unicode whitespace' => [$field, "\u{00A0}\u{2003}\u{3000}"];
+        }
     }
 
     private function getFlashBag(): FlashBag

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -446,6 +446,44 @@ class CheckoutControllerTest extends TestCase
         static::assertArrayHasKey(CheckoutCartPageLoadedHook::HOOK_NAME, $traces);
     }
 
+    #[DataProvider('checkoutHelperForms')]
+    public function testCheckoutHelperFormsHaveVisibleLabelsAndOptionalInputs(string $path, string $inputId, string $buttonId): void
+    {
+        $browser = $this->getBrowserWithLoggedInCustomer();
+        $browserSalesChannelId = $browser->getServerParameter('test-sales-channel-id');
+
+        $this->createProductOnDatabase(Uuid::randomHex(), 'test.123', $browserSalesChannelId);
+
+        $browser->request('POST', '/checkout/product/add-by-number', ['number' => 'test.123']);
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+
+        $crawler = $browser->request('GET', $path);
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+
+        $label = $crawler->filter(\sprintf('label[for="%s"].mb-1:not(.visually-hidden)', $inputId));
+        static::assertCount(1, $label);
+        static::assertNotSame('', $label->text());
+
+        $input = $crawler->filter(\sprintf('input#%s', $inputId));
+        static::assertCount(1, $input);
+        static::assertNull($input->attr('required'));
+        static::assertNull($input->attr('aria-label'));
+        static::assertNull($input->attr('aria-describedby'));
+        static::assertCount(1, $crawler->filter(\sprintf('button#%s[type="submit"]', $buttonId)));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function checkoutHelperForms(): array
+    {
+        return [
+            'cart product' => ['/checkout/cart', 'addProductInput', 'addProductButton'],
+            'cart promotion' => ['/checkout/cart', 'addPromotionInput', 'addPromotion'],
+            'offcanvas promotion' => ['/checkout/offcanvas', 'addPromotionOffcanvasCartInput', 'addPromotionOffcanvasCart'],
+        ];
+    }
+
     public function testCheckoutConfirmPageLoadedHookScriptsAreExecuted(): void
     {
         $contextToken = Uuid::randomHex();

--- a/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Content\Product\SalesChannel\ProductListResponse;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -318,9 +319,9 @@ class CartLineItemControllerTest extends TestCase
         $this->controller->addLineItems($cart, new RequestDataBag($request->request->all()), $request, $context);
     }
 
-    public function testAddByProductNumber(): void
+    #[DataProvider('validProductNumbers')]
+    public function testAddByProductNumber(string $productNumber): void
     {
-        $productNumber = Uuid::randomHex();
         $id = Uuid::randomHex();
         $request = new Request([], ['number' => $productNumber]);
         $cart = new Cart(Uuid::randomHex());
@@ -333,6 +334,15 @@ class CartLineItemControllerTest extends TestCase
         $cart->add($item);
         $this->productListRouteMock->expects($this->once())
             ->method('load')
+            ->with(static::callback(static function (Criteria $criteria) use ($productNumber): bool {
+                foreach ($criteria->getFilters() as $filter) {
+                    if ($filter instanceof EqualsFilter && $filter->getField() === 'productNumber' && $filter->getValue() === $productNumber) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }), $context)
             ->willReturn(
                 new ProductListResponse(
                     new EntitySearchResult(
@@ -359,6 +369,61 @@ class CartLineItemControllerTest extends TestCase
         $this->translatorCallback();
 
         $this->controller->addProductByNumber($request, $context);
+    }
+
+    public static function validProductNumbers(): \Generator
+    {
+        yield 'ordinary number' => ['test.123'];
+        yield 'surrounding spaces are part of the number' => [' test.123 '];
+        yield 'zero is not blank' => ['0'];
+    }
+
+    #[DataProvider('blankHelperInputs')]
+    public function testAddByProductNumberWithBlankInput(?string $input): void
+    {
+        $request = new Request([], $input === null ? [] : ['number' => $input]);
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->productListRouteMock->expects($this->never())->method('load');
+        $this->productLineItemFactoryMock->expects($this->never())->method('create');
+        $this->cartService->expects($this->never())->method('getCart');
+        $this->cartService->expects($this->never())->method('add');
+
+        $session = new Session(new MockArraySessionStorage());
+        $this->translatorCallback($session);
+
+        $response = $this->controller->addProductByNumber($request, $context);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
+
+    #[DataProvider('blankHelperInputs')]
+    public function testAddPromotionWithBlankInput(?string $input): void
+    {
+        $request = new Request([], $input === null ? [] : ['code' => $input]);
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->promotionItemBuilderMock->expects($this->never())->method('buildPlaceholderItem');
+        $this->cartService->expects($this->never())->method('add');
+
+        $session = new Session(new MockArraySessionStorage());
+        $this->translatorCallback($session);
+
+        $response = $this->controller->addPromotion($cart, $request, $context);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
+
+    public static function blankHelperInputs(): \Generator
+    {
+        yield 'missing' => [null];
+        yield 'empty' => [''];
+        yield 'spaces' => ['   '];
+        yield 'tabs and newlines' => ["\t\n\r"];
+        yield 'unicode whitespace' => ["\u{00A0}\u{2003}\u{3000}"];
     }
 
     public function testAddByProductNumberNotFound(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The checkout helper forms have the same accessibility issues on 6.6: the product-number label is visually hidden and optional product-number/promo-code fields are marked as required. Blank submissions also produce misleading errors or enter product/promotion processing.

### 2. What does this change do, exactly?

- Backports #16047 into the existing 6.6 cart and offcanvas templates, making the product-number label visible and removing required and redundant ARIA attributes from the helper inputs.
- Rejects missing, empty and whitespace-only inputs with the existing translated validation message before processing; preserves exact product numbers and the existing promotion-code normalization.
- Adds regression coverage verified to fail before the fix; all 105 tests in the three affected classes pass (621 assertions), along with focused PHPStan, PHP CS, Twig and changelog checks, and rendered-form checks with `ACCESSIBILITY_TWEAKS` enabled and disabled.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a product to the storefront cart, then inspect the product-number and promo-code helper forms on the cart page and the promo-code form in the offcanvas cart.
2. Before the fix, the product-number label is hidden and all three inputs are required; after the fix, the label is visible and the helper fields are optional.
3. Submit an empty or whitespace-only helper value: after the fix, the validation message is displayed without looking up a product or processing a promotion; valid product numbers, including surrounding spaces, continue to work.

### 4. Please link to the relevant issues (if any).

- Backport of #16047
- Relates to #14796
- Relates to #14834

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
