### PR TITLE
fix(storefront): group checkout payment and shipping choices in 6.6

### DIFF
--- a/changelog/_unreleased/2026-09-13-add-fieldsets-to-checkout-method-selections.md
+++ b/changelog/_unreleased/2026-09-13-add-fieldsets-to-checkout-method-selections.md
@@ -1,0 +1,8 @@
+---
+title: Add fieldsets to checkout payment and shipping method selections
+issue: 13980
+author: Daniel Vien
+author_email: d.vienphamtri@shopware.com
+---
+# Storefront
+* Changed the payment and shipping method containers in `page/checkout/confirm/confirm-payment.html.twig` and `page/checkout/confirm/confirm-shipping.html.twig` to fieldsets with legends so assistive technology can identify the radio groups.

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -1,6 +1,6 @@
 {% block page_checkout_confirm_payment_inner %}
     <div class="card checkout-card">
-        <div class="card-body">
+        <fieldset class="card-body">
             {% set paymentMethodInvalid = true %}
 
             {% for payment in page.paymentMethods %}
@@ -10,9 +10,9 @@
             {% endfor %}
 
             {% block page_checkout_confirm_payment_title %}
-                <div class="card-title">
+                <legend class="card-title">
                     {{ 'checkout.confirmPaymentMethod'|trans|sw_sanitize }}
-                </div>
+                </legend>
             {% endblock %}
 
             {% block page_checkout_change_payment_form %}
@@ -23,6 +23,6 @@
                     redirectParameters: {redirected: 0}|json_encode,
                 } %}
             {% endblock %}
-        </div>
+        </fieldset>
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-shipping.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-shipping.html.twig
@@ -1,6 +1,6 @@
 {% block page_checkout_confirm_shipping_inner %}
     <div class="card checkout-card">
-        <div class="card-body">
+        <fieldset class="card-body">
             {% set shippingMethodInvalid = true %}
 
             {% for shipping in page.shippingMethods %}
@@ -10,9 +10,9 @@
             {% endfor %}
 
             {% block page_checkout_confirm_shipping_title %}
-                <div class="card-title">
+                <legend class="card-title">
                     {{ 'checkout.confirmShippingMethod'|trans|sw_sanitize }}
-                </div>
+                </legend>
             {% endblock %}
 
             {% block page_checkout_confirm_shipping_form %}
@@ -23,6 +23,6 @@
                     redirectParameters: {redirected: 0}|json_encode,
                 } %}
             {% endblock %}
-        </div>
+        </fieldset>
     </div>
 {% endblock %}

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -446,6 +446,41 @@ class CheckoutControllerTest extends TestCase
         static::assertArrayHasKey(CheckoutCartPageLoadedHook::HOOK_NAME, $traces);
     }
 
+    #[DataProvider('checkoutMethodSelections')]
+    public function testCheckoutConfirmMethodSelectionsHaveNamedGroups(string $formId, string $inputName, string $legend): void
+    {
+        $browser = $this->getBrowserWithLoggedInCustomer();
+        $browser->followRedirects(true);
+        $salesChannelId = $browser->getServerParameter('test-sales-channel-id');
+
+        $this->createProductOnDatabase(Uuid::randomHex(), 'test.123', $salesChannelId);
+        $browser->request('POST', '/checkout/product/add-by-number', ['number' => 'test.123']);
+
+        $crawler = $browser->request('GET', '/checkout/confirm');
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('#' . $formId);
+        static::assertCount(1, $form);
+        $radios = $form->filter('input[type="radio"][name="' . $inputName . '"]');
+        static::assertGreaterThan(0, $radios->count());
+
+        $fieldset = $crawler->filterXPath('//fieldset[.//form[@id="' . $formId . '"]]');
+        static::assertCount(1, $fieldset, 'Checkout method choices must have a fieldset with a descriptive legend.');
+        static::assertCount(1, $fieldset->children('legend'));
+        static::assertSame($legend, $fieldset->children('legend')->text());
+        static::assertCount($radios->count(), $fieldset->filter('input[type="radio"]'));
+        static::assertCount(1, $radios->filter('[checked]'));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function checkoutMethodSelections(): iterable
+    {
+        yield 'payment' => ['changePaymentForm', 'paymentMethodId', 'Payment method'];
+        yield 'shipping' => ['changeShippingForm', 'shippingMethodId', 'Shipping method'];
+    }
+
     public function testCheckoutConfirmPageLoadedHookScriptsAreExecuted(): void
     {
         $contextToken = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?

Payment and shipping radio buttons on the 6.6 checkout confirmation page lack fieldsets and legends, so assistive technology cannot identify their groups.

### 2. What does this change do, exactly?

- Backports #14095 by changing the existing card containers and titles to fieldsets and legends, preserving 6.6 Twig blocks, form includes, styling classes, and accessibility feature paths.
- Adds rendered checkout regression tests and the required 6.6 changelog.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a product to the cart, sign in, and open checkout confirmation.
2. Inspect the payment and shipping choices: before this change, neither group has a fieldset or legend; afterward, each has its own named group.
3. Repeat with `ACCESSIBILITY_TWEAKS` disabled and enabled; both regression cases fail before the fix and pass afterward.

### 4. Please link to the relevant issues (if any).

- Backport of #14095
- Relates to #13980

### Validation

- All 42 checkout controller tests pass with `ACCESSIBILITY_TWEAKS=0`; the new regression cases and two account order-edit/shipping tests also pass with the flag enabled.
- PHPStan, PHP CS Fixer, Twig syntax, changelog validation, and `git diff --check` pass; browser inspection of rendered test HTML with the local theme CSS confirms named groups and intact desktop/mobile layout.
- With `ACCESSIBILITY_TWEAKS=1`, the full controller suite has one existing error in `testCheckoutConfirmPageLoadedHookScriptsAreExecuted`: the zero-item plural translation fails. The same error was reproduced with unchanged 6.6 templates.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
